### PR TITLE
feat(draft): add pick timer countdown and auto-pick badge

### DIFF
--- a/client/src/features/draft/DraftBoard.test.tsx
+++ b/client/src/features/draft/DraftBoard.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import { DraftBoard } from "./DraftBoard";
 import { makeDraftState, makePlayer, makePoolItem } from "./fixtures";
-import type { DraftPick } from "@make-the-pick/shared";
+import type { DraftPick } from "./draft-types.ts";
 
 function renderBoard(props: Parameters<typeof DraftBoard>[0]) {
   return render(
@@ -18,6 +18,7 @@ function pick(
   poolItemId: string,
   leaguePlayerId: string,
   pickNumber: number,
+  autoPicked = false,
 ): DraftPick {
   return {
     id,
@@ -26,6 +27,7 @@ function pick(
     poolItemId,
     pickNumber,
     pickedAt: "2026-01-01T00:00:00Z",
+    autoPicked,
   };
 }
 
@@ -102,6 +104,38 @@ describe("DraftBoard", () => {
     // Alice appears as column header AND in at least one empty cell.
     const aliceHits = screen.getAllByText("Alice");
     expect(aliceHits.length).toBeGreaterThan(1);
+  });
+
+  it("shows an AUTO badge on cells for auto-picked picks", () => {
+    const picks = [
+      pick("pk-1", "item-1", "p1", 0, true), // auto-picked
+      pick("pk-2", "item-2", "p2", 1, false), // normal
+    ];
+    const draftState = makeDraftState({
+      players,
+      currentPick: 2,
+      picks,
+    });
+    const { container } = renderBoard({
+      draftState,
+      totalRounds: 2,
+      poolItemsById,
+    });
+
+    const autoCell = container.querySelector(
+      '[data-cell][data-auto-picked="true"]',
+    );
+    expect(autoCell).not.toBeNull();
+    expect(within(autoCell as HTMLElement).getByText(/auto/i))
+      .toBeInTheDocument();
+
+    // Normal pick cell should not have the badge.
+    const normalCells = container.querySelectorAll(
+      '[data-cell]:not([data-auto-picked="true"])',
+    );
+    for (const cell of Array.from(normalCells)) {
+      expect(within(cell as HTMLElement).queryByText(/^auto$/i)).toBeNull();
+    }
   });
 
   it("reverses slot order on odd rounds (snake)", () => {

--- a/client/src/features/draft/DraftBoard.tsx
+++ b/client/src/features/draft/DraftBoard.tsx
@@ -1,9 +1,14 @@
-import { Avatar, Card, Group, ScrollArea, Stack, Text } from "@mantine/core";
-import type {
-  DraftPick,
-  DraftPoolItem,
-  DraftState,
-} from "@make-the-pick/shared";
+import {
+  Avatar,
+  Badge,
+  Card,
+  Group,
+  ScrollArea,
+  Stack,
+  Text,
+} from "@mantine/core";
+import type { DraftPoolItem } from "@make-the-pick/shared";
+import type { DraftPick, DraftState } from "./draft-types.ts";
 import { useMemo } from "react";
 
 export interface DraftBoardProps {
@@ -115,6 +120,7 @@ export function DraftBoard(
                 const item = cell.pick
                   ? poolItemsById[cell.pick.poolItemId]
                   : undefined;
+                const isAutoPicked = cell.pick?.autoPicked === true;
                 return (
                   <Card
                     key={`${roundIdx}-${cell.columnIndex}`}
@@ -123,6 +129,7 @@ export function DraftBoard(
                     radius="sm"
                     data-cell
                     data-current-pick={isCurrent ? "true" : undefined}
+                    data-auto-picked={isAutoPicked ? "true" : undefined}
                     style={{
                       flex: 1,
                       minWidth: 140,
@@ -145,9 +152,21 @@ export function DraftBoard(
                             radius="sm"
                           />
                           <Stack gap={0} style={{ minWidth: 0 }}>
-                            <Text size="xs" c="dimmed">
-                              Pick {cell.pickNumber + 1}
-                            </Text>
+                            <Group gap={4} wrap="nowrap">
+                              <Text size="xs" c="dimmed">
+                                Pick {cell.pickNumber + 1}
+                              </Text>
+                              {isAutoPicked && (
+                                <Badge
+                                  size="xs"
+                                  color="orange"
+                                  variant="light"
+                                  title="Auto-picked when the timer expired"
+                                >
+                                  AUTO
+                                </Badge>
+                              )}
+                            </Group>
                             <Text size="sm" fw={500} tt="capitalize" truncate>
                               {item.name}
                             </Text>

--- a/client/src/features/draft/DraftHeader.test.tsx
+++ b/client/src/features/draft/DraftHeader.test.tsx
@@ -53,4 +53,17 @@ describe("DraftHeader", () => {
     renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
     expect(screen.getByText(/in_progress|in progress/i)).toBeInTheDocument();
   });
+
+  it("shows a pick timer when the draft state has a current turn deadline", () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const draftState = makeDraftState({ currentTurnDeadline: future });
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    expect(screen.getByTestId("pick-timer")).toBeInTheDocument();
+  });
+
+  it("does not show a pick timer when the draft state has no deadline", () => {
+    const draftState = makeDraftState({ currentTurnDeadline: null });
+    renderHeader({ draftState, totalRounds: 6, currentTurnPlayerName: "Bob" });
+    expect(screen.queryByTestId("pick-timer")).toBeNull();
+  });
 });

--- a/client/src/features/draft/DraftHeader.tsx
+++ b/client/src/features/draft/DraftHeader.tsx
@@ -1,5 +1,6 @@
 import { Badge, Card, Group, Stack, Text, Title } from "@mantine/core";
-import type { DraftState } from "@make-the-pick/shared";
+import type { DraftState } from "./draft-types.ts";
+import { PickTimer } from "./PickTimer.tsx";
 import { roundForPick } from "./snake.ts";
 
 export interface DraftHeaderProps {
@@ -19,6 +20,7 @@ export function DraftHeader(
   const displayPick = Math.min(currentPick + 1, totalPicks);
   const format = draftState.draft.format;
   const status = draftState.draft.status;
+  const deadline = draftState.draft.currentTurnDeadline ?? null;
 
   return (
     <Card withBorder shadow="sm" padding="md" radius="md">
@@ -53,6 +55,7 @@ export function DraftHeader(
             {currentTurnPlayerName ?? "—"}
           </Title>
         </Stack>
+        <PickTimer deadline={deadline} />
         <Stack gap={2}>
           <Text size="xs" c="dimmed" tt="uppercase">
             Status

--- a/client/src/features/draft/DraftPage.test.tsx
+++ b/client/src/features/draft/DraftPage.test.tsx
@@ -166,6 +166,27 @@ describe("DraftPage", () => {
     expect(screen.getByText(/available pool/i)).toBeInTheDocument();
   });
 
+  it("shows the pick timer in the header when the draft state has a deadline", () => {
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({
+        players: [
+          makePlayer("p1", "Alice", {
+            userId: "user-p1",
+            role: "commissioner",
+          }),
+          makePlayer("p2", "Bob", { userId: "user-p2" }),
+        ],
+        currentPick: 0,
+        currentTurnDeadline: new Date(Date.now() + 45_000).toISOString(),
+      }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByTestId("pick-timer")).toBeInTheDocument();
+  });
+
   it("shows waiting message when draft status is pending", () => {
     mockUseDraft.mockReturnValue({
       data: makeDraftState({

--- a/client/src/features/draft/PickTimer.test.tsx
+++ b/client/src/features/draft/PickTimer.test.tsx
@@ -1,0 +1,98 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { PickTimer } from "./PickTimer";
+
+const NOW = new Date("2026-04-10T12:00:00.000Z");
+
+function deadlineIn(seconds: number): string {
+  return new Date(NOW.getTime() + seconds * 1000).toISOString();
+}
+
+function renderTimer(props: Parameters<typeof PickTimer>[0]) {
+  return render(
+    <MantineProvider>
+      <PickTimer {...props} />
+    </MantineProvider>,
+  );
+}
+
+describe("PickTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when deadline is null", () => {
+    renderTimer({ deadline: null });
+    expect(screen.queryByTestId("pick-timer")).toBeNull();
+  });
+
+  it("shows MM:SS for a deadline in the future", () => {
+    renderTimer({ deadline: deadlineIn(60) });
+    expect(screen.getByText("01:00")).toBeInTheDocument();
+  });
+
+  it("uses the neutral state when more than 30 seconds remain", () => {
+    renderTimer({ deadline: deadlineIn(60) });
+    const el = screen.getByTestId("pick-timer");
+    expect(el.getAttribute("data-state")).toBe("normal");
+  });
+
+  it("uses the warning state at 30 seconds or less", () => {
+    renderTimer({ deadline: deadlineIn(20) });
+    const el = screen.getByTestId("pick-timer");
+    expect(el.getAttribute("data-state")).toBe("warning");
+    expect(screen.getByText("00:20")).toBeInTheDocument();
+  });
+
+  it("uses the urgent state at 10 seconds or less", () => {
+    renderTimer({ deadline: deadlineIn(5) });
+    const el = screen.getByTestId("pick-timer");
+    expect(el.getAttribute("data-state")).toBe("urgent");
+    expect(screen.getByText("00:05")).toBeInTheDocument();
+  });
+
+  it("shows 00:00 and expired state for a deadline in the past", () => {
+    renderTimer({ deadline: deadlineIn(-5) });
+    const el = screen.getByTestId("pick-timer");
+    expect(el.getAttribute("data-state")).toBe("expired");
+    expect(screen.getByText("00:00")).toBeInTheDocument();
+    expect(screen.getByText(/time's up/i)).toBeInTheDocument();
+  });
+
+  it("ticks down as time advances", () => {
+    renderTimer({ deadline: deadlineIn(10) });
+    expect(screen.getByText("00:10")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText("00:07")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByText("00:02")).toBeInTheDocument();
+  });
+
+  it("clears its interval on unmount", () => {
+    const { unmount } = renderTimer({ deadline: deadlineIn(30) });
+    unmount();
+    // Advancing timers after unmount should not throw or produce act warnings.
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+    }).not.toThrow();
+  });
+
+  it("has an aria-live region so screen readers announce updates", () => {
+    renderTimer({ deadline: deadlineIn(30) });
+    const el = screen.getByTestId("pick-timer");
+    expect(el.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/client/src/features/draft/PickTimer.tsx
+++ b/client/src/features/draft/PickTimer.tsx
@@ -1,0 +1,98 @@
+import { Text } from "@mantine/core";
+import { useEffect, useState } from "react";
+
+export interface PickTimerProps {
+  /** ISO timestamp of when the current pick expires, or null if no timer. */
+  deadline: string | null;
+  /** Injectable "now" for tests. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+type TimerState = "normal" | "warning" | "urgent" | "expired";
+
+const WARNING_THRESHOLD_SECONDS = 30;
+const URGENT_THRESHOLD_SECONDS = 10;
+const TICK_INTERVAL_MS = 250;
+
+function computeSecondsRemaining(deadlineMs: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((deadlineMs - nowMs) / 1000));
+}
+
+function stateForSeconds(seconds: number): TimerState {
+  if (seconds <= 0) return "expired";
+  if (seconds <= URGENT_THRESHOLD_SECONDS) return "urgent";
+  if (seconds <= WARNING_THRESHOLD_SECONDS) return "warning";
+  return "normal";
+}
+
+function colorForState(state: TimerState): string {
+  switch (state) {
+    case "urgent":
+    case "expired":
+      return "red.6";
+    case "warning":
+      return "yellow.6";
+    case "normal":
+    default:
+      return "dimmed";
+  }
+}
+
+function formatMMSS(seconds: number): string {
+  const mm = Math.floor(seconds / 60).toString().padStart(2, "0");
+  const ss = (seconds % 60).toString().padStart(2, "0");
+  return `${mm}:${ss}`;
+}
+
+const pulseKeyframes = `
+@keyframes pick-timer-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+`;
+
+export function PickTimer(
+  { deadline, now }: PickTimerProps,
+): JSX.Element | null {
+  const initialNowMs = (now ?? new Date()).getTime();
+  const deadlineMs = deadline ? new Date(deadline).getTime() : null;
+  const [nowMs, setNowMs] = useState<number>(initialNowMs);
+
+  useEffect(() => {
+    if (deadlineMs === null) return;
+    const id = setInterval(() => {
+      setNowMs(Date.now());
+    }, TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [deadlineMs]);
+
+  if (deadlineMs === null) {
+    return null;
+  }
+
+  const secondsRemaining = computeSecondsRemaining(deadlineMs, nowMs);
+  const state = stateForSeconds(secondsRemaining);
+  const color = colorForState(state);
+  const pulse = state === "urgent"
+    ? { animation: "pick-timer-pulse 1s infinite" }
+    : undefined;
+
+  return (
+    <div
+      data-testid="pick-timer"
+      data-state={state}
+      aria-live="polite"
+      aria-atomic="true"
+      style={{ display: "inline-flex", flexDirection: "column", ...pulse }}
+    >
+      <style>{pulseKeyframes}</style>
+      <Text size="xs" c="dimmed" tt="uppercase">
+        Time left
+      </Text>
+      <Text fw={700} c={color} ff="monospace">
+        {formatMMSS(secondsRemaining)}
+      </Text>
+      {state === "expired" && <Text size="xs" c="red.6">Time's up</Text>}
+    </div>
+  );
+}

--- a/client/src/features/draft/draft-types.ts
+++ b/client/src/features/draft/draft-types.ts
@@ -1,0 +1,25 @@
+import type {
+  DraftPick as SharedDraftPick,
+  DraftState as SharedDraftState,
+} from "@make-the-pick/shared";
+
+/**
+ * Local extensions of the shared draft types that add the pick-timer and
+ * auto-pick fields. The authoritative fields are landing in a parallel server
+ * PR (`feat/draft-pick-timer`) that adds `currentTurnDeadline` to the draft
+ * snapshot and `autoPicked` to each pick.
+ *
+ * TODO(draft-pick-timer): once the shared schema PR merges, delete this file
+ * and import `DraftState`/`DraftPick` directly from `@make-the-pick/shared`.
+ */
+
+export type DraftPick = SharedDraftPick & {
+  autoPicked?: boolean;
+};
+
+export type DraftState = Omit<SharedDraftState, "draft" | "picks"> & {
+  draft: SharedDraftState["draft"] & {
+    currentTurnDeadline?: string | null;
+  };
+  picks: DraftPick[];
+};

--- a/client/src/features/draft/fixtures.ts
+++ b/client/src/features/draft/fixtures.ts
@@ -1,8 +1,5 @@
-import type {
-  DraftPoolItem,
-  DraftState,
-  LeaguePlayer,
-} from "@make-the-pick/shared";
+import type { DraftPoolItem, LeaguePlayer } from "@make-the-pick/shared";
+import type { DraftPick, DraftState } from "./draft-types.ts";
 
 export function makePlayer(
   id: string,
@@ -46,15 +43,40 @@ export function makePoolItem(
   };
 }
 
+export interface MakePickOverrides {
+  id?: string;
+  draftId?: string;
+  pickedAt?: string;
+  autoPicked?: boolean;
+}
+
+export function makePick(
+  poolItemId: string,
+  leaguePlayerId: string,
+  pickNumber: number,
+  overrides: MakePickOverrides = {},
+): DraftPick {
+  return {
+    id: overrides.id ?? `pk-${pickNumber}`,
+    draftId: overrides.draftId ?? "draft-1",
+    leaguePlayerId,
+    poolItemId,
+    pickNumber,
+    pickedAt: overrides.pickedAt ?? "2026-01-01T00:00:00Z",
+    autoPicked: overrides.autoPicked ?? false,
+  };
+}
+
 export interface DraftStateOverrides {
   status?: string;
   currentPick?: number;
   pickOrder?: string[];
   players?: LeaguePlayer[];
   poolItems?: DraftPoolItem[];
-  picks?: DraftState["picks"];
+  picks?: DraftPick[];
   availableItemIds?: string[];
   leagueId?: string;
+  currentTurnDeadline?: string | null;
 }
 
 export function makeDraftState(
@@ -85,6 +107,7 @@ export function makeDraftState(
       currentPick: overrides.currentPick ?? 0,
       startedAt: "2026-01-01T00:00:00Z",
       completedAt: null,
+      currentTurnDeadline: overrides.currentTurnDeadline ?? null,
     },
     picks,
     players,


### PR DESCRIPTION
## Summary

Phase 2 client UI for the draft pick timer. Adds:

- A new `PickTimer` component (presentational, `deadline` in + DOM out) that renders an `MM:SS` countdown with escalating states:
  - **normal** (> 30s): dimmed
  - **warning** (<= 30s): amber
  - **urgent** (<= 10s): red with a pulse animation
  - **expired** (0s): red "Time's up"
  - Internally ticks every 250ms via `setInterval` and cleans up on unmount; exposes `data-state` + an `aria-live="polite"` region for screen readers.
- Wires `PickTimer` into `DraftHeader` next to the "on the clock" slot. When no deadline is configured the slot collapses cleanly.
- Shows a compact orange **AUTO** badge (plus `data-auto-picked="true"`) on `DraftBoard` cells whose pick was auto-selected by the server when the timer expired.
- Extends fixtures (`makeDraftState` with `currentTurnDeadline`, new `makePick` helper with `autoPicked`) so downstream tests can exercise both flows.

### Temporary local type alias

The authoritative shared-schema additions (`currentTurnDeadline` on `draftStateSchema.draft`, `autoPicked` on `draftPickSchema`) are landing in the parallel server PR `feat/draft-pick-timer`. To avoid blocking on it, this PR introduces `client/src/features/draft/draft-types.ts` with extended `DraftState` / `DraftPick` aliases that add those fields as **optional**. The file carries a `TODO(draft-pick-timer)` comment — delete the file and switch imports back to `@make-the-pick/shared` once the server PR merges.

## Test plan

- [x] `deno task test:client` — 104 passing (9 new `PickTimer` tests, 2 new `DraftHeader` tests, 1 new `DraftBoard` test, 1 new `DraftPage` test)
- [x] `deno lint client/` — clean
- [x] `deno fmt --check client/src/features/draft` — clean
- [ ] Manual smoke: open a league draft with `pickTimeLimitSeconds` set, confirm countdown updates live and warning/urgent states kick in (will fully light up once server PR merges and sends `currentTurnDeadline`).
- [ ] Manual smoke: confirm drafts without a configured pick time continue to render exactly as before (no timer slot).

## Notes

- Followed strict TDD for `PickTimer` — tests were written first and drove the prop shape and the `data-state` hook used to assert visual states.
- No server code touched. No sound effects (Phase 4). No auto-pick-from-watchlist (v2).