### PR TITLE
feat(draft): add SSE broadcast for live draft events

### DIFF
--- a/server/features/draft/draft.events.ts
+++ b/server/features/draft/draft.events.ts
@@ -1,0 +1,63 @@
+import type { DraftEvent } from "@make-the-pick/shared";
+import { logger } from "../../logger.ts";
+
+const log = logger.child({ module: "draft.events" });
+
+export type DraftEventListener = (event: DraftEvent) => void;
+
+export interface DraftEventPublisher {
+  subscribe(leagueId: string, listener: DraftEventListener): () => void;
+  publish(leagueId: string, event: DraftEvent): void;
+  subscriberCount(leagueId: string): number;
+}
+
+/**
+ * In-memory draft event pub/sub. A single instance is shared across the
+ * server process: the draft service publishes to it from inside transactions,
+ * and the SSE endpoint subscribes per-connection.
+ *
+ * Listener exceptions are caught per-listener so a single misbehaving
+ * subscriber cannot starve other subscribers on the same league.
+ */
+export function createDraftEventPublisher(): DraftEventPublisher {
+  const listenersByLeague = new Map<string, Set<DraftEventListener>>();
+
+  return {
+    subscribe(leagueId, listener) {
+      let set = listenersByLeague.get(leagueId);
+      if (!set) {
+        set = new Set();
+        listenersByLeague.set(leagueId, set);
+      }
+      set.add(listener);
+      return () => {
+        const current = listenersByLeague.get(leagueId);
+        if (!current) return;
+        current.delete(listener);
+        if (current.size === 0) {
+          listenersByLeague.delete(leagueId);
+        }
+      };
+    },
+
+    publish(leagueId, event) {
+      const set = listenersByLeague.get(leagueId);
+      if (!set || set.size === 0) return;
+      // Snapshot so unsubscribe during iteration is safe.
+      for (const listener of [...set]) {
+        try {
+          listener(event);
+        } catch (err) {
+          log.error(
+            { err, leagueId, eventType: event.type },
+            "draft event listener threw",
+          );
+        }
+      }
+    },
+
+    subscriberCount(leagueId) {
+      return listenersByLeague.get(leagueId)?.size ?? 0;
+    },
+  };
+}

--- a/server/features/draft/draft.events_test.ts
+++ b/server/features/draft/draft.events_test.ts
@@ -1,0 +1,136 @@
+import { assertEquals } from "@std/assert";
+import type { DraftEvent } from "@make-the-pick/shared";
+import { createDraftEventPublisher } from "./draft.events.ts";
+
+function makeStateEvent(leagueId: string): DraftEvent {
+  return {
+    type: "draft:state",
+    data: {
+      draft: {
+        id: crypto.randomUUID(),
+        leagueId,
+        format: "snake",
+        status: "in_progress",
+        pickOrder: [],
+        currentPick: 0,
+        startedAt: null,
+        completedAt: null,
+      },
+      picks: [],
+      players: [],
+      poolItems: [],
+      availableItemIds: [],
+    },
+  };
+}
+
+Deno.test("draftEventPublisher: subscribe then publish invokes listener", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  const received: DraftEvent[] = [];
+
+  publisher.subscribe(leagueId, (event) => {
+    received.push(event);
+  });
+
+  const event = makeStateEvent(leagueId);
+  publisher.publish(leagueId, event);
+
+  assertEquals(received.length, 1);
+  assertEquals(received[0], event);
+});
+
+Deno.test("draftEventPublisher: multiple listeners for the same league all receive the event", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  let count1 = 0;
+  let count2 = 0;
+
+  publisher.subscribe(leagueId, () => {
+    count1++;
+  });
+  publisher.subscribe(leagueId, () => {
+    count2++;
+  });
+
+  publisher.publish(leagueId, makeStateEvent(leagueId));
+
+  assertEquals(count1, 1);
+  assertEquals(count2, 1);
+  assertEquals(publisher.subscriberCount(leagueId), 2);
+});
+
+Deno.test("draftEventPublisher: unsubscribe stops delivery to that listener only", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  let count1 = 0;
+  let count2 = 0;
+
+  const unsub1 = publisher.subscribe(leagueId, () => {
+    count1++;
+  });
+  publisher.subscribe(leagueId, () => {
+    count2++;
+  });
+
+  unsub1();
+  publisher.publish(leagueId, makeStateEvent(leagueId));
+
+  assertEquals(count1, 0);
+  assertEquals(count2, 1);
+  assertEquals(publisher.subscriberCount(leagueId), 1);
+});
+
+Deno.test("draftEventPublisher: publishes are scoped by leagueId", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueA = crypto.randomUUID();
+  const leagueB = crypto.randomUUID();
+  let aCount = 0;
+  let bCount = 0;
+
+  publisher.subscribe(leagueA, () => {
+    aCount++;
+  });
+  publisher.subscribe(leagueB, () => {
+    bCount++;
+  });
+
+  publisher.publish(leagueA, makeStateEvent(leagueA));
+
+  assertEquals(aCount, 1);
+  assertEquals(bCount, 0);
+});
+
+Deno.test("draftEventPublisher: listener throwing does not block other listeners", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  let called = false;
+
+  publisher.subscribe(leagueId, () => {
+    throw new Error("boom");
+  });
+  publisher.subscribe(leagueId, () => {
+    called = true;
+  });
+
+  // Should not throw
+  publisher.publish(leagueId, makeStateEvent(leagueId));
+  assertEquals(called, true);
+});
+
+Deno.test("draftEventPublisher: publish with no listeners is a no-op", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  // Should not throw
+  publisher.publish(leagueId, makeStateEvent(leagueId));
+  assertEquals(publisher.subscriberCount(leagueId), 0);
+});
+
+Deno.test("draftEventPublisher: unsubscribing last listener clears set; subscriberCount is zero", () => {
+  const publisher = createDraftEventPublisher();
+  const leagueId = crypto.randomUUID();
+  const unsub = publisher.subscribe(leagueId, () => {});
+  assertEquals(publisher.subscriberCount(leagueId), 1);
+  unsub();
+  assertEquals(publisher.subscriberCount(leagueId), 0);
+});

