### PR TITLE
feat(auth): redirect cancelled Google sign-in back to login

### DIFF
--- a/client/src/pages/LoginPage.test.tsx
+++ b/client/src/pages/LoginPage.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { LoginPage } from "./LoginPage";
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock("wouter", async () => {
+  const actual = await vi.importActual<typeof import("wouter")>("wouter");
+  return { ...actual, useSearch: () => mockSearch() };
+});
+
+vi.mock("../auth", () => ({
+  signIn: { social: vi.fn() },
+}));
+
+function renderPage() {
+  return render(
+    <MantineProvider>
+      <LoginPage />
+    </MantineProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LoginPage", () => {
+  it("does not show an error banner by default", () => {
+    mockSearch.mockReturnValue("");
+    renderPage();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows a cancellation message when ?error=oauth is present", () => {
+    mockSearch.mockReturnValue("error=oauth");
+    renderPage();
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toMatch(/sign[- ]in (was )?cancelled/i);
+  });
+});

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
-import { Center, Stack, Title, UnstyledButton } from "@mantine/core";
+import { Alert, Center, Stack, Title, UnstyledButton } from "@mantine/core";
+import { useSearch } from "wouter";
 import { signIn } from "../auth";
 
 const googleLogoSvg =
@@ -10,10 +11,18 @@ const googleLogoSvg =
 </svg>`;
 
 export function LoginPage() {
+  const search = useSearch();
+  const hasOAuthError = new URLSearchParams(search).get("error") === "oauth";
+
   return (
     <Center h="100vh">
       <Stack align="center" gap="md">
         <Title order={1}>Make The Pick</Title>
+        {hasOAuthError && (
+          <Alert color="red" role="alert">
+            Sign-in was cancelled. Please try again to continue.
+          </Alert>
+        )}
         <UnstyledButton
           onClick={() =>
             signIn.social({ provider: "google", callbackURL: "/" })}

--- a/server/auth/auth.ts
+++ b/server/auth/auth.ts
@@ -17,6 +17,7 @@ export const auth = betterAuth({
     google: {
       clientId: Deno.env.get("GOOGLE_CLIENT_ID") ?? "",
       clientSecret: Deno.env.get("GOOGLE_CLIENT_SECRET") ?? "",
+      errorCallbackURL: "/login?error=oauth",
     },
   },
   secret: Deno.env.get("BETTER_AUTH_SECRET"),

--- a/server/auth/auth_test.ts
+++ b/server/auth/auth_test.ts
@@ -1,0 +1,10 @@
+import { assertEquals } from "@std/assert";
+import { auth } from "./auth.ts";
+
+Deno.test("google social provider redirects cancelled sign-in to /login?error=oauth", () => {
+  const google = auth.options.socialProviders?.google as
+    | { errorCallbackURL?: string }
+    | undefined;
+
+  assertEquals(google?.errorCallbackURL, "/login?error=oauth");
+});


### PR DESCRIPTION
## Summary
- When a user cancels Google's OAuth consent, Better Auth was rendering its default `/api/auth/error` page — a dead-end with no matching client route.
- Configure `errorCallbackURL` on the Google social provider so OAuth errors redirect to `/login?error=oauth`.
- `LoginPage` now reads the query string and shows a Mantine `Alert` ("Sign-in was cancelled…") when that flag is present.

## Test plan
- [x] `deno task test:server` — new `server/auth/auth_test.ts` asserts the provider config
- [x] `deno task test:client` — new `LoginPage.test.tsx` covers both default and cancelled states
- [x] `deno lint`
- [ ] Manual: click "Sign in with Google", cancel at the consent screen, confirm redirect back to `/login` with the alert visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)