### PR TITLE
bisect: probe at bd6bb1a (mantine-react-table added)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
-    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
-    continue-on-error: true
+    # Tolerate failures on main pushes so deploys aren't blocked, but keep PRs strict
+    # so bisect PRs still surface the real pass/fail signal.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   workflow_call:
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -27,6 +29,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
+    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
+    continue-on-error: true
     services:
       postgres:
         image: postgres:17


### PR DESCRIPTION
**Do not merge.** Bisect probe PR.

Probing `bd6bb1a` ("feat(draft): replace basic table with Mantine React Table") directly. This is the strongest suspect for introducing the Linux-only `react-remove-scroll-bar` resolution failure in client vitest.

## Hypothesis
`mantine-react-table` brings in `react-remove-scroll` transitively, which Deno's npm resolver can't locate `react-remove-scroll-bar/dist/es5/constants.js` for on Linux (but can on macOS).

## Expected
CI **fails** here (red). Paired with the `before-mantine-table` probe PR (expected green), this would confirm `bd6bb1a` is the offending commit.

## Contents
- Base commit: `bd6bb1a`
- Plus the two CI config commits cherry-picked from main so the `pull_request` trigger fires.