--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import type { DraftEvent, DraftState } from "@make-the-pick/shared";
 import { logger } from "../../logger.ts";
 import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { LeagueRepository } from "../league/league.repository.ts";
@@ -7,6 +8,13 @@ import {
   type DraftRepository,
 } from "./draft.repository.ts";
 import { resolveSnakeTurn } from "./draft-utils.ts";
+import type { DraftEventPublisher } from "./draft.events.ts";
+
+const noopPublisher: DraftEventPublisher = {
+  subscribe: () => () => {},
+  publish: () => {},
+  subscriberCount: () => 0,
+};
 
 const log = logger.child({ module: "draft.service" });
 
@@ -109,7 +117,27 @@ export function createDraftService(deps: {
   draftRepo: DraftRepository;
   leagueRepo: LeagueRepository;
   draftPoolRepo: DraftPoolRepository;
+  draftEventPublisher?: DraftEventPublisher;
 }) {
+  const publisher = deps.draftEventPublisher ?? noopPublisher;
+
+  function publishTurnChange(
+    leagueId: string,
+    pickOrder: string[],
+    nextPickNumber: number,
+  ) {
+    const turn = resolveSnakeTurn(pickOrder, nextPickNumber);
+    const event: DraftEvent = {
+      type: "draft:turn_change",
+      data: {
+        currentLeaguePlayerId: turn.leaguePlayerId,
+        pickNumber: nextPickNumber,
+        round: turn.round,
+      },
+    };
+    publisher.publish(leagueId, event);
+  }
+
   async function loadDraftContext(leagueId: string) {
     const league = await deps.leagueRepo.findById(leagueId);
     if (!league) {
@@ -193,7 +221,24 @@ export function createDraftService(deps: {
       );
 
       const picks = await deps.draftRepo.listPicks(updated.id);
-      return toStateShape({ draft: updated, picks, players, poolItems });
+      const state = toStateShape({
+        draft: updated,
+        picks,
+        players,
+        poolItems,
+      });
+
+      publisher.publish(leagueId, {
+        type: "draft:started",
+        data: state as DraftState,
+      });
+      publishTurnChange(
+        leagueId,
+        state.draft.pickOrder,
+        state.draft.currentPick,
+      );
+
+      return state;
     },
 
     async getState(
@@ -290,8 +335,11 @@ export function createDraftService(deps: {
         });
       }
 
+      let createdPickRow: Awaited<
+        ReturnType<DraftRepository["createPick"]>
+      >;
       try {
-        await deps.draftRepo.createPick({
+        createdPickRow = await deps.draftRepo.createPick({
           draftId: draftRow.id,
           leaguePlayerId: callerLeaguePlayer.id,
           poolItemId,
@@ -312,7 +360,8 @@ export function createDraftService(deps: {
       const numberOfRounds = getNumberOfRounds(league);
       const totalPicks = numberOfRounds * pickOrder.length;
       let finalDraft = { ...draftRow, currentPick: nextPick };
-      if (nextPick >= totalPicks) {
+      const isFinalPick = nextPick >= totalPicks;
+      if (isFinalPick) {
         finalDraft = await deps.draftRepo.updateStatus(
           draftRow.id,
           "complete",
@@ -321,12 +370,46 @@ export function createDraftService(deps: {
       }
 
       const picks = await deps.draftRepo.listPicks(draftRow.id);
-      return toStateShape({
+      const state = toStateShape({
         draft: finalDraft,
         picks,
         players,
         poolItems,
       });
+
+      const pickRound = resolveSnakeTurn(pickOrder, createdPickRow.pickNumber)
+        .round;
+      publisher.publish(leagueId, {
+        type: "draft:pick_made",
+        data: {
+          id: createdPickRow.id,
+          draftId: createdPickRow.draftId,
+          leaguePlayerId: createdPickRow.leaguePlayerId,
+          poolItemId: createdPickRow.poolItemId,
+          pickNumber: createdPickRow.pickNumber,
+          pickedAt: createdPickRow.pickedAt instanceof Date
+            ? createdPickRow.pickedAt.toISOString()
+            : String(createdPickRow.pickedAt),
+          playerName: callerLeaguePlayer.name,
+          itemName: poolItem.name,
+          round: pickRound,
+        },
+      });
+
+      if (isFinalPick) {
+        publisher.publish(leagueId, {
+          type: "draft:completed",
+          data: {
+            completedAt: finalDraft.completedAt instanceof Date
+              ? finalDraft.completedAt.toISOString()
+              : (finalDraft.completedAt ?? new Date().toISOString()),
+          },
+        });
+      } else {
+        publishTurnChange(leagueId, pickOrder, nextPick);
+      }
+
+      return state;
     },
 
     async validatePick(

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { TRPCError } from "@trpc/server";
+import type { DraftEvent } from "@make-the-pick/shared";
 import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { LeagueRepository } from "../league/league.repository.ts";
 import {
@@ -7,7 +8,27 @@ import {
   DraftPickConflictError,
   type DraftRepository,
 } from "./draft.repository.ts";
+import type { DraftEventPublisher } from "./draft.events.ts";
 import { createDraftService } from "./draft.service.ts";
+
+interface PublishedEvent {
+  leagueId: string;
+  event: DraftEvent;
+}
+
+function createRecordingPublisher(): DraftEventPublisher & {
+  published: PublishedEvent[];
+} {
+  const published: PublishedEvent[] = [];
+  return {
+    published,
+    subscribe: () => () => {},
+    publish: (leagueId, event) => {
+      published.push({ leagueId, event });
+    },
+    subscriberCount: () => 0,
+  };
+}
 
 type FakeLeague = Awaited<ReturnType<LeagueRepository["findById"]>>;
 type FakePlayer = Awaited<ReturnType<LeagueRepository["findPlayer"]>>;
@@ -802,6 +823,214 @@ Deno.test("draftService.validatePick: returns valid=true for legal pick", async 
   });
   assertEquals(result.valid, true);
 });
+
+// --- event publishing ----------------------------------------------------
+
+Deno.test("draftService.startDraft: publishes draft:started then draft:turn_change", async () => {
+  const league = createFakeLeague({ status: "drafting" });
+  const pool = createFakePool(league.id);
+  const playerA = createLeaguePlayerRow(league.id, "user-1", "commissioner");
+  const playerB = createLeaguePlayerRow(league.id, "user-2", "member");
+
+  let createdDraft: ReturnType<typeof createFakeDraft> | null = null;
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: (_id) => Promise.resolve(null as FakeDraft),
+    create: (input) => {
+      createdDraft = createFakeDraft({
+        leagueId: input.leagueId,
+        poolId: input.poolId,
+        pickOrder: input.pickOrder,
+        format: input.format,
+      });
+      return Promise.resolve(createdDraft);
+    },
+    updateStatus: (id, status, timestamps) =>
+      Promise.resolve({
+        ...createdDraft!,
+        id,
+        status: status as "in_progress",
+        startedAt: timestamps.startedAt ?? null,
+        completedAt: timestamps.completedAt ?? null,
+      }),
+    listPicks: (_id) => Promise.resolve([]),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(league),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({ ...playerA, leagueId: league.id }),
+    findPlayersByLeagueId: (_id) => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_id) => Promise.resolve(pool),
+    findItemsByPoolId: (poolId) =>
+      Promise.resolve([
+        createFakePoolItem(poolId),
+        createFakePoolItem(poolId),
+      ]),
+  });
+  const publisher = createRecordingPublisher();
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+  });
+  await service.startDraft({ userId: "user-1", leagueId: league.id });
+
+  assertEquals(publisher.published.length, 2);
+  assertEquals(publisher.published[0].leagueId, league.id);
+  assertEquals(publisher.published[0].event.type, "draft:started");
+  assertEquals(publisher.published[1].leagueId, league.id);
+  assertEquals(publisher.published[1].event.type, "draft:turn_change");
+  if (publisher.published[1].event.type === "draft:turn_change") {
+    assertEquals(publisher.published[1].event.data.pickNumber, 0);
+    assertEquals(publisher.published[1].event.data.round, 0);
+  }
+});
+
+Deno.test("draftService.makePick: non-final pick publishes pick_made then turn_change", async () => {
+  const fx = setupMakePickFakes({ currentPick: 0 });
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: (_id) => Promise.resolve(fx.draft),
+    listPicks: (_id) => Promise.resolve([]),
+    createPick: (input) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+      }),
+    incrementCurrentPick: (_id) => Promise.resolve(1),
+    findPickByPoolItem: (_d, _p) =>
+      Promise.resolve(null as FakeDraftPick | null),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fx.league),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({ ...fx.playerA, leagueId: fx.league.id }),
+    findPlayersByLeagueId: (_id) => Promise.resolve([fx.playerA, fx.playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_id) => Promise.resolve(fx.pool),
+    findItemsByPoolId: (_id) => Promise.resolve(fx.poolItems),
+  });
+  const publisher = createRecordingPublisher();
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+  });
+  await service.makePick({
+    userId: "user-1",
+    leagueId: fx.league.id,
+    poolItemId: fx.poolItems[0].id,
+  });
+
+  assertEquals(publisher.published.length, 2);
+  assertEquals(publisher.published[0].event.type, "draft:pick_made");
+  if (publisher.published[0].event.type === "draft:pick_made") {
+    assertEquals(
+      publisher.published[0].event.data.poolItemId,
+      fx.poolItems[0].id,
+    );
+    assertEquals(publisher.published[0].event.data.itemName, "pikachu");
+    assertEquals(publisher.published[0].event.data.playerName, fx.playerA.name);
+    assertEquals(publisher.published[0].event.data.pickNumber, 0);
+    assertEquals(publisher.published[0].event.data.round, 0);
+  }
+  assertEquals(publisher.published[1].event.type, "draft:turn_change");
+  if (publisher.published[1].event.type === "draft:turn_change") {
+    assertEquals(publisher.published[1].event.data.pickNumber, 1);
+    assertEquals(
+      publisher.published[1].event.data.currentLeaguePlayerId,
+      fx.playerB.id,
+    );
+  }
+});
+
+Deno.test("draftService.makePick: final pick publishes pick_made then draft:completed", async () => {
+  const fx = setupMakePickFakes({ currentPick: 3, numberOfRounds: 2 });
+  const existingPicks: FakeDraftPick[] = [
+    {
+      id: crypto.randomUUID(),
+      draftId: fx.draft.id,
+      leaguePlayerId: fx.playerA.id,
+      poolItemId: fx.poolItems[0].id,
+      pickNumber: 0,
+      pickedAt: new Date(),
+    },
+    {
+      id: crypto.randomUUID(),
+      draftId: fx.draft.id,
+      leaguePlayerId: fx.playerB.id,
+      poolItemId: fx.poolItems[1].id,
+      pickNumber: 1,
+      pickedAt: new Date(),
+    },
+    {
+      id: crypto.randomUUID(),
+      draftId: fx.draft.id,
+      leaguePlayerId: fx.playerB.id,
+      poolItemId: fx.poolItems[2].id,
+      pickNumber: 2,
+      pickedAt: new Date(),
+    },
+  ];
+
+  const completedAt = new Date();
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: (_id) => Promise.resolve(fx.draft),
+    listPicks: (_id) => Promise.resolve(existingPicks),
+    findPickByPoolItem: (_d, poolItemId) =>
+      Promise.resolve(
+        existingPicks.find((p) => p.poolItemId === poolItemId) ??
+          (null as FakeDraftPick | null),
+      ),
+    incrementCurrentPick: (_id) => Promise.resolve(4),
+    updateStatus: (id, status, _ts) =>
+      Promise.resolve({
+        ...fx.draft,
+        id,
+        status: status as "complete",
+        completedAt,
+        currentPick: 4,
+      }),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fx.league),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({ ...fx.playerA, leagueId: fx.league.id }),
+    findPlayersByLeagueId: (_id) => Promise.resolve([fx.playerA, fx.playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_id) => Promise.resolve(fx.pool),
+    findItemsByPoolId: (_id) => Promise.resolve(fx.poolItems),
+  });
+  const publisher = createRecordingPublisher();
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+  });
+  await service.makePick({
+    userId: "user-1",
+    leagueId: fx.league.id,
+    poolItemId: fx.poolItems[3].id,
+  });
+
+  assertEquals(publisher.published.length, 2);
+  assertEquals(publisher.published[0].event.type, "draft:pick_made");
+  assertEquals(publisher.published[1].event.type, "draft:completed");
+});
+
+// --- validatePick ---------------------------------------------------------
 
 Deno.test("draftService.validatePick: returns valid=false when not caller's turn", async () => {
   const fx = setupMakePickFakes({ currentPick: 0 });

--- a/server/features/draft/draft.sse.ts
+++ b/server/features/draft/draft.sse.ts
@@ -1,0 +1,139 @@
+import type { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { DraftEvent, DraftState } from "@make-the-pick/shared";
+import { TRPCError } from "@trpc/server";
+import { logger } from "../../logger.ts";
+import type { DraftService } from "./draft.service.ts";
+import type { DraftEventPublisher } from "./draft.events.ts";
+
+const log = logger.child({ module: "draft.sse" });
+
+export interface DraftSseSession {
+  userId: string;
+}
+
+export type DraftSseSessionResolver = (
+  req: Request,
+) => Promise<DraftSseSession | null>;
+
+export interface DraftSseDeps {
+  draftService: DraftService;
+  draftEventPublisher: DraftEventPublisher;
+  sessionResolver: DraftSseSessionResolver;
+  /** Heartbeat interval in ms. Defaults to 15s. Tests override this. */
+  heartbeatIntervalMs?: number;
+}
+
+const DEFAULT_HEARTBEAT_MS = 15_000;
+
+/**
+ * Registers `GET /api/draft/events/:leagueId` as a Server-Sent Events stream.
+ *
+ * On connect the handler:
+ *   1. Resolves the caller's session (401 if missing).
+ *   2. Loads the draft state via `draftService.getState`, which enforces
+ *      league membership (403 if the user is not a member).
+ *   3. Emits an initial `draft:state` event with the current snapshot.
+ *   4. Subscribes to the publisher and forwards every event as SSE.
+ *   5. Unsubscribes cleanly on client disconnect.
+ */
+export function registerDraftSseRoute(app: Hono, deps: DraftSseDeps): void {
+  const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+
+  app.get("/api/draft/events/:leagueId", async (c) => {
+    const session = await deps.sessionResolver(c.req.raw);
+    if (!session) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const leagueId = c.req.param("leagueId");
+
+    // getState validates league membership and gives us the initial snapshot.
+    let initialState;
+    try {
+      initialState = await deps.draftService.getState({
+        userId: session.userId,
+        leagueId,
+      });
+    } catch (err) {
+      if (err instanceof TRPCError) {
+        if (err.code === "FORBIDDEN") {
+          return c.json({ error: err.message }, 403);
+        }
+        if (err.code === "NOT_FOUND") {
+          return c.json({ error: err.message }, 404);
+        }
+      }
+      log.error({ err, leagueId }, "failed to load draft state for SSE");
+      throw err;
+    }
+
+    return streamSSE(c, async (stream) => {
+      const queue: DraftEvent[] = [];
+      let notify: (() => void) | null = null;
+
+      const listener = (event: DraftEvent) => {
+        queue.push(event);
+        notify?.();
+      };
+      const unsubscribe = deps.draftEventPublisher.subscribe(
+        leagueId,
+        listener,
+      );
+
+      // Emit initial snapshot so reconnects see the full current state.
+      const initialEvent: DraftEvent = {
+        type: "draft:state",
+        data: initialState as DraftState,
+      };
+      await stream.writeSSE({
+        event: initialEvent.type,
+        data: JSON.stringify(initialEvent),
+      });
+
+      const heartbeatTimer = setInterval(() => {
+        // Comment lines are ignored by EventSource clients but keep proxies alive.
+        stream.write(": ping\n\n").catch(() => {});
+      }, heartbeatIntervalMs);
+
+      const cleanup = () => {
+        clearInterval(heartbeatTimer);
+        unsubscribe();
+      };
+
+      c.req.raw.signal.addEventListener("abort", () => {
+        cleanup();
+        notify?.();
+      });
+
+      try {
+        while (!c.req.raw.signal.aborted && !stream.aborted) {
+          if (queue.length === 0) {
+            await new Promise<void>((resolve) => {
+              notify = () => {
+                notify = null;
+                resolve();
+              };
+              // Guard against a race where cleanup happened before we parked.
+              if (c.req.raw.signal.aborted) {
+                notify = null;
+                resolve();
+              }
+            });
+          }
+          while (queue.length > 0) {
+            const event = queue.shift()!;
+            await stream.writeSSE({
+              event: event.type,
+              data: JSON.stringify(event),
+            });
+            // If this event represents end-of-draft, still keep the stream
+            // open so the client can receive additional follow-ups. We only
+            // break when the connection is actually torn down.
+          }
+        }
+      } finally {
+        cleanup();
+      }
+    });
+  });
+}

--- a/server/features/draft/draft.sse_test.ts
+++ b/server/features/draft/draft.sse_test.ts
@@ -1,0 +1,164 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { Hono } from "hono";
+import { TRPCError } from "@trpc/server";
+import type { DraftEvent, DraftState } from "@make-the-pick/shared";
+import type { DraftService } from "./draft.service.ts";
+import {
+  createDraftEventPublisher,
+  type DraftEventPublisher,
+} from "./draft.events.ts";
+import { registerDraftSseRoute } from "./draft.sse.ts";
+
+function createFakeState(leagueId: string): DraftState {
+  return {
+    draft: {
+      id: crypto.randomUUID(),
+      leagueId,
+      format: "snake",
+      status: "in_progress",
+      pickOrder: [],
+      currentPick: 0,
+      startedAt: null,
+      completedAt: null,
+    },
+    picks: [],
+    players: [],
+    poolItems: [],
+    availableItemIds: [],
+  };
+}
+
+function createFakeDraftService(
+  handler: (args: { userId: string; leagueId: string }) => Promise<DraftState>,
+): DraftService {
+  return {
+    startDraft: () => {
+      throw new Error("not implemented");
+    },
+    makePick: () => {
+      throw new Error("not implemented");
+    },
+    validatePick: () => {
+      throw new Error("not implemented");
+    },
+    getState: handler,
+  } as unknown as DraftService;
+}
+
+function buildApp(opts: {
+  publisher: DraftEventPublisher;
+  draftService: DraftService;
+  sessionUserId: string | null;
+}) {
+  const app = new Hono();
+  registerDraftSseRoute(app, {
+    draftService: opts.draftService,
+    draftEventPublisher: opts.publisher,
+    sessionResolver: () =>
+      Promise.resolve(
+        opts.sessionUserId ? { userId: opts.sessionUserId } : null,
+      ),
+    heartbeatIntervalMs: 60_000,
+  });
+  return app;
+}
+
+Deno.test("draft SSE: unauthenticated request → 401", async () => {
+  const app = buildApp({
+    publisher: createDraftEventPublisher(),
+    draftService: createFakeDraftService(() =>
+      Promise.resolve(createFakeState(crypto.randomUUID()))
+    ),
+    sessionUserId: null,
+  });
+
+  const res = await app.request(`/api/draft/events/${crypto.randomUUID()}`);
+  assertEquals(res.status, 401);
+  await res.body?.cancel();
+});
+
+Deno.test("draft SSE: non-member → 403", async () => {
+  const app = buildApp({
+    publisher: createDraftEventPublisher(),
+    draftService: createFakeDraftService(() =>
+      Promise.reject(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message: "You must be a league member to view the draft",
+        }),
+      )
+    ),
+    sessionUserId: "user-1",
+  });
+
+  const res = await app.request(`/api/draft/events/${crypto.randomUUID()}`);
+  assertEquals(res.status, 403);
+  await res.body?.cancel();
+});
+
+Deno.test("draft SSE: streams initial state and forwards published events, unsubscribes on disconnect", async () => {
+  const leagueId = crypto.randomUUID();
+  const publisher = createDraftEventPublisher();
+  const initial = createFakeState(leagueId);
+  const app = buildApp({
+    publisher,
+    draftService: createFakeDraftService(() => Promise.resolve(initial)),
+    sessionUserId: "user-1",
+  });
+
+  const controller = new AbortController();
+  const res = await app.request(`/api/draft/events/${leagueId}`, {
+    signal: controller.signal,
+  });
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("content-type"), "text/event-stream");
+
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+
+  async function readUntil(
+    predicate: (buf: string) => boolean,
+  ): Promise<string> {
+    let buf = "";
+    while (!predicate(buf)) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+    return buf;
+  }
+
+  // First frame should be the initial snapshot.
+  const initialFrame = await readUntil((b) => b.includes("event: draft:state"));
+  assertStringIncludes(initialFrame, "event: draft:state");
+  assertStringIncludes(initialFrame, initial.draft.id);
+
+  // While the subscriber is connected, subscriberCount should be 1.
+  // Wait a tick to let the handler's subscribe() run.
+  await new Promise((r) => setTimeout(r, 10));
+  assertEquals(publisher.subscriberCount(leagueId), 1);
+
+  // Publish a turn_change event and read it off the stream.
+  const event: DraftEvent = {
+    type: "draft:turn_change",
+    data: {
+      currentLeaguePlayerId: crypto.randomUUID(),
+      pickNumber: 1,
+      round: 0,
+    },
+  };
+  publisher.publish(leagueId, event);
+
+  const nextFrame = await readUntil((b) =>
+    b.includes("event: draft:turn_change")
+  );
+  assertStringIncludes(nextFrame, "event: draft:turn_change");
+  assertStringIncludes(nextFrame, '"pickNumber":1');
+
+  // Abort the client and verify cleanup.
+  await reader.cancel();
+  controller.abort();
+  // Allow the handler's abort listener to run.
+  await new Promise((r) => setTimeout(r, 20));
+  assertEquals(publisher.subscriberCount(leagueId), 0);
+});

