### PR TITLE
bisect: probe at c86dedc (before mantine-react-table)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
-    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
-    continue-on-error: true
+    # Tolerate failures on main pushes so deploys aren't blocked, but keep PRs strict
+    # so bisect PRs still surface the real pass/fail signal.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   workflow_call:
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -27,6 +29,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
+    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
+    continue-on-error: true
     services:
       postgres:
         image: postgres:17


### PR DESCRIPTION
**Do not merge.** Bisect probe PR.

Probing the commit immediately BEFORE `bd6bb1a` ("feat(draft): replace basic table with Mantine React Table") to see whether the Linux-only client vitest failure already exists here.

## Hypothesis
The error:
```
Cannot find module '/home/runner/.../node_modules/.deno/react-remove-scroll@2.7.2/node_modules/react-remove-scroll-bar/dist/es5/constants.js'
```
points to `react-remove-scroll-bar`, which is a transitive dep of `react-remove-scroll`, pulled in by `mantine-react-table`. That package was added in `bd6bb1a`.

## Expected
CI **passes** here (green). The paired PR at `bd6bb1a` should fail.

## Contents
- Base commit: `c86dedc` (docs-only commit right before the suspect)
- Plus the two CI config commits cherry-picked from main so the `pull_request` trigger fires.