### PR TITLE
feat(draft): add live draft room UI (Phase 1)

### DIFF
--- a/client/src/features/draft/DraftBoard.test.tsx
+++ b/client/src/features/draft/DraftBoard.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { DraftBoard } from "./DraftBoard";
+import { makeDraftState, makePlayer, makePoolItem } from "./fixtures";
+import type { DraftPick } from "@make-the-pick/shared";
+
+function renderBoard(props: Parameters<typeof DraftBoard>[0]) {
+  return render(
+    <MantineProvider>
+      <DraftBoard {...props} />
+    </MantineProvider>,
+  );
+}
+
+function pick(
+  id: string,
+  poolItemId: string,
+  leaguePlayerId: string,
+  pickNumber: number,
+): DraftPick {
+  return {
+    id,
+    draftId: "draft-1",
+    leaguePlayerId,
+    poolItemId,
+    pickNumber,
+    pickedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("DraftBoard", () => {
+  afterEach(() => cleanup());
+
+  const players = [
+    makePlayer("p1", "Alice"),
+    makePlayer("p2", "Bob"),
+  ];
+  const poolItemsById = {
+    "item-1": makePoolItem("item-1", "bulbasaur"),
+    "item-2": makePoolItem("item-2", "charmander"),
+    "item-3": makePoolItem("item-3", "squirtle"),
+    "item-4": makePoolItem("item-4", "pikachu"),
+  };
+
+  it("renders rows for each round and shows player column headers", () => {
+    const draftState = makeDraftState({
+      players,
+      currentPick: 0,
+      picks: [],
+    });
+    renderBoard({
+      draftState,
+      totalRounds: 3,
+      poolItemsById,
+    });
+    expect(screen.getAllByText("Alice").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Bob").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/round 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/round 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/round 3/i)).toBeInTheDocument();
+  });
+
+  it("renders made picks in the correct cells", () => {
+    const picks = [
+      pick("pk-1", "item-1", "p1", 0), // Round 1, Alice
+      pick("pk-2", "item-2", "p2", 1), // Round 1, Bob
+    ];
+    const draftState = makeDraftState({
+      players,
+      currentPick: 2,
+      picks,
+    });
+    renderBoard({ draftState, totalRounds: 3, poolItemsById });
+
+    expect(screen.getByText(/bulbasaur/i)).toBeInTheDocument();
+    expect(screen.getByText(/charmander/i)).toBeInTheDocument();
+  });
+
+  it("highlights the current pick cell", () => {
+    const draftState = makeDraftState({
+      players,
+      currentPick: 0,
+      picks: [],
+    });
+    const { container } = renderBoard({
+      draftState,
+      totalRounds: 2,
+      poolItemsById,
+    });
+    const currentCell = container.querySelector('[data-current-pick="true"]');
+    expect(currentCell).not.toBeNull();
+  });
+
+  it("shows the upcoming player name in empty cells", () => {
+    const draftState = makeDraftState({
+      players,
+      currentPick: 0,
+      picks: [],
+    });
+    renderBoard({ draftState, totalRounds: 2, poolItemsById });
+    // Alice appears as column header AND in at least one empty cell.
+    const aliceHits = screen.getAllByText("Alice");
+    expect(aliceHits.length).toBeGreaterThan(1);
+  });
+
+  it("reverses slot order on odd rounds (snake)", () => {
+    // Pick 0 (round 0 slot 0) -> Alice; Pick 2 (round 1 slot 1 reversed -> Alice)
+    const picks = [
+      pick("pk-1", "item-1", "p1", 0),
+      pick("pk-2", "item-2", "p2", 1),
+      pick("pk-3", "item-3", "p2", 2), // snake back to Bob in round 2
+      pick("pk-4", "item-4", "p1", 3),
+    ];
+    const draftState = makeDraftState({
+      players,
+      currentPick: 4,
+      picks,
+    });
+    const { container } = renderBoard({
+      draftState,
+      totalRounds: 2,
+      poolItemsById,
+    });
+    // Row 2, first visual column should be Bob (squirtle), last should be Alice (pikachu)
+    const row2 = container.querySelector('[data-round="1"]');
+    expect(row2).not.toBeNull();
+    const cells = row2!.querySelectorAll("[data-cell]");
+    expect(cells.length).toBe(2);
+    // Columns are fixed: col0=Alice, col1=Bob.
+    // Snake round 2: Bob picks first (pick 2, squirtle) then Alice (pick 3, pikachu)
+    // so Alice's column shows pikachu, Bob's shows squirtle.
+    expect(within(cells[0] as HTMLElement).getByText(/pikachu/i))
+      .toBeInTheDocument();
+    expect(within(cells[1] as HTMLElement).getByText(/squirtle/i))
+      .toBeInTheDocument();
+  });
+});

--- a/client/src/features/draft/DraftBoard.tsx
+++ b/client/src/features/draft/DraftBoard.tsx
@@ -1,0 +1,176 @@
+import { Avatar, Card, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import type {
+  DraftPick,
+  DraftPoolItem,
+  DraftState,
+} from "@make-the-pick/shared";
+import { useMemo } from "react";
+
+export interface DraftBoardProps {
+  draftState: DraftState;
+  totalRounds: number;
+  poolItemsById: Record<string, DraftPoolItem>;
+}
+
+interface BoardCell {
+  round: number;
+  /** Visual column (0 = left). Columns are fixed to pickOrder. */
+  columnIndex: number;
+  leaguePlayerId: string;
+  playerName: string;
+  /** Pick number (0-indexed, global) landing in this cell under snake order. */
+  pickNumber: number;
+  pick: DraftPick | undefined;
+}
+
+function buildGrid(
+  draftState: DraftState,
+  totalRounds: number,
+): BoardCell[][] {
+  const pickOrder = draftState.draft.pickOrder;
+  const playersCount = pickOrder.length;
+  const playerNameById = new Map(
+    draftState.players.map((p) => [p.id, p.name]),
+  );
+  const picksByNumber = new Map(
+    draftState.picks.map((p) => [p.pickNumber, p]),
+  );
+
+  const rows: BoardCell[][] = [];
+  for (let round = 0; round < totalRounds; round++) {
+    const reversed = round % 2 === 1;
+    const row: BoardCell[] = [];
+    for (let columnIndex = 0; columnIndex < playersCount; columnIndex++) {
+      // In snake, odd rounds walk pickOrder right-to-left, but the visual
+      // column for a player stays fixed. So if columnIndex = 0 (Alice) and
+      // reversed, Alice's pick is the LAST pick of this round.
+      const positionInRound = reversed
+        ? playersCount - 1 - columnIndex
+        : columnIndex;
+      const pickNumber = round * playersCount + positionInRound;
+      const leaguePlayerId = pickOrder[columnIndex] ?? "";
+      row.push({
+        round,
+        columnIndex,
+        leaguePlayerId,
+        playerName: playerNameById.get(leaguePlayerId) ?? "—",
+        pickNumber,
+        pick: picksByNumber.get(pickNumber),
+      });
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+export function DraftBoard(
+  { draftState, totalRounds, poolItemsById }: DraftBoardProps,
+) {
+  const grid = useMemo(
+    () => buildGrid(draftState, totalRounds),
+    [draftState, totalRounds],
+  );
+  const playersCount = draftState.draft.pickOrder.length;
+  const currentPick = draftState.draft.currentPick;
+  const playerNameById = new Map(
+    draftState.players.map((p) => [p.id, p.name]),
+  );
+
+  return (
+    <Card withBorder shadow="sm" padding="md" radius="md">
+      <ScrollArea scrollbarSize={8} offsetScrollbars type="auto">
+        <Stack gap="xs" style={{ minWidth: Math.max(320, playersCount * 160) }}>
+          {/* Column header row */}
+          <Group gap="xs" wrap="nowrap" style={{ paddingLeft: 80 }}>
+            {draftState.draft.pickOrder.map((playerId) => (
+              <Text
+                key={playerId}
+                fw={600}
+                size="sm"
+                ta="center"
+                style={{ flex: 1, minWidth: 140 }}
+              >
+                {playerNameById.get(playerId) ?? "—"}
+              </Text>
+            ))}
+          </Group>
+
+          {grid.map((row, roundIdx) => (
+            <Group
+              key={`round-${roundIdx}`}
+              gap="xs"
+              wrap="nowrap"
+              data-round={roundIdx}
+            >
+              <Text
+                size="xs"
+                c="dimmed"
+                style={{ width: 72, textAlign: "right" }}
+              >
+                Round {roundIdx + 1} {roundIdx % 2 === 1 ? "\u2190" : "\u2192"}
+              </Text>
+              {row.map((cell) => {
+                const isCurrent = cell.pickNumber === currentPick &&
+                  !cell.pick;
+                const item = cell.pick
+                  ? poolItemsById[cell.pick.poolItemId]
+                  : undefined;
+                return (
+                  <Card
+                    key={`${roundIdx}-${cell.columnIndex}`}
+                    withBorder
+                    padding="xs"
+                    radius="sm"
+                    data-cell
+                    data-current-pick={isCurrent ? "true" : undefined}
+                    style={{
+                      flex: 1,
+                      minWidth: 140,
+                      minHeight: 72,
+                      backgroundColor: isCurrent
+                        ? "var(--mantine-color-mint-green-light, #e6fff2)"
+                        : undefined,
+                      borderColor: isCurrent
+                        ? "var(--mantine-color-mint-green-filled, #21c76e)"
+                        : undefined,
+                    }}
+                  >
+                    {item
+                      ? (
+                        <Group gap="xs" wrap="nowrap" align="center">
+                          <Avatar
+                            src={item.thumbnailUrl}
+                            alt={item.name}
+                            size="sm"
+                            radius="sm"
+                          />
+                          <Stack gap={0} style={{ minWidth: 0 }}>
+                            <Text size="xs" c="dimmed">
+                              Pick {cell.pickNumber + 1}
+                            </Text>
+                            <Text size="sm" fw={500} tt="capitalize" truncate>
+                              {item.name}
+                            </Text>
+                          </Stack>
+                        </Group>
+                      )
+                      : (
+                        <Stack gap={0}>
+                          <Text size="xs" c="dimmed">
+                            Pick {cell.pickNumber + 1}
+                          </Text>
+                          <Text size="sm" c="dimmed" truncate>
+                            {cell.playerName}
+                          </Text>
+                        </Stack>
+                      )}
+                  </Card>
+                );
+              })}
+            </Group>
+          ))}
+        </Stack>
+      </ScrollArea>
+    </Card>
+  );
+}

--- a/client/src/features/draft/DraftHeader.test.tsx
+++ b/client/src/features/draft/DraftHeader.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { DraftHeader } from "./DraftHeader";
+import { makeDraftState, makePlayer } from "./fixtures";
+
+function renderHeader(props: Parameters<typeof DraftHeader>[0]) {
+  return render(
+    <MantineProvider>
+      <DraftHeader {...props} />
+    </MantineProvider>,
+  );
+}
+
+describe("DraftHeader", () => {
+  afterEach(() => cleanup());
+
+  it("shows current round and total rounds (1-indexed)", () => {
+    const draftState = makeDraftState({
+      currentPick: 2, // round 1 (0-indexed) for 2 players
+    });
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    expect(screen.getByText(/round 2 of 6/i)).toBeInTheDocument();
+  });
+
+  it("shows current pick number and total pick count (1-indexed)", () => {
+    const draftState = makeDraftState({ currentPick: 3 });
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    // 2 players x 6 rounds = 12 picks, currentPick=3 -> pick 4
+    expect(screen.getByText(/pick 4 of 12/i)).toBeInTheDocument();
+  });
+
+  it("shows draft format label", () => {
+    const draftState = makeDraftState();
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    expect(screen.getByText(/snake/i)).toBeInTheDocument();
+  });
+
+  it("prominently shows whose turn it is", () => {
+    const draftState = makeDraftState({
+      players: [makePlayer("p1", "Alice"), makePlayer("p2", "Bob")],
+    });
+    renderHeader({
+      draftState,
+      totalRounds: 6,
+      currentTurnPlayerName: "Bob",
+    });
+    expect(screen.getByText(/bob/i)).toBeInTheDocument();
+  });
+
+  it("shows draft status", () => {
+    const draftState = makeDraftState({ status: "in_progress" });
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    expect(screen.getByText(/in_progress|in progress/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/features/draft/DraftHeader.tsx
+++ b/client/src/features/draft/DraftHeader.tsx
@@ -1,0 +1,65 @@
+import { Badge, Card, Group, Stack, Text, Title } from "@mantine/core";
+import type { DraftState } from "@make-the-pick/shared";
+import { roundForPick } from "./snake.ts";
+
+export interface DraftHeaderProps {
+  draftState: DraftState;
+  totalRounds: number;
+  currentTurnPlayerName: string | null;
+}
+
+export function DraftHeader(
+  { draftState, totalRounds, currentTurnPlayerName }: DraftHeaderProps,
+) {
+  const playersCount = draftState.draft.pickOrder.length;
+  const totalPicks = playersCount * totalRounds;
+  const currentPick = draftState.draft.currentPick;
+  const currentRound = roundForPick(currentPick, playersCount);
+  const displayRound = Math.min(currentRound + 1, totalRounds);
+  const displayPick = Math.min(currentPick + 1, totalPicks);
+  const format = draftState.draft.format;
+  const status = draftState.draft.status;
+
+  return (
+    <Card withBorder shadow="sm" padding="md" radius="md">
+      <Group justify="space-between" wrap="wrap" gap="md">
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            Round
+          </Text>
+          <Text fw={600}>
+            Round {displayRound} of {totalRounds}
+          </Text>
+        </Stack>
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            Pick
+          </Text>
+          <Text fw={600}>
+            Pick {displayPick} of {totalPicks}
+          </Text>
+        </Stack>
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            Format
+          </Text>
+          <Badge variant="light" tt="capitalize">{format}</Badge>
+        </Stack>
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            On the clock
+          </Text>
+          <Title order={4}>
+            {currentTurnPlayerName ?? "—"}
+          </Title>
+        </Stack>
+        <Stack gap={2}>
+          <Text size="xs" c="dimmed" tt="uppercase">
+            Status
+          </Text>
+          <Badge variant="outline">{status}</Badge>
+        </Stack>
+      </Group>
+    </Card>
+  );
+}

--- a/client/src/features/draft/DraftPage.test.tsx
+++ b/client/src/features/draft/DraftPage.test.tsx
@@ -2,13 +2,39 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import { DraftPage } from "./DraftPage";
+import { makeDraftState, makePlayer } from "./fixtures";
 
-const { mockUseLeague } = vi.hoisted(() => ({
+const {
+  mockUseLeague,
+  mockUseLeaguePlayers,
+  mockUseDraft,
+  mockUseMakePick,
+  mockUseStartDraft,
+  mockStartDraftMutate,
+  mockMakePickMutate,
+} = vi.hoisted(() => ({
   mockUseLeague: vi.fn(),
+  mockUseLeaguePlayers: vi.fn(),
+  mockUseDraft: vi.fn(),
+  mockUseMakePick: vi.fn(),
+  mockUseStartDraft: vi.fn(),
+  mockStartDraftMutate: vi.fn(),
+  mockMakePickMutate: vi.fn(),
 }));
 
 vi.mock("../league/use-leagues", () => ({
   useLeague: mockUseLeague,
+  useLeaguePlayers: mockUseLeaguePlayers,
+}));
+
+vi.mock("./use-draft", () => ({
+  useDraft: mockUseDraft,
+  useMakePick: mockUseMakePick,
+  useStartDraft: mockUseStartDraft,
+}));
+
+vi.mock("../../auth", () => ({
+  useSession: () => ({ data: { user: { id: "user-p1" } } }),
 }));
 
 vi.mock("wouter", async () => {
@@ -27,10 +53,28 @@ const mockLeague = {
   sportType: "pokemon",
   rulesConfig: {
     draftFormat: "snake",
-    numberOfRounds: 10,
+    numberOfRounds: 3,
     pickTimeLimitSeconds: null,
   },
   createdAt: "2026-01-01T00:00:00Z",
+};
+
+const commissionerPlayer = {
+  id: "p1",
+  userId: "user-p1",
+  name: "Alice",
+  image: null,
+  role: "commissioner" as const,
+  joinedAt: "2026-01-01T00:00:00Z",
+};
+
+const memberPlayer = {
+  id: "p2",
+  userId: "user-p2",
+  name: "Bob",
+  image: null,
+  role: "member" as const,
+  joinedAt: "2026-01-01T00:00:00Z",
 };
 
 function renderPage() {
@@ -44,11 +88,58 @@ function renderPage() {
 describe("DraftPage", () => {
   beforeEach(() => {
     mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [commissionerPlayer, memberPlayer],
+      isLoading: false,
+    });
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({
+        players: [
+          makePlayer("p1", "Alice", {
+            userId: "user-p1",
+            role: "commissioner",
+          }),
+          makePlayer("p2", "Bob", { userId: "user-p2" }),
+        ],
+        currentPick: 0,
+      }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockUseMakePick.mockReturnValue({
+      mutate: mockMakePickMutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    });
+    mockUseStartDraft.mockReturnValue({
+      mutate: mockStartDraftMutate,
+      mutateAsync: vi.fn(),
+      isPending: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+  });
+
+  it("shows loading overlay when league is loading", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseDraft.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(
+      document.querySelector(
+        "[data-mantine-loading-overlay],.mantine-LoadingOverlay-root",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows the league name in the title", () => {
@@ -59,17 +150,68 @@ describe("DraftPage", () => {
   it("has a back link to the league detail page", () => {
     renderPage();
     const backLink = screen.getByRole("link", { name: /back to league/i });
-    expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute("href", "/leagues/league-1");
   });
 
-  it("shows loading overlay when league is loading", () => {
-    mockUseLeague.mockReturnValue({ data: undefined, isLoading: true });
+  it("renders the draft board, pick panel, and header when draft is in progress", () => {
+    renderPage();
+    expect(screen.getByText(/round 1 of 3/i)).toBeInTheDocument();
+    expect(screen.getByText(/available pool/i)).toBeInTheDocument();
+  });
+
+  it("shows waiting message when draft status is pending", () => {
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({
+        status: "pending",
+        players: [
+          makePlayer("p1", "Alice", {
+            userId: "user-p1",
+            role: "commissioner",
+          }),
+          makePlayer("p2", "Bob", { userId: "user-p2" }),
+        ],
+      }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByText(/draft has not started/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/waiting for the commissioner/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Start Draft button when pending and user is commissioner", () => {
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({ status: "pending" }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
     renderPage();
     expect(
-      document.querySelector(
-        "[data-mantine-loading-overlay],.mantine-LoadingOverlay-root",
-      ),
+      screen.getByRole("button", { name: /start draft/i }),
     ).toBeInTheDocument();
+  });
+
+  it("does not show Start Draft button when pending and user is not commissioner", () => {
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        { ...commissionerPlayer, userId: "user-someone-else" },
+        { ...memberPlayer, userId: "user-p1" },
+      ],
+      isLoading: false,
+    });
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({ status: "pending" }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /start draft/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -1,16 +1,106 @@
-import { Anchor, Container, LoadingOverlay, Title } from "@mantine/core";
+import {
+  Alert,
+  Anchor,
+  Button,
+  Card,
+  Container,
+  Grid,
+  LoadingOverlay,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import { useMemo } from "react";
 import { Link, useParams } from "wouter";
-import { useLeague } from "../league/use-leagues";
+import { useSession } from "../../auth";
+import { useLeague, useLeaguePlayers } from "../league/use-leagues";
+import { DraftBoard } from "./DraftBoard";
+import { DraftHeader } from "./DraftHeader";
+import { PickPanel } from "./PickPanel";
+import { RosterStrip } from "./RosterStrip";
+import { useDraft, useMakePick, useStartDraft } from "./use-draft";
+import { leaguePlayerForPick } from "./snake.ts";
 
 export function DraftPage() {
   const { id } = useParams<{ id: string }>();
-  const league = useLeague(id!);
+  const leagueId = id!;
+  const league = useLeague(leagueId);
+  const leaguePlayers = useLeaguePlayers(leagueId);
+  const draft = useDraft(leagueId);
+  const makePick = useMakePick(leagueId);
+  const startDraft = useStartDraft(leagueId);
+  const { data: session } = useSession();
+
+  const myLeaguePlayer = useMemo(
+    () =>
+      leaguePlayers.data?.find((p) => p.userId === session?.user?.id) ?? null,
+    [leaguePlayers.data, session?.user?.id],
+  );
+  const isCommissioner = myLeaguePlayer?.role === "commissioner";
+
+  const rulesConfig = (league.data?.rulesConfig ?? null) as
+    | { numberOfRounds?: number }
+    | null;
+  const totalRounds = rulesConfig?.numberOfRounds ?? 6;
+
+  const draftState = draft.data;
+
+  const currentTurnPlayerId = draftState
+    ? leaguePlayerForPick(
+      draftState.draft.currentPick,
+      draftState.draft.pickOrder,
+    )
+    : null;
+  const currentTurnPlayer = draftState?.players.find(
+    (p) => p.id === currentTurnPlayerId,
+  ) ?? null;
+  const isMyTurn = !!(myLeaguePlayer && currentTurnPlayerId &&
+    myLeaguePlayer.id === currentTurnPlayerId);
+
+  const poolItemsById = useMemo(() => {
+    const map: Record<string, NonNullable<typeof draftState>["poolItems"][0]> =
+      {};
+    for (const item of draftState?.poolItems ?? []) {
+      map[item.id] = item;
+    }
+    return map;
+  }, [draftState]);
+
+  const myPicks = useMemo(
+    () =>
+      draftState?.picks.filter(
+        (p) => p.leaguePlayerId === myLeaguePlayer?.id,
+      ) ?? [],
+    [draftState, myLeaguePlayer?.id],
+  );
+
+  async function handlePick(poolItemId: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      makePick.mutate(
+        { leagueId, poolItemId },
+        {
+          onSuccess: () => resolve(),
+          onError: (err) => reject(err),
+        },
+      );
+    });
+  }
+
+  const isLoading = league.isLoading || draft.isLoading ||
+    leaguePlayers.isLoading;
+  const draftStatus = draftState?.draft.status;
+  const isPending = draftStatus === "pending";
 
   return (
     <Container size="xl" py="xl" pos="relative">
-      <LoadingOverlay visible={league.isLoading} />
+      <LoadingOverlay visible={isLoading} />
 
-      <Anchor component={Link} href={`/leagues/${id}`} mb="md" display="block">
+      <Anchor
+        component={Link}
+        href={`/leagues/${leagueId}`}
+        mb="md"
+        display="block"
+      >
         &larr; Back to League
       </Anchor>
 
@@ -18,6 +108,65 @@ export function DraftPage() {
         <Title order={1} mb="lg">
           {league.data.name} — Draft
         </Title>
+      )}
+
+      {draft.error && (
+        <Alert color="red" title="Failed to load draft" mb="md">
+          {draft.error.message}
+        </Alert>
+      )}
+
+      {draftState && isPending && (
+        <Card withBorder shadow="sm" padding="lg" radius="md">
+          <Stack gap="md" align="flex-start">
+            <Title order={3}>Draft has not started</Title>
+            <Text c="dimmed">
+              Waiting for the commissioner to start the draft.
+            </Text>
+            {isCommissioner && (
+              <Button
+                onClick={() => startDraft.mutate({ leagueId })}
+                loading={startDraft.isPending}
+              >
+                Start Draft
+              </Button>
+            )}
+            {startDraft.error && (
+              <Alert color="red" title="Failed to start draft">
+                {startDraft.error.message}
+              </Alert>
+            )}
+          </Stack>
+        </Card>
+      )}
+
+      {draftState && !isPending && (
+        <Stack gap="md">
+          <DraftHeader
+            draftState={draftState}
+            totalRounds={totalRounds}
+            currentTurnPlayerName={currentTurnPlayer?.name ?? null}
+          />
+          <Grid>
+            <Grid.Col span={{ base: 12, md: 8 }}>
+              <DraftBoard
+                draftState={draftState}
+                totalRounds={totalRounds}
+                poolItemsById={poolItemsById}
+              />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, md: 4 }}>
+              <PickPanel
+                draftState={draftState}
+                poolItems={draftState.poolItems}
+                isMyTurn={isMyTurn}
+                onPick={handlePick}
+                isPicking={makePick.isPending}
+              />
+            </Grid.Col>
+          </Grid>
+          <RosterStrip picks={myPicks} poolItemsById={poolItemsById} />
+        </Stack>
       )}
     </Container>
   );

--- a/client/src/features/draft/PickPanel.test.tsx
+++ b/client/src/features/draft/PickPanel.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { PickPanel } from "./PickPanel";
+import { makeDraftState, makePoolItem } from "./fixtures";
+
+function renderPanel(overrides: Partial<Parameters<typeof PickPanel>[0]> = {}) {
+  const poolItems = [
+    makePoolItem("item-1", "bulbasaur", ["grass"]),
+    makePoolItem("item-2", "charmander", ["fire"]),
+    makePoolItem("item-3", "squirtle", ["water"]),
+  ];
+  const draftState = makeDraftState({
+    poolItems,
+    availableItemIds: ["item-1", "item-2", "item-3"],
+  });
+  const onPick = vi.fn().mockResolvedValue(undefined);
+  render(
+    <MantineProvider>
+      <PickPanel
+        draftState={draftState}
+        poolItems={poolItems}
+        isMyTurn
+        onPick={onPick}
+        isPicking={false}
+        {...overrides}
+      />
+    </MantineProvider>,
+  );
+  return { onPick };
+}
+
+describe("PickPanel", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows only available pool items", () => {
+    const poolItems = [
+      makePoolItem("item-1", "bulbasaur"),
+      makePoolItem("item-2", "charmander"),
+    ];
+    const draftState = makeDraftState({
+      poolItems,
+      availableItemIds: ["item-1"], // charmander already picked
+    });
+    render(
+      <MantineProvider>
+        <PickPanel
+          draftState={draftState}
+          poolItems={poolItems}
+          isMyTurn
+          onPick={vi.fn()}
+          isPicking={false}
+        />
+      </MantineProvider>,
+    );
+    expect(screen.getByText(/bulbasaur/i)).toBeInTheDocument();
+    expect(screen.queryByText(/charmander/i)).not.toBeInTheDocument();
+  });
+
+  it("opens confirmation modal when clicking an item on your turn", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /draft bulbasaur/i }));
+    expect(screen.getByText(/this cannot be undone/i)).toBeInTheDocument();
+  });
+
+  it("calls onPick with the correct id when confirmed", () => {
+    const { onPick } = renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /draft bulbasaur/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
+    expect(onPick).toHaveBeenCalledWith("item-1");
+  });
+
+  it("filters items by text search", () => {
+    renderPanel();
+    const input = screen.getByPlaceholderText(/search/i);
+    fireEvent.change(input, { target: { value: "char" } });
+    expect(screen.getByText(/charmander/i)).toBeInTheDocument();
+    expect(screen.queryByText(/bulbasaur/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show pick buttons when it is not my turn", () => {
+    renderPanel({ isMyTurn: false });
+    expect(
+      screen.queryByRole("button", { name: /draft bulbasaur/i }),
+    ).not.toBeInTheDocument();
+    // Names still visible
+    expect(screen.getByText(/bulbasaur/i)).toBeInTheDocument();
+  });
+
+  it("shows loading state on confirm button when isPicking", () => {
+    renderPanel({ isPicking: true });
+    fireEvent.click(screen.getByRole("button", { name: /draft bulbasaur/i }));
+    const confirmBtn = screen.getByRole("button", { name: /^confirm$/i });
+    // Mantine sets data-loading on loading buttons
+    expect(confirmBtn.hasAttribute("data-loading")).toBe(true);
+  });
+});

--- a/client/src/features/draft/PickPanel.tsx
+++ b/client/src/features/draft/PickPanel.tsx
@@ -1,0 +1,174 @@
+import {
+  Avatar,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { useMemo, useState } from "react";
+import type { DraftPoolItem, DraftState } from "@make-the-pick/shared";
+
+export interface PickPanelProps {
+  draftState: DraftState;
+  poolItems: DraftPoolItem[];
+  isMyTurn: boolean;
+  onPick: (poolItemId: string) => Promise<void>;
+  isPicking: boolean;
+}
+
+export function PickPanel(
+  { draftState, poolItems, isMyTurn, onPick, isPicking }: PickPanelProps,
+) {
+  const [search, setSearch] = useState("");
+  const [pendingItem, setPendingItem] = useState<DraftPoolItem | null>(null);
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const availableSet = useMemo(
+    () => new Set(draftState.availableItemIds),
+    [draftState.availableItemIds],
+  );
+
+  const filteredItems = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return poolItems
+      .filter((item) => availableSet.has(item.id))
+      .filter((item) =>
+        query === "" ? true : item.name.toLowerCase().includes(query)
+      );
+  }, [poolItems, availableSet, search]);
+
+  function handleClickItem(item: DraftPoolItem) {
+    setPendingItem(item);
+    open();
+  }
+
+  async function handleConfirm() {
+    if (!pendingItem) return;
+    await onPick(pendingItem.id);
+    close();
+    setPendingItem(null);
+  }
+
+  function handleCancel() {
+    close();
+    setPendingItem(null);
+  }
+
+  return (
+    <Card withBorder shadow="sm" padding="md" radius="md">
+      <Stack gap="sm">
+        <Group justify="space-between" align="center">
+          <Title order={4}>Available Pool</Title>
+          <Text size="xs" c="dimmed">
+            {filteredItems.length} available
+          </Text>
+        </Group>
+
+        {!isMyTurn && (
+          <Text size="sm" c="dimmed">
+            Waiting for your turn. You can still browse the pool.
+          </Text>
+        )}
+
+        <TextInput
+          placeholder="Search by name..."
+          value={search}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+        />
+
+        <ScrollArea h={480} scrollbarSize={8} offsetScrollbars>
+          <Stack gap="xs">
+            {filteredItems.length === 0
+              ? (
+                <Text size="sm" c="dimmed">
+                  No available Pokemon match that search.
+                </Text>
+              )
+              : filteredItems.map((item) => (
+                <Card
+                  key={item.id}
+                  withBorder
+                  padding="xs"
+                  radius="sm"
+                >
+                  <Group gap="xs" justify="space-between" wrap="nowrap">
+                    <Group gap="xs" wrap="nowrap" style={{ minWidth: 0 }}>
+                      <Avatar
+                        src={item.thumbnailUrl}
+                        alt={item.name}
+                        size="sm"
+                        radius="sm"
+                      />
+                      <Stack gap={0} style={{ minWidth: 0 }}>
+                        <Text size="sm" fw={500} tt="capitalize" truncate>
+                          {item.name}
+                        </Text>
+                        {item.metadata && (
+                          <Group gap={4}>
+                            {item.metadata.types.map((t) => (
+                              <Badge
+                                key={t}
+                                size="xs"
+                                variant="light"
+                                tt="capitalize"
+                              >
+                                {t}
+                              </Badge>
+                            ))}
+                          </Group>
+                        )}
+                      </Stack>
+                    </Group>
+                    {isMyTurn && (
+                      <Button
+                        size="xs"
+                        variant="light"
+                        onClick={() => handleClickItem(item)}
+                        aria-label={`Draft ${item.name}`}
+                      >
+                        Draft
+                      </Button>
+                    )}
+                  </Group>
+                </Card>
+              ))}
+          </Stack>
+        </ScrollArea>
+      </Stack>
+
+      <Modal
+        opened={opened}
+        onClose={handleCancel}
+        title="Confirm Pick"
+        transitionProps={{ duration: 0 }}
+      >
+        {pendingItem && (
+          <Stack gap="md">
+            <Text>
+              Draft{" "}
+              <Text span fw={700} tt="capitalize">
+                {pendingItem.name}
+              </Text>
+              ? This cannot be undone.
+            </Text>
+            <Group justify="flex-end">
+              <Button variant="default" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button onClick={handleConfirm} loading={isPicking}>
+                Confirm
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </Card>
+  );
+}

--- a/client/src/features/draft/RosterStrip.test.tsx
+++ b/client/src/features/draft/RosterStrip.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { RosterStrip } from "./RosterStrip";
+import { makePoolItem } from "./fixtures";
+import type { DraftPick } from "@make-the-pick/shared";
+
+function renderStrip(props: Parameters<typeof RosterStrip>[0]) {
+  return render(
+    <MantineProvider>
+      <RosterStrip {...props} />
+    </MantineProvider>,
+  );
+}
+
+const poolItemsById: Record<string, ReturnType<typeof makePoolItem>> = {
+  "item-1": makePoolItem("item-1", "bulbasaur", ["grass"]),
+  "item-2": makePoolItem("item-2", "charmander", ["fire"]),
+  "item-3": makePoolItem("item-3", "squirtle", ["water"]),
+};
+
+function pick(
+  poolItemId: string,
+  pickNumber: number,
+  leaguePlayerId = "p1",
+): DraftPick {
+  return {
+    id: `pick-${pickNumber}`,
+    draftId: "draft-1",
+    leaguePlayerId,
+    poolItemId,
+    pickNumber,
+    pickedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("RosterStrip", () => {
+  afterEach(() => cleanup());
+
+  it("renders drafted items in pickNumber order", () => {
+    const picks = [
+      pick("item-3", 2),
+      pick("item-1", 0),
+      pick("item-2", 1),
+    ];
+    renderStrip({ picks, poolItemsById });
+
+    const names = screen.getAllByText(/bulbasaur|charmander|squirtle/i)
+      .map((el) => el.textContent?.toLowerCase() ?? "");
+    expect(names).toEqual(["bulbasaur", "charmander", "squirtle"]);
+  });
+
+  it("shows empty message when no picks", () => {
+    renderStrip({ picks: [], poolItemsById });
+    expect(screen.getByText(/no picks yet/i)).toBeInTheDocument();
+  });
+
+  it("renders type badges from metadata", () => {
+    const picks = [pick("item-1", 0)];
+    renderStrip({ picks, poolItemsById });
+    expect(screen.getByText(/grass/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/features/draft/RosterStrip.tsx
+++ b/client/src/features/draft/RosterStrip.tsx
@@ -1,0 +1,79 @@
+import {
+  Avatar,
+  Badge,
+  Card,
+  Group,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import type { DraftPick, DraftPoolItem } from "@make-the-pick/shared";
+
+export interface RosterStripProps {
+  picks: DraftPick[];
+  poolItemsById: Record<string, DraftPoolItem>;
+}
+
+export function RosterStrip({ picks, poolItemsById }: RosterStripProps) {
+  const ordered = [...picks].sort((a, b) => a.pickNumber - b.pickNumber);
+
+  return (
+    <Card withBorder shadow="sm" padding="md" radius="md">
+      <Title order={5} mb="sm">
+        Your Roster
+      </Title>
+      {ordered.length === 0
+        ? (
+          <Text size="sm" c="dimmed">
+            No picks yet — your drafted Pokemon will appear here.
+          </Text>
+        )
+        : (
+          <ScrollArea scrollbarSize={8} offsetScrollbars>
+            <Group gap="sm" wrap="nowrap" align="flex-start">
+              {ordered.map((pick) => {
+                const item = poolItemsById[pick.poolItemId];
+                if (!item) return null;
+                return (
+                  <Card
+                    key={pick.id}
+                    withBorder
+                    padding="xs"
+                    radius="sm"
+                    style={{ minWidth: 140 }}
+                  >
+                    <Stack gap={4} align="center">
+                      <Avatar
+                        src={item.thumbnailUrl}
+                        alt={item.name}
+                        size="md"
+                        radius="sm"
+                      />
+                      <Text size="sm" fw={500} tt="capitalize">
+                        {item.name}
+                      </Text>
+                      {item.metadata && (
+                        <Group gap={4} justify="center">
+                          {item.metadata.types.map((t) => (
+                            <Badge
+                              key={t}
+                              size="xs"
+                              variant="light"
+                              tt="capitalize"
+                            >
+                              {t}
+                            </Badge>
+                          ))}
+                        </Group>
+                      )}
+                    </Stack>
+                  </Card>
+                );
+              })}
+            </Group>
+          </ScrollArea>
+        )}
+    </Card>
+  );
+}

--- a/client/src/features/draft/fixtures.ts
+++ b/client/src/features/draft/fixtures.ts
@@ -1,0 +1,94 @@
+import type {
+  DraftPoolItem,
+  DraftState,
+  LeaguePlayer,
+} from "@make-the-pick/shared";
+
+export function makePlayer(
+  id: string,
+  name: string,
+  overrides: Partial<LeaguePlayer> = {},
+): LeaguePlayer {
+  return {
+    id,
+    userId: `user-${id}`,
+    name,
+    image: null,
+    role: "member",
+    joinedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+export function makePoolItem(
+  id: string,
+  name: string,
+  types: string[] = ["normal"],
+): DraftPoolItem {
+  return {
+    id,
+    draftPoolId: "pool-1",
+    name,
+    thumbnailUrl: null,
+    metadata: {
+      pokemonId: 1,
+      types,
+      baseStats: {
+        hp: 50,
+        attack: 50,
+        defense: 50,
+        specialAttack: 50,
+        specialDefense: 50,
+        speed: 50,
+      },
+      generation: "1",
+    },
+  };
+}
+
+export interface DraftStateOverrides {
+  status?: string;
+  currentPick?: number;
+  pickOrder?: string[];
+  players?: LeaguePlayer[];
+  poolItems?: DraftPoolItem[];
+  picks?: DraftState["picks"];
+  availableItemIds?: string[];
+  leagueId?: string;
+}
+
+export function makeDraftState(
+  overrides: DraftStateOverrides = {},
+): DraftState {
+  const players = overrides.players ?? [
+    makePlayer("p1", "Alice"),
+    makePlayer("p2", "Bob"),
+  ];
+  const poolItems = overrides.poolItems ?? [
+    makePoolItem("item-1", "bulbasaur", ["grass"]),
+    makePoolItem("item-2", "charmander", ["fire"]),
+    makePoolItem("item-3", "squirtle", ["water"]),
+    makePoolItem("item-4", "pikachu", ["electric"]),
+  ];
+  const picks = overrides.picks ?? [];
+  const pickedIds = new Set(picks.map((p) => p.poolItemId));
+  const availableItemIds = overrides.availableItemIds ??
+    poolItems.filter((i) => !pickedIds.has(i.id)).map((i) => i.id);
+
+  return {
+    draft: {
+      id: "draft-1",
+      leagueId: overrides.leagueId ?? "league-1",
+      format: "snake",
+      status: overrides.status ?? "in_progress",
+      pickOrder: overrides.pickOrder ?? players.map((p) => p.id),
+      currentPick: overrides.currentPick ?? 0,
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: null,
+    },
+    picks,
+    players,
+    poolItems,
+    availableItemIds,
+  };
+}

--- a/client/src/features/draft/mod.ts
+++ b/client/src/features/draft/mod.ts
@@ -1,2 +1,6 @@
 export { DraftPage } from "./DraftPage.tsx";
 export { DraftPoolPage } from "./DraftPoolPage.tsx";
+export { DraftBoard } from "./DraftBoard.tsx";
+export { DraftHeader } from "./DraftHeader.tsx";
+export { PickPanel } from "./PickPanel.tsx";
+export { RosterStrip } from "./RosterStrip.tsx";

--- a/client/src/features/draft/snake.ts
+++ b/client/src/features/draft/snake.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared snake-draft helpers used by the client draft room.
+ *
+ * The server owns the authoritative pick order, but the client needs the same
+ * arithmetic to (a) render the board grid with rows = rounds and (b) know
+ * whose turn is up without a round-trip.
+ *
+ * All functions treat `currentPick` as a 0-indexed pick counter (0 = first
+ * pick of round 0) and `pickOrder` as the array of leaguePlayerIds in first-
+ * round order.
+ */
+
+export function roundForPick(pickNumber: number, playersCount: number): number {
+  if (playersCount <= 0) return 0;
+  return Math.floor(pickNumber / playersCount);
+}
+
+export function slotForPick(
+  pickNumber: number,
+  playersCount: number,
+): number {
+  if (playersCount <= 0) return 0;
+  const positionInRound = pickNumber % playersCount;
+  const round = roundForPick(pickNumber, playersCount);
+  // In snake, even rounds go in pick order, odd rounds go reversed.
+  return round % 2 === 0 ? positionInRound : playersCount - 1 - positionInRound;
+}
+
+export function leaguePlayerForPick(
+  pickNumber: number,
+  pickOrder: string[],
+): string | null {
+  if (pickOrder.length === 0) return null;
+  const slot = slotForPick(pickNumber, pickOrder.length);
+  return pickOrder[slot] ?? null;
+}

--- a/client/src/features/draft/use-draft.ts
+++ b/client/src/features/draft/use-draft.ts
@@ -1,5 +1,88 @@
+import type {
+  DraftState,
+  MakePickInput,
+  StartDraftInput,
+} from "@make-the-pick/shared";
 import { trpc } from "../../trpc";
 
 export function useDraftPool(leagueId: string) {
   return trpc.draftPool.getByLeagueId.useQuery({ leagueId });
+}
+
+// TODO(draft-server): the `trpc.draft.*` namespace is provided by the draft
+// router being built in parallel on `feat/draft-core-pick-loop-server`. Until
+// that PR merges and the AppRouter type picks it up, we access it behind a
+// local `DraftApi` interface via a cast, so the type error is isolated to one
+// place in this file.
+interface DraftQueryLike {
+  data: DraftState | undefined;
+  isLoading: boolean;
+  error: { message: string } | null;
+  refetch: () => void;
+}
+
+interface DraftMutationLike<Input> {
+  mutate: (
+    input: Input,
+    options?: { onSuccess?: () => void; onError?: (err: unknown) => void },
+  ) => void;
+  mutateAsync: (input: Input) => Promise<unknown>;
+  isPending: boolean;
+  error: { message: string } | null;
+}
+
+interface DraftApi {
+  draft: {
+    getState: {
+      useQuery: (input: { leagueId: string }) => DraftQueryLike;
+    };
+    makePick: {
+      useMutation: (opts?: {
+        onSuccess?: () => void;
+      }) => DraftMutationLike<MakePickInput>;
+    };
+    startDraft: {
+      useMutation: (opts?: {
+        onSuccess?: () => void;
+      }) => DraftMutationLike<StartDraftInput>;
+    };
+  };
+}
+
+interface DraftUtilsLike {
+  draft: {
+    getState: {
+      invalidate: (input: { leagueId: string }) => void;
+    };
+  };
+}
+
+const draftApi = trpc as unknown as DraftApi;
+
+export function useDraft(leagueId: string): DraftQueryLike {
+  return draftApi.draft.getState.useQuery({ leagueId });
+}
+
+export function useMakePick(
+  leagueId: string,
+): DraftMutationLike<MakePickInput> {
+  // deno-lint-ignore no-explicit-any
+  const utils = (trpc as any).useUtils() as DraftUtilsLike;
+  return draftApi.draft.makePick.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}
+
+export function useStartDraft(
+  leagueId: string,
+): DraftMutationLike<StartDraftInput> {
+  // deno-lint-ignore no-explicit-any
+  const utils = (trpc as any).useUtils() as DraftUtilsLike;
+  return draftApi.draft.startDraft.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
 }


### PR DESCRIPTION
## Summary

Phase 1 of the live draft experience. Replaces the placeholder `DraftPage` with a real draft room composed from presentational pieces:

- **`DraftHeader`** — round/pick counters, format, whose turn it is, status.
- **`DraftBoard`** — grid with rows = rounds, columns = players (fixed to first-round order). Snake pick arithmetic means odd rows fill right-to-left; an arrow indicator shows direction. Current pick cell is highlighted.
- **`PickPanel`** — available pool with text search and a confirmation modal. Draft buttons are hidden when it is not the user's turn; shows a loading state while the pick mutation is pending.
- **`RosterStrip`** — horizontal strip of the current user's picks, ordered by `pickNumber`, with type badges.
- **`DraftPage`** — composition root. Resolves the current user's `leaguePlayer`, computes `isMyTurn` via a shared `leaguePlayerForPick` snake helper, handles loading / error / `pending` draft states (with a Start Draft button for commissioners), and invalidates the draft state query on pick success so the room refetches.

Hooks `useDraft`, `useMakePick`, and `useStartDraft` are added to `use-draft.ts` as a thin wrapper over `trpc.draft.*`.

## Coordination with server PR

The `trpc.draft.*` namespace is being built in parallel on `feat/draft-core-pick-loop-server` and does not yet exist on `main`. To avoid blocking, the tRPC client is cast through a local `DraftApi` interface in `use-draft.ts` so the type escape hatch is isolated to one place. Once the server PR merges, that cast can be removed in a follow-up and the hook return types will snap into the real tRPC-generated ones.

All component tests mock `use-draft` entirely via `vi.mock()` + `vi.hoisted()` (matching `LeagueDetailPage.test.tsx`), so the test suite does not depend on the server router existing.

## Out of scope (deferred)

- SSE / real-time subscriptions (next PR).
- Pick timer, commissioner undo, on-deck highlighting.
- Watchlist integration inside the PickPanel.
- Type-filter multi-select in the PickPanel (text search only for Phase 1).

## Test plan

- [x] `deno task test:client` — 82/82 passing, including new suites for `DraftBoard`, `DraftHeader`, `PickPanel`, `RosterStrip`, and rewritten `DraftPage`.
- [x] `deno lint` — clean.
- [x] `deno fmt` — clean.
- [ ] Manual smoke test after the server draft router PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)