### PR TITLE
fix(seed): make dev seed idempotent and surface failures

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   },
   "tasks": {
     "setup": "test -f .env || cp .env.example .env && deno install",
-    "dev": "deno task setup && deno task db:start && deno task db:migrate:dev && deno task seed:dev; deno run -A npm:concurrently -n server,client -c blue,green \"deno task dev:server\" \"deno task dev:client\"",
+    "dev": "deno task setup && deno task db:start && deno task db:migrate:dev && deno task seed:dev && deno run -A npm:concurrently -n server,client -c blue,green \"deno task dev:server\" \"deno task dev:client\"",
     "db:migrate:dev": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env db/migrate.ts",
     "seed:dev": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env cli.ts seed dev",
     "dev:server": "cd server && deno run --watch --allow-net --allow-env --allow-read --allow-sys --env main.ts | deno run -A npm:pino-pretty",

--- a/server/cli/seed/seed-dev.ts
+++ b/server/cli/seed/seed-dev.ts
@@ -347,6 +347,18 @@ export async function seedDev() {
 
   try {
     const devUser = await ensureDevUser(db);
+
+    const existingDevLeagues = await db.select().from(schema.league).where(
+      eq(schema.league.createdBy, devUser.id),
+    );
+    if (existingDevLeagues.length > 0) {
+      log.info(
+        { count: existingDevLeagues.length },
+        "dev leagues already seeded, skipping",
+      );
+      return;
+    }
+
     const fakePlayers = await ensureFakePlayers(db, PLAYERS_PER_LEAGUE - 1);
 
     for (const spec of LEAGUE_SPECS) {


### PR DESCRIPTION
## Summary
- `seedDev` now short-circuits when the dev user already has leagues, so rerunning `deno task dev` no longer duplicates leagues, drafts, pools, watchlist items, and notes.
- Replaced the `;` before `concurrently` in the `dev` task with `&&` so seed failures actually stop the dev server from starting instead of being silently swallowed (which is why the seed looked like it "wasn't running").

## Test plan
- [x] `deno lint server/cli/seed/seed-dev.ts`
- [x] `deno task test:server` (169 passed)
- [x] Ran `deno task seed:dev` twice against the dev DB — first run seeded, second run logged `dev leagues already seeded, skipping` and exited without inserting anything.