### PR TITLE
feat(draft): subscribe to live draft events via SSE

### DIFF
--- a/client/src/features/draft/DraftPage.test.tsx
+++ b/client/src/features/draft/DraftPage.test.tsx
@@ -12,6 +12,7 @@ const {
   mockUseStartDraft,
   mockStartDraftMutate,
   mockMakePickMutate,
+  mockUseDraftEvents,
 } = vi.hoisted(() => ({
   mockUseLeague: vi.fn(),
   mockUseLeaguePlayers: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockUseStartDraft: vi.fn(),
   mockStartDraftMutate: vi.fn(),
   mockMakePickMutate: vi.fn(),
+  mockUseDraftEvents: vi.fn(),
 }));
 
 vi.mock("../league/use-leagues", () => ({
@@ -31,6 +33,10 @@ vi.mock("./use-draft", () => ({
   useDraft: mockUseDraft,
   useMakePick: mockUseMakePick,
   useStartDraft: mockUseStartDraft,
+}));
+
+vi.mock("./use-draft-events", () => ({
+  useDraftEvents: mockUseDraftEvents,
 }));
 
 vi.mock("../../auth", () => ({
@@ -119,6 +125,7 @@ describe("DraftPage", () => {
       isPending: false,
       error: null,
     });
+    mockUseDraftEvents.mockReturnValue({ status: "idle" });
   });
 
   afterEach(() => {
@@ -193,6 +200,28 @@ describe("DraftPage", () => {
     expect(
       screen.getByRole("button", { name: /start draft/i }),
     ).toBeInTheDocument();
+  });
+
+  it("subscribes to live draft events with the league id when the draft is in progress", () => {
+    renderPage();
+    expect(mockUseDraftEvents).toHaveBeenCalled();
+    const [calledLeagueId, calledOpts] = mockUseDraftEvents.mock.calls[0];
+    expect(calledLeagueId).toBe("league-1");
+    expect(calledOpts).toMatchObject({ enabled: true });
+  });
+
+  it("does not enable the draft events subscription when the draft is pending", () => {
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({ status: "pending" }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    const lastCall =
+      mockUseDraftEvents.mock.calls[mockUseDraftEvents.mock.calls.length - 1];
+    expect(lastCall[0]).toBe("league-1");
+    expect(lastCall[1]).toMatchObject({ enabled: false });
   });
 
   it("does not show Start Draft button when pending and user is not commissioner", () => {

--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -19,6 +19,7 @@ import { DraftHeader } from "./DraftHeader";
 import { PickPanel } from "./PickPanel";
 import { RosterStrip } from "./RosterStrip";
 import { useDraft, useMakePick, useStartDraft } from "./use-draft";
+import { useDraftEvents } from "./use-draft-events";
 import { leaguePlayerForPick } from "./snake.ts";
 
 export function DraftPage() {
@@ -44,6 +45,14 @@ export function DraftPage() {
   const totalRounds = rulesConfig?.numberOfRounds ?? 6;
 
   const draftState = draft.data;
+
+  // Subscribe to live SSE updates for the draft room. The subscription is
+  // only active once a draft snapshot has loaded — before that there's
+  // nothing to keep in sync, and for pending drafts there are no live
+  // events yet. The hook's query invalidation keeps `useDraft` reactive
+  // without the page needing to handle individual events itself.
+  const isDraftLive = !!draftState && draftState.draft.status === "in_progress";
+  useDraftEvents(leagueId, { enabled: isDraftLive });
 
   const currentTurnPlayerId = draftState
     ? leaguePlayerForPick(

--- a/client/src/features/draft/use-draft-events.test.ts
+++ b/client/src/features/draft/use-draft-events.test.ts
@@ -1,0 +1,178 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockInvalidate = vi.fn();
+
+vi.mock("../../trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      draft: {
+        getState: {
+          invalidate: mockInvalidate,
+        },
+      },
+    }),
+  },
+}));
+
+// Import AFTER the mock is declared
+import { useDraftEvents } from "./use-draft-events";
+
+type Listener = (event: MessageEvent) => void;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  listeners: Record<string, Listener[]> = {};
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    if (!this.listeners[type]) this.listeners[type] = [];
+    this.listeners[type].push(listener);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners[type] = (this.listeners[type] ?? []).filter((l) =>
+      l !== listener
+    );
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  // Test helpers
+  fireOpen() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  fire(type: string, data: unknown) {
+    const event = { data: JSON.stringify(data) } as MessageEvent;
+    for (const listener of this.listeners[type] ?? []) {
+      listener(event);
+    }
+  }
+
+  fireRaw(type: string, rawData: string) {
+    const event = { data: rawData } as MessageEvent;
+    for (const listener of this.listeners[type] ?? []) {
+      listener(event);
+    }
+  }
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  mockInvalidate.mockClear();
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const validPickMadePayload = {
+  id: "00000000-0000-0000-0000-000000000001",
+  draftId: "00000000-0000-0000-0000-000000000002",
+  leaguePlayerId: "00000000-0000-0000-0000-000000000003",
+  poolItemId: "00000000-0000-0000-0000-000000000004",
+  pickNumber: 0,
+  pickedAt: "2026-04-10T00:00:00.000Z",
+  playerName: "Alice",
+  itemName: "Pikachu",
+  round: 1,
+};
+
+describe("useDraftEvents", () => {
+  it("opens an EventSource and transitions to open on onopen", () => {
+    const { result } = renderHook(() => useDraftEvents("league-1"));
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toContain("league-1");
+    expect(result.current.status).toBe("connecting");
+
+    act(() => {
+      FakeEventSource.instances[0].fireOpen();
+    });
+
+    expect(result.current.status).toBe("open");
+  });
+
+  it("dispatches a valid draft:pick_made event to onEvent and invalidates the state query", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useDraftEvents("league-1", { onEvent }));
+
+    act(() => {
+      FakeEventSource.instances[0].fire("draft:pick_made", {
+        type: "draft:pick_made",
+        data: validPickMadePayload,
+      });
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0][0]).toMatchObject({
+      type: "draft:pick_made",
+    });
+    expect(mockInvalidate).toHaveBeenCalledWith({ leagueId: "league-1" });
+  });
+
+  it("ignores invalid JSON payloads without crashing or calling onEvent", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useDraftEvents("league-1", { onEvent }));
+
+    expect(() => {
+      act(() => {
+        FakeEventSource.instances[0].fireRaw("draft:pick_made", "{not json");
+      });
+    }).not.toThrow();
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(mockInvalidate).not.toHaveBeenCalled();
+  });
+
+  it("ignores payloads that fail schema validation", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useDraftEvents("league-1", { onEvent }));
+
+    act(() => {
+      FakeEventSource.instances[0].fire("draft:pick_made", {
+        type: "draft:pick_made",
+        data: { nope: true },
+      });
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(mockInvalidate).not.toHaveBeenCalled();
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const { unmount } = renderHook(() => useDraftEvents("league-1"));
+    const instance = FakeEventSource.instances[0];
+    expect(instance.closed).toBe(false);
+    unmount();
+    expect(instance.closed).toBe(true);
+  });
+
+  it("does not create an EventSource when enabled is false", () => {
+    const { result } = renderHook(() =>
+      useDraftEvents("league-1", { enabled: false })
+    );
+    expect(FakeEventSource.instances).toHaveLength(0);
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("returns idle when EventSource is undefined in the environment", () => {
+    vi.stubGlobal("EventSource", undefined);
+    const { result } = renderHook(() => useDraftEvents("league-1"));
+    expect(result.current.status).toBe("idle");
+  });
+});

--- a/client/src/features/draft/use-draft-events.ts
+++ b/client/src/features/draft/use-draft-events.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  draftCompletedEventSchema,
+  type DraftEvent,
+  draftPickMadeEventSchema,
+  draftStartedEventSchema,
+  draftStateEventSchema,
+  draftTurnChangeEventSchema,
+} from "@make-the-pick/shared";
+import { trpc } from "../../trpc";
+
+// The SSE endpoint path. Isolated here so it's trivially editable if the
+// parallel server PR (`feat/draft-sse-events`) lands with a different route.
+function draftEventsUrl(leagueId: string): string {
+  return `/api/draft/events/${leagueId}`;
+}
+
+// Per-event-name schema lookup. The shared `draftEventSchema` union exists,
+// but we already know the event `type` from the SSE event name, so a direct
+// lookup gives us a narrower error when validation fails.
+const eventSchemas = {
+  "draft:state": draftStateEventSchema,
+  "draft:started": draftStartedEventSchema,
+  "draft:pick_made": draftPickMadeEventSchema,
+  "draft:turn_change": draftTurnChangeEventSchema,
+  "draft:completed": draftCompletedEventSchema,
+} as const;
+
+type DraftEventName = keyof typeof eventSchemas;
+
+const DRAFT_EVENT_NAMES = Object.keys(eventSchemas) as DraftEventName[];
+
+export type DraftEventsStatus =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "closed"
+  | "error";
+
+export interface UseDraftEventsOptions {
+  enabled?: boolean;
+  onEvent?: (event: DraftEvent) => void;
+}
+
+export interface UseDraftEventsResult {
+  status: DraftEventsStatus;
+}
+
+export function useDraftEvents(
+  leagueId: string,
+  opts: UseDraftEventsOptions = {},
+): UseDraftEventsResult {
+  const { enabled = true, onEvent } = opts;
+  const [status, setStatus] = useState<DraftEventsStatus>("idle");
+  const utils = trpc.useUtils();
+
+  // Keep latest callback + utils in refs so that re-renders driven by
+  // `setStatus` don't tear down and recreate the EventSource.
+  const onEventRef = useRef(onEvent);
+  const utilsRef = useRef(utils);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+    utilsRef.current = utils;
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus("idle");
+      return;
+    }
+    if (typeof EventSource === "undefined") {
+      setStatus("idle");
+      return;
+    }
+
+    setStatus("connecting");
+    const source = new EventSource(draftEventsUrl(leagueId));
+
+    source.onopen = () => {
+      setStatus("open");
+    };
+    source.onerror = () => {
+      // EventSource auto-reconnects; reflect the transitional state but
+      // don't tear down the connection.
+      setStatus("error");
+    };
+
+    const listeners: Array<
+      { name: string; handler: (e: MessageEvent) => void }
+    > = [];
+
+    for (const name of DRAFT_EVENT_NAMES) {
+      const schema = eventSchemas[name];
+      const handler = (e: MessageEvent) => {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(e.data);
+        } catch (err) {
+          console.warn(`[useDraftEvents] invalid JSON for ${name}`, err);
+          return;
+        }
+        const result = schema.safeParse(parsed);
+        if (!result.success) {
+          console.warn(
+            `[useDraftEvents] schema validation failed for ${name}`,
+            result.error,
+          );
+          return;
+        }
+        onEventRef.current?.(result.data as DraftEvent);
+        utilsRef.current.draft.getState.invalidate({ leagueId });
+      };
+      source.addEventListener(name, handler as EventListener);
+      listeners.push({ name, handler });
+    }
+
+    return () => {
+      for (const { name, handler } of listeners) {
+        source.removeEventListener(name, handler as EventListener);
+      }
+      source.close();
+      setStatus("closed");
+    };
+  }, [leagueId, enabled]);
+
+  return { status };
+}

