### PR TITLE
bisect: control probe at e95d63e9 (last known green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
-    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
-    continue-on-error: true
+    # Tolerate failures on main pushes so deploys aren't blocked, but keep PRs strict
+    # so bisect PRs still surface the real pass/fail signal.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   workflow_call:
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -27,6 +29,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # TODO: remove once the react-remove-scroll / Linux client test failure is bisected and fixed.
+    # Tracked via bisect PRs — allowing failures here keeps main deploys unblocked.
+    continue-on-error: true
     services:
       postgres:
         image: postgres:17


### PR DESCRIPTION
**Do not merge.** Bisect control PR.

Running CI at `e95d63e9` — the commit that produced the last successful deploy run. This is a *control* to verify my bisect probes are meaningful.

## Why
Both `c86dedc` and `bd6bb1a` probes failed with the same `react-remove-scroll-bar` error. But `git log e95d63e9..c86dedc -- deno.lock client/package.json` shows **no dep changes** in that range. That means either:

1. The failure is environmental/non-deterministic (registry resolution, Deno version, etc.) — in which case this control PR will also fail.
2. Something non-obvious changed between those commits.

## Expected
If hypothesis (1) → this PR **fails**, and we know the regression is environmental, not a commit in the range.
If hypothesis (2) → this PR **passes** (matching the historical green run), and we keep bisecting.