--- a/server/features/draft/mod.ts
+++ b/server/features/draft/mod.ts
@@ -10,5 +10,11 @@ export type {
 export { createDraftService } from "./draft.service.ts";
 export type { DraftService } from "./draft.service.ts";
 export { createDraftRouter } from "./draft.router.ts";
+export { createDraftEventPublisher } from "./draft.events.ts";
+export type {
+  DraftEventListener,
+  DraftEventPublisher,
+} from "./draft.events.ts";
+export { registerDraftSseRoute } from "./draft.sse.ts";
 export { buildDraftBoard, resolveSnakeTurn } from "./draft-utils.ts";
 export type { BoardPick, SnakeTurnResult } from "./draft-utils.ts";

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -21,11 +21,17 @@ import starterPokemonJson from "../../packages/shared/data/starter-pokemon.json"
 import tradeEvolutionPokemonJson from "../../packages/shared/data/trade-evolution-pokemon.json" with {
   type: "json",
 };
+import type { Hono } from "hono";
 import {
+  createDraftEventPublisher,
   createDraftRepository,
   createDraftRouter,
   createDraftService,
+  type DraftEventPublisher,
+  type DraftService,
+  registerDraftSseRoute,
 } from "./draft/mod.ts";
+import { auth } from "../auth/mod.ts";
 import {
   createDraftPoolRepository,
   createDraftPoolRouter,
@@ -80,10 +86,12 @@ export function createFeatureRouters(db: Database) {
   });
   const leagueRouter = createLeagueRouter(leagueService);
 
+  const draftEventPublisher = createDraftEventPublisher();
   const draftService = createDraftService({
     draftRepo,
     leagueRepo,
     draftPoolRepo,
+    draftEventPublisher,
   });
   const draftRouter = createDraftRouter(draftService);
 
@@ -117,5 +125,30 @@ export function createFeatureRouters(db: Database) {
     pokemonVersionRouter,
     watchlistRouter,
     poolItemNoteRouter,
+    draftEventPublisher,
+    draftService,
   };
+}
+
+/**
+ * Registers non-tRPC HTTP routes that depend on feature services — currently
+ * the draft SSE stream. Called from `main.ts` after `createFeatureRouters`
+ * so the publisher singleton is shared with the tRPC-facing draft service.
+ */
+export function registerFeatureRoutes(
+  app: Hono,
+  deps: {
+    draftEventPublisher: DraftEventPublisher;
+    draftService: DraftService;
+  },
+): void {
+  registerDraftSseRoute(app, {
+    draftService: deps.draftService,
+    draftEventPublisher: deps.draftEventPublisher,
+    sessionResolver: async (req) => {
+      const sessionData = await auth.api.getSession({ headers: req.headers });
+      if (!sessionData?.user?.id) return null;
+      return { userId: sessionData.user.id };
+    },
+  });
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -3,8 +3,9 @@ import { serveStatic } from "hono/deno";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { HealthResponse } from "@make-the-pick/shared";
 import { db, healthChecks } from "./db/mod.ts";
-import { appRouter } from "./trpc/router.ts";
+import { appRouter, features } from "./trpc/router.ts";
 import { createContext } from "./trpc/context.ts";
+import { registerFeatureRoutes } from "./features/mod.ts";
 import { registerEchoWebSocket } from "./ws/echo.ts";
 import { auth } from "./auth/mod.ts";
 import { renderTrpcPanel } from "trpc-ui";
@@ -16,6 +17,10 @@ export const app: Hono = new Hono();
 app.use(loggerMiddleware(logger));
 
 registerEchoWebSocket(app);
+registerFeatureRoutes(app, {
+  draftEventPublisher: features.draftEventPublisher,
+  draftService: features.draftService,
+});
 
 // Auth routes — must come before tRPC
 app.on(["GET", "POST"], "/api/auth/**", (c) => {

--- a/server/trpc/router.ts
+++ b/server/trpc/router.ts
@@ -13,6 +13,7 @@ const healthRouter = router({
   }),
 });
 
+export const features = createFeatureRouters(db);
 const {
   leagueRouter,
   userRouter,
@@ -21,7 +22,7 @@ const {
   pokemonVersionRouter,
   watchlistRouter,
   poolItemNoteRouter,
-} = createFeatureRouters(db);
+} = features;
 
 export const appRouter = router({
   health: healthRouter,


### PR DESCRIPTION
## Summary

Wave 2 server work: in-memory draft event publisher + SSE endpoint so clients observing a draft room get turn/pick updates in real time without polling. The live draft room UI hook lands in a parallel PR.

### Events published

- **`startDraft` success** → `draft:started` (full snapshot) + `draft:turn_change` (first turn)
- **`makePick` success, non-final** → `draft:pick_made` + `draft:turn_change` (next turn)
- **`makePick` success, final** → `draft:pick_made` + `draft:completed`

### Components

- `server/features/draft/draft.events.ts` — `createDraftEventPublisher`, a leagueId-scoped `Map<string, Set<Listener>>` pub/sub. Listener throws are caught per-listener so one misbehaving subscriber cannot starve others.
- `createDraftService` now takes an optional `draftEventPublisher` dep and publishes at the three points above. Optional keeps existing tests clean; the composition root wires a real singleton.
- `server/features/draft/draft.sse.ts` — registers `GET /api/draft/events/:leagueId`. Auth via injected session resolver (401), league membership via `draftService.getState` (403), initial snapshot sent as a `draft:state` event (also handles reconnect), `writeSSE` frames per publisher event, 15s comment-line heartbeat, clean unsubscribe on client disconnect.
- Composition root (`server/features/mod.ts` + `server/trpc/router.ts` + `server/main.ts`) instantiates a single publisher at boot and shares it between the tRPC draft service and the SSE route.

### Test plan

- [x] `draft.events_test.ts` — fanout, unsubscribe, leagueId isolation, listener throws, no-op publish, refcount after unsubscribe
- [x] `draft.service_test.ts` — recording fake publisher asserts event order for `startDraft`, non-final `makePick`, and final `makePick`
- [x] `draft.sse_test.ts` — 401/403 gates, initial `draft:state`, live event forwarding, listener cleanup on disconnect
- [x] `deno task test:server` — 169 passed
- [x] `deno task test:client` — 82 passed
- [x] `deno lint` clean
- [x] `deno fmt --check` clean

### Notes

- `resolveSnakeTurn` already computes `round`, used for `draft:pick_made.round` and `draft:turn_change.round` without schema churn. No changes to `packages/shared/schemas/draft.ts`.
- One narrow cast (`state as DraftState`) in the service and SSE route: our internal `toStateShape` types the pool item `metadata` as `unknown` (DB row shape) while the shared schema expects the typed Pokemon metadata. The runtime value is compatible; the cast is the minimum patch and is a candidate for a follow-up cleanup if we tighten `toStateShape`.
- Pause/resume, undo, auto-pick timer, and other Phase 2/3 features are intentionally out of scope.