--- a/client/src/features/draft/use-draft.ts
+++ b/client/src/features/draft/use-draft.ts
@@ -1,86 +1,25 @@
-import type {
-  DraftState,
-  MakePickInput,
-  StartDraftInput,
-} from "@make-the-pick/shared";
 import { trpc } from "../../trpc";
 
 export function useDraftPool(leagueId: string) {
   return trpc.draftPool.getByLeagueId.useQuery({ leagueId });
 }
 
-// TODO(draft-server): the `trpc.draft.*` namespace is provided by the draft
-// router being built in parallel on `feat/draft-core-pick-loop-server`. Until
-// that PR merges and the AppRouter type picks it up, we access it behind a
-// local `DraftApi` interface via a cast, so the type error is isolated to one
-// place in this file.
-interface DraftQueryLike {
-  data: DraftState | undefined;
-  isLoading: boolean;
-  error: { message: string } | null;
-  refetch: () => void;
+export function useDraft(leagueId: string) {
+  return trpc.draft.getState.useQuery({ leagueId });
 }
 
-interface DraftMutationLike<Input> {
-  mutate: (
-    input: Input,
-    options?: { onSuccess?: () => void; onError?: (err: unknown) => void },
-  ) => void;
-  mutateAsync: (input: Input) => Promise<unknown>;
-  isPending: boolean;
-  error: { message: string } | null;
-}
-
-interface DraftApi {
-  draft: {
-    getState: {
-      useQuery: (input: { leagueId: string }) => DraftQueryLike;
-    };
-    makePick: {
-      useMutation: (opts?: {
-        onSuccess?: () => void;
-      }) => DraftMutationLike<MakePickInput>;
-    };
-    startDraft: {
-      useMutation: (opts?: {
-        onSuccess?: () => void;
-      }) => DraftMutationLike<StartDraftInput>;
-    };
-  };
-}
-
-interface DraftUtilsLike {
-  draft: {
-    getState: {
-      invalidate: (input: { leagueId: string }) => void;
-    };
-  };
-}
-
-const draftApi = trpc as unknown as DraftApi;
-
-export function useDraft(leagueId: string): DraftQueryLike {
-  return draftApi.draft.getState.useQuery({ leagueId });
-}
-
-export function useMakePick(
-  leagueId: string,
-): DraftMutationLike<MakePickInput> {
-  // deno-lint-ignore no-explicit-any
-  const utils = (trpc as any).useUtils() as DraftUtilsLike;
-  return draftApi.draft.makePick.useMutation({
+export function useMakePick(leagueId: string) {
+  const utils = trpc.useUtils();
+  return trpc.draft.makePick.useMutation({
     onSuccess: () => {
       utils.draft.getState.invalidate({ leagueId });
     },
   });
 }
 
-export function useStartDraft(
-  leagueId: string,
-): DraftMutationLike<StartDraftInput> {
-  // deno-lint-ignore no-explicit-any
-  const utils = (trpc as any).useUtils() as DraftUtilsLike;
-  return draftApi.draft.startDraft.useMutation({
+export function useStartDraft(leagueId: string) {
+  const utils = trpc.useUtils();
+  return trpc.draft.startDraft.useMutation({
     onSuccess: () => {
       utils.draft.getState.invalidate({ leagueId });
     },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,5 +1,9 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { createLogger, defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const logger = createLogger();
 const originalInfo = logger.info.bind(logger);
@@ -17,6 +21,17 @@ logger.info = (msg, options) => {
 export default defineConfig({
   customLogger: logger,
   plugins: [react()],
+  resolve: {
+    alias: {
+      // The shared workspace package is a Deno workspace member and not
+      // installed under node_modules. Alias it to its entry file so vite
+      // can resolve runtime imports of Zod schemas.
+      "@make-the-pick/shared": path.resolve(
+        __dirname,
+        "../packages/shared/mod.ts",
+      ),
+    },
+  },
   server: {
     proxy: {
       "/api": {

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -15,6 +15,13 @@ export default defineConfig({
         __dirname,
         "src/test-stubs/react-remove-scroll.ts",
       ),
+      // The shared workspace package is a Deno workspace member and not
+      // installed under node_modules. Alias it to its entry file so vite
+      // (and vitest) can resolve runtime imports of Zod schemas.
+      "@make-the-pick/shared": path.resolve(
+        __dirname,
+        "../packages/shared/mod.ts",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Wave 2 client-side real-time for the draft room, plus type cleanup.

- **Remove the temporary `DraftApi` cast from `use-draft.ts`.** PR #5 added `trpc.draft.*` to the server router, so the `as unknown as DraftApi` + `as any` shims and the local `DraftQueryLike` / `DraftMutationLike` interfaces are no longer needed. Hooks now call `trpc.draft.getState.useQuery`, `.makePick.useMutation`, `.startDraft.useMutation`, and `trpc.useUtils().draft.getState.invalidate(...)` directly with full inference. No hook or component test changes were needed — the existing DraftPage tests already mock this module. No real type mismatches surfaced; the cast was a clean drop.

- **New `useDraftEvents(leagueId, { enabled, onEvent })` hook** in `client/src/features/draft/use-draft-events.ts`. Opens an `EventSource` against `/api/draft/events/:leagueId` (path isolated in a single `draftEventsUrl` constant so it can flex if the parallel `feat/draft-sse-events` server PR lands with a slightly different route). Listens for all five shared event names from `packages/shared/schemas/draft.ts`. Each payload is validated via a per-event-name Zod schema lookup; invalid JSON or schema mismatches are logged and dropped rather than crashing the hook. Every valid event fires the caller's `onEvent` and invalidates `trpc.draft.getState`, which is the cheapest way to keep `useDraft` reactive without this hook understanding event-to-state reducers. The effect deps are only `leagueId` + `enabled` — latest callback and trpc utils live in refs so internal `setStatus` calls don't tear down and reopen the connection.

- **`DraftPage` subscribes** via `useDraftEvents(leagueId, { enabled: isDraftLive })` where `isDraftLive` is `draftState?.draft.status === "in_progress"`. Pending drafts don't subscribe — there are no live events yet.

- **Shared package vite alias.** The hook's runtime imports of Zod schemas from `@make-the-pick/shared` surfaced that the workspace package isn't under `node_modules` (only type-only imports worked before because those are erased by TS). Added an alias in both `vite.config.ts` and `vitest.config.ts` pointing at `../packages/shared/mod.ts`. This is the minimum fix; server/deno builds are unaffected.

The matching SSE endpoint lands in the parallel `feat/draft-sse-events` PR — this client work is designed to land independently and start working the moment that PR merges.

## Test plan

- [x] `deno task test:client` — 91 tests passing (added 9: 7 for `useDraftEvents`, 2 for `DraftPage` subscribe wiring).
- [x] `deno lint` — clean.
- [x] `deno fmt --check` — clean.
- [x] `useDraftEvents` covers: mount + `onopen` → status transitions; valid `draft:pick_made` → `onEvent` + invalidate; invalid JSON → no crash, no dispatch; schema mismatch → no crash, no dispatch; unmount → `close()`; `enabled: false` → no EventSource created; `typeof EventSource === "undefined"` → `{ status: 'idle' }` no-op.
- [x] `DraftPage.test.tsx` mocks `useDraftEvents` as a no-op (existing tests unchanged) and adds assertions that `enabled: true` when in progress and `enabled: false` when pending.