### PR TITLE
feat(draft): add commissioner controls UI and paused overlay

### DIFF
--- a/client/src/features/draft/CommissionerControls.test.tsx
+++ b/client/src/features/draft/CommissionerControls.test.tsx
@@ -1,0 +1,207 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { CommissionerControls } from "./CommissionerControls";
+import { makeDraftState, makePick, makePoolItem } from "./fixtures";
+import type { DraftPoolItem } from "@make-the-pick/shared";
+
+const {
+  mockUsePauseDraft,
+  mockUseResumeDraft,
+  mockUseUndoLastPick,
+  mockPauseMutate,
+  mockResumeMutate,
+  mockUndoMutate,
+} = vi.hoisted(() => ({
+  mockUsePauseDraft: vi.fn(),
+  mockUseResumeDraft: vi.fn(),
+  mockUseUndoLastPick: vi.fn(),
+  mockPauseMutate: vi.fn(),
+  mockResumeMutate: vi.fn(),
+  mockUndoMutate: vi.fn(),
+}));
+
+vi.mock("./use-draft-commissioner", () => ({
+  usePauseDraft: mockUsePauseDraft,
+  useResumeDraft: mockUseResumeDraft,
+  useUndoLastPick: mockUseUndoLastPick,
+}));
+
+const leagueId = "league-1";
+const players = [
+  { leaguePlayerId: "p1", name: "Alice" },
+  { leaguePlayerId: "p2", name: "Bob" },
+];
+
+function poolMap(items: DraftPoolItem[]): Record<string, DraftPoolItem> {
+  const map: Record<string, DraftPoolItem> = {};
+  for (const i of items) map[i.id] = i;
+  return map;
+}
+
+function setupDefaultMocks() {
+  mockUsePauseDraft.mockReturnValue({
+    mutate: mockPauseMutate,
+    isPending: false,
+    error: null,
+  });
+  mockUseResumeDraft.mockReturnValue({
+    mutate: mockResumeMutate,
+    isPending: false,
+    error: null,
+  });
+  mockUseUndoLastPick.mockReturnValue({
+    mutate: mockUndoMutate,
+    isPending: false,
+    error: null,
+  });
+}
+
+function renderControls(
+  overrides: Partial<Parameters<typeof CommissionerControls>[0]> = {},
+) {
+  const poolItems = [
+    makePoolItem("item-1", "bulbasaur", ["grass"]),
+    makePoolItem("item-2", "charmander", ["fire"]),
+  ];
+  const draftState = makeDraftState({ poolItems });
+  return render(
+    <MantineProvider>
+      <CommissionerControls
+        draftState={draftState}
+        leagueId={leagueId}
+        players={players}
+        poolItemsById={poolMap(poolItems)}
+        {...overrides}
+      />
+    </MantineProvider>,
+  );
+}
+
+describe("CommissionerControls", () => {
+  beforeEach(() => {
+    setupDefaultMocks();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the Pause button when the draft is in progress", () => {
+    renderControls();
+    expect(screen.getByRole("button", { name: /pause/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^resume$/i })).toBeNull();
+  });
+
+  it("shows the Resume button when the draft is paused", () => {
+    const draftState = makeDraftState({ status: "paused" });
+    renderControls({ draftState });
+    expect(screen.getByRole("button", { name: /resume/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^pause$/i })).toBeNull();
+  });
+
+  it("shows neither Pause nor Resume nor Undo when the draft is pending", () => {
+    const draftState = makeDraftState({ status: "pending" });
+    renderControls({ draftState });
+    expect(screen.queryByRole("button", { name: /pause/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /resume/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /undo/i })).toBeNull();
+  });
+
+  it("hides the Undo button when there are no picks", () => {
+    renderControls();
+    expect(screen.queryByRole("button", { name: /undo/i })).toBeNull();
+  });
+
+  it("shows the Undo button when there is at least one pick", () => {
+    const poolItems = [makePoolItem("item-1", "bulbasaur", ["grass"])];
+    const draftState = makeDraftState({
+      poolItems,
+      picks: [makePick("item-1", "p1", 0)],
+    });
+    renderControls({
+      draftState,
+      poolItemsById: poolMap(poolItems),
+    });
+    expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
+  });
+
+  it("opens a confirmation modal with the player and pokemon name when Undo is clicked", () => {
+    const poolItems = [makePoolItem("item-1", "bulbasaur", ["grass"])];
+    const draftState = makeDraftState({
+      poolItems,
+      picks: [makePick("item-1", "p1", 0)],
+    });
+    renderControls({
+      draftState,
+      poolItemsById: poolMap(poolItems),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    expect(screen.getByText(/Alice/)).toBeInTheDocument();
+    expect(screen.getByText(/bulbasaur/i)).toBeInTheDocument();
+  });
+
+  it("calls the undo mutation with the leagueId when confirmed", () => {
+    const poolItems = [makePoolItem("item-1", "bulbasaur", ["grass"])];
+    const draftState = makeDraftState({
+      poolItems,
+      picks: [makePick("item-1", "p1", 0)],
+    });
+    renderControls({
+      draftState,
+      poolItemsById: poolMap(poolItems),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^confirm undo$/i }));
+    expect(mockUndoMutate).toHaveBeenCalledWith({ leagueId });
+  });
+
+  it("does NOT call the undo mutation when canceled", () => {
+    const poolItems = [makePoolItem("item-1", "bulbasaur", ["grass"])];
+    const draftState = makeDraftState({
+      poolItems,
+      picks: [makePick("item-1", "p1", 0)],
+    });
+    renderControls({
+      draftState,
+      poolItemsById: poolMap(poolItems),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(mockUndoMutate).not.toHaveBeenCalled();
+  });
+
+  it("calls the pause mutation when Pause is clicked", () => {
+    renderControls();
+    fireEvent.click(screen.getByRole("button", { name: /pause/i }));
+    expect(mockPauseMutate).toHaveBeenCalledWith({ leagueId });
+  });
+
+  it("calls the resume mutation when Resume is clicked", () => {
+    const draftState = makeDraftState({ status: "paused" });
+    renderControls({ draftState });
+    fireEvent.click(screen.getByRole("button", { name: /resume/i }));
+    expect(mockResumeMutate).toHaveBeenCalledWith({ leagueId });
+  });
+
+  it("disables and shows loading state on the pause button while pending", () => {
+    mockUsePauseDraft.mockReturnValue({
+      mutate: mockPauseMutate,
+      isPending: true,
+      error: null,
+    });
+    renderControls();
+    const btn = screen.getByRole("button", { name: /pause/i });
+    expect(btn.hasAttribute("data-loading")).toBe(true);
+  });
+
+  it("shows an error message when the pause mutation errors", () => {
+    mockUsePauseDraft.mockReturnValue({
+      mutate: mockPauseMutate,
+      isPending: false,
+      error: { message: "Boom" },
+    });
+    renderControls();
+    expect(screen.getByText(/Boom/)).toBeInTheDocument();
+  });
+});

--- a/client/src/features/draft/CommissionerControls.tsx
+++ b/client/src/features/draft/CommissionerControls.tsx
@@ -1,0 +1,136 @@
+import { Alert, Button, Group, Modal, Stack, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import type { DraftPoolItem, DraftState } from "@make-the-pick/shared";
+import {
+  usePauseDraft,
+  useResumeDraft,
+  useUndoLastPick,
+} from "./use-draft-commissioner";
+
+export interface CommissionerControlsProps {
+  draftState: DraftState;
+  leagueId: string;
+  players: Array<{ leaguePlayerId: string; name: string }>;
+  poolItemsById: Record<string, DraftPoolItem>;
+}
+
+export function CommissionerControls(
+  { draftState, leagueId, players, poolItemsById }: CommissionerControlsProps,
+) {
+  const pause = usePauseDraft(leagueId);
+  const resume = useResumeDraft(leagueId);
+  const undo = useUndoLastPick(leagueId);
+  const [undoOpened, { open: openUndo, close: closeUndo }] = useDisclosure(
+    false,
+  );
+
+  const status = draftState.draft.status;
+  const picks = draftState.picks;
+  const lastPick = picks.length > 0 ? picks[picks.length - 1] : null;
+  const canUndo = (status === "in_progress" || status === "paused" ||
+    status === "complete") && picks.length > 0;
+  const canPause = status === "in_progress";
+  const canResume = status === "paused";
+
+  const lastPickPlayerName = lastPick
+    ? players.find((p) => p.leaguePlayerId === lastPick.leaguePlayerId)?.name ??
+      "player"
+    : "";
+  const lastPickPokemonName = lastPick
+    ? poolItemsById[lastPick.poolItemId]?.name ?? "pick"
+    : "";
+
+  function handleConfirmUndo() {
+    undo.mutate({ leagueId });
+    closeUndo();
+  }
+
+  return (
+    <Stack gap="xs">
+      <Group gap="xs">
+        {canPause && (
+          <Button
+            size="xs"
+            variant="light"
+            color="yellow"
+            onClick={() => pause.mutate({ leagueId })}
+            loading={pause.isPending}
+          >
+            Pause
+          </Button>
+        )}
+        {canResume && (
+          <Button
+            size="xs"
+            variant="light"
+            color="green"
+            onClick={() => resume.mutate({ leagueId })}
+            loading={resume.isPending}
+          >
+            Resume
+          </Button>
+        )}
+        {canUndo && (
+          <Button
+            size="xs"
+            variant="light"
+            color="red"
+            onClick={openUndo}
+            loading={undo.isPending}
+          >
+            Undo Last Pick
+          </Button>
+        )}
+      </Group>
+
+      {pause.error && (
+        <Alert color="red" title="Failed to pause draft">
+          {pause.error.message}
+        </Alert>
+      )}
+      {resume.error && (
+        <Alert color="red" title="Failed to resume draft">
+          {resume.error.message}
+        </Alert>
+      )}
+      {undo.error && (
+        <Alert color="red" title="Failed to undo pick">
+          {undo.error.message}
+        </Alert>
+      )}
+
+      <Modal
+        opened={undoOpened}
+        onClose={closeUndo}
+        title="Undo last pick"
+        transitionProps={{ duration: 0 }}
+      >
+        <Stack gap="md">
+          <Text>
+            Undo{" "}
+            <Text span fw={700}>
+              {lastPickPlayerName}
+            </Text>
+            's pick of{" "}
+            <Text span fw={700} tt="capitalize">
+              {lastPickPokemonName}
+            </Text>? This will return the Pokemon to the pool and rewind the
+            current pick.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={closeUndo}>
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={handleConfirmUndo}
+              loading={undo.isPending}
+            >
+              Confirm Undo
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+}

--- a/client/src/features/draft/DraftPage.test.tsx
+++ b/client/src/features/draft/DraftPage.test.tsx
@@ -39,6 +39,19 @@ vi.mock("./use-draft-events", () => ({
   useDraftEvents: mockUseDraftEvents,
 }));
 
+vi.mock("./CommissionerControls", () => ({
+  CommissionerControls: () => (
+    <div data-testid="commissioner-controls">commissioner-controls</div>
+  ),
+}));
+
+vi.mock("./PausedOverlay", () => ({
+  PausedOverlay: ({ status }: { status: string }) =>
+    status === "paused"
+      ? <div data-testid="paused-overlay">paused-overlay</div>
+      : null,
+}));
+
 vi.mock("../../auth", () => ({
   useSession: () => ({ data: { user: { id: "user-p1" } } }),
 }));
@@ -243,6 +256,43 @@ describe("DraftPage", () => {
       mockUseDraftEvents.mock.calls[mockUseDraftEvents.mock.calls.length - 1];
     expect(lastCall[0]).toBe("league-1");
     expect(lastCall[1]).toMatchObject({ enabled: false });
+  });
+
+  it("shows commissioner controls when user is commissioner and draft is started", () => {
+    renderPage();
+    expect(screen.getByTestId("commissioner-controls")).toBeInTheDocument();
+  });
+
+  it("does not show commissioner controls for non-commissioners", () => {
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        { ...commissionerPlayer, userId: "user-someone-else" },
+        { ...memberPlayer, userId: "user-p1" },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("commissioner-controls")).toBeNull();
+  });
+
+  it("shows the paused overlay when the draft status is paused", () => {
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({
+        status: "paused",
+        players: [
+          makePlayer("p1", "Alice", {
+            userId: "user-p1",
+            role: "commissioner",
+          }),
+          makePlayer("p2", "Bob", { userId: "user-p2" }),
+        ],
+      }),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByTestId("paused-overlay")).toBeInTheDocument();
   });
 
   it("does not show Start Draft button when pending and user is not commissioner", () => {

--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -14,8 +14,10 @@ import { useMemo } from "react";
 import { Link, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { useLeague, useLeaguePlayers } from "../league/use-leagues";
+import { CommissionerControls } from "./CommissionerControls";
 import { DraftBoard } from "./DraftBoard";
 import { DraftHeader } from "./DraftHeader";
+import { PausedOverlay } from "./PausedOverlay";
 import { PickPanel } from "./PickPanel";
 import { RosterStrip } from "./RosterStrip";
 import { useDraft, useMakePick, useStartDraft } from "./use-draft";
@@ -51,7 +53,9 @@ export function DraftPage() {
   // nothing to keep in sync, and for pending drafts there are no live
   // events yet. The hook's query invalidation keeps `useDraft` reactive
   // without the page needing to handle individual events itself.
-  const isDraftLive = !!draftState && draftState.draft.status === "in_progress";
+  const isDraftLive = !!draftState &&
+    (draftState.draft.status === "in_progress" ||
+      draftState.draft.status === "paused");
   useDraftEvents(leagueId, { enabled: isDraftLive });
 
   const currentTurnPlayerId = draftState
@@ -100,9 +104,25 @@ export function DraftPage() {
   const draftStatus = draftState?.draft.status;
   const isPending = draftStatus === "pending";
 
+  const commissionerPlayerList = useMemo(
+    () =>
+      (draftState?.players ?? []).map((p) => ({
+        leaguePlayerId: p.id,
+        name: p.name,
+      })),
+    [draftState],
+  );
+
   return (
     <Container size="xl" py="xl" pos="relative">
       <LoadingOverlay visible={isLoading} />
+      {draftState && (
+        <PausedOverlay
+          status={draftState.draft.status}
+          isCommissioner={isCommissioner}
+          leagueId={leagueId}
+        />
+      )}
 
       <Anchor
         component={Link}
@@ -156,6 +176,14 @@ export function DraftPage() {
             totalRounds={totalRounds}
             currentTurnPlayerName={currentTurnPlayer?.name ?? null}
           />
+          {isCommissioner && (
+            <CommissionerControls
+              draftState={draftState}
+              leagueId={leagueId}
+              players={commissionerPlayerList}
+              poolItemsById={poolItemsById}
+            />
+          )}
           <Grid>
             <Grid.Col span={{ base: 12, md: 8 }}>
               <DraftBoard

--- a/client/src/features/draft/PausedOverlay.test.tsx
+++ b/client/src/features/draft/PausedOverlay.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { PausedOverlay } from "./PausedOverlay";
+
+const { mockUseResumeDraft, mockResumeMutate } = vi.hoisted(() => ({
+  mockUseResumeDraft: vi.fn(),
+  mockResumeMutate: vi.fn(),
+}));
+
+vi.mock("./use-draft-commissioner", () => ({
+  useResumeDraft: mockUseResumeDraft,
+}));
+
+function renderOverlay(
+  overrides: Partial<Parameters<typeof PausedOverlay>[0]> = {},
+) {
+  return render(
+    <MantineProvider>
+      <PausedOverlay
+        status="paused"
+        isCommissioner={false}
+        leagueId="league-1"
+        {...overrides}
+      />
+    </MantineProvider>,
+  );
+}
+
+describe("PausedOverlay", () => {
+  beforeEach(() => {
+    mockUseResumeDraft.mockReturnValue({
+      mutate: mockResumeMutate,
+      isPending: false,
+      error: null,
+    });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the overlay when status is paused", () => {
+    renderOverlay();
+    expect(screen.getByText(/draft paused/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when status is not paused", () => {
+    renderOverlay({ status: "in_progress" });
+    expect(screen.queryByText(/draft paused/i)).toBeNull();
+  });
+
+  it("shows a Resume button for the commissioner", () => {
+    renderOverlay({ isCommissioner: true });
+    expect(screen.getByRole("button", { name: /resume/i })).toBeInTheDocument();
+  });
+
+  it("does not show a Resume button for non-commissioners", () => {
+    renderOverlay({ isCommissioner: false });
+    expect(screen.queryByRole("button", { name: /resume/i })).toBeNull();
+  });
+
+  it("calls useResumeDraft when the commissioner clicks Resume", () => {
+    renderOverlay({ isCommissioner: true });
+    fireEvent.click(screen.getByRole("button", { name: /resume/i }));
+    expect(mockResumeMutate).toHaveBeenCalledWith({ leagueId: "league-1" });
+  });
+});

--- a/client/src/features/draft/PausedOverlay.tsx
+++ b/client/src/features/draft/PausedOverlay.tsx
@@ -1,0 +1,44 @@
+import { Button, Modal, Stack, Text, Title } from "@mantine/core";
+import { useResumeDraft } from "./use-draft-commissioner";
+
+export interface PausedOverlayProps {
+  status: string;
+  isCommissioner: boolean;
+  leagueId: string;
+}
+
+export function PausedOverlay(
+  { status, isCommissioner, leagueId }: PausedOverlayProps,
+) {
+  const resume = useResumeDraft(leagueId);
+  if (status !== "paused") return null;
+
+  return (
+    <Modal
+      opened
+      onClose={() => {}}
+      withCloseButton={false}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      centered
+      size="md"
+      transitionProps={{ duration: 0 }}
+      title={null}
+    >
+      <Stack gap="md" align="center" py="md">
+        <Title order={2}>Draft Paused</Title>
+        <Text c="dimmed" ta="center">
+          The commissioner has paused the draft. Waiting to resume…
+        </Text>
+        {isCommissioner && (
+          <Button
+            onClick={() => resume.mutate({ leagueId })}
+            loading={resume.isPending}
+          >
+            Resume Draft
+          </Button>
+        )}
+      </Stack>
+    </Modal>
+  );
+}

--- a/client/src/features/draft/use-draft-commissioner.ts
+++ b/client/src/features/draft/use-draft-commissioner.ts
@@ -1,0 +1,54 @@
+import { trpc } from "../../trpc";
+
+// TODO(draft-commissioner): remove this cast once the parallel server PR
+// `feat/draft-commissioner-controls` lands. At that point `trpc.draft` will
+// have `pause`, `resume`, and `undoLastPick` procedures generated from the
+// shared AppRouter type and we can call them directly without the interface
+// escape hatch below.
+interface CommissionerMutation {
+  useMutation: (opts?: {
+    onSuccess?: () => void;
+  }) => {
+    mutate: (input: { leagueId: string }) => void;
+    mutateAsync: (input: { leagueId: string }) => Promise<unknown>;
+    isPending: boolean;
+    error: { message: string } | null;
+    reset: () => void;
+  };
+}
+
+interface CommissionerApi {
+  pause: CommissionerMutation;
+  resume: CommissionerMutation;
+  undoLastPick: CommissionerMutation;
+}
+
+// deno-lint-ignore no-explicit-any
+const commissionerApi = (trpc.draft as any) as CommissionerApi;
+
+export function usePauseDraft(leagueId: string) {
+  const utils = trpc.useUtils();
+  return commissionerApi.pause.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}
+
+export function useResumeDraft(leagueId: string) {
+  const utils = trpc.useUtils();
+  return commissionerApi.resume.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}
+
+export function useUndoLastPick(leagueId: string) {
+  const utils = trpc.useUtils();
+  return commissionerApi.undoLastPick.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3 client UI for the live draft room's commissioner controls:

- **New mutation hooks** (`use-draft-commissioner.ts`) — `usePauseDraft`, `useResumeDraft`, and `useUndoLastPick`, each invalidating `draft.getState` on success. The parallel `feat/draft-commissioner-controls` server PR has not landed yet, so the hooks reach through a single isolated `CommissionerApi` interface cast with a `TODO(draft-commissioner)` marker. Cleanup becomes a one-line removal once the AppRouter type picks up the new procedures.
- **`CommissionerControls` component** — visible only to the commissioner. Shows Pause while `in_progress`, Resume while `paused`, and Undo Last Pick whenever there is at least one pick and the draft is in progress/paused/complete. Undo opens a Mantine confirmation modal naming the player and Pokemon before firing. Mutation errors surface inline as Mantine `Alert`s.
- **`PausedOverlay` component** — a non-dismissible Mantine `Modal` (no close button, no click-outside, no escape) rendered at the top of the draft room for **all** players when `draft.status === 'paused'`. Commissioners also get a convenience Resume button inside the overlay. It unmounts automatically once SSE invalidates the draft state with a non-paused status.
- **`DraftPage` wiring** — renders `CommissionerControls` alongside the draft header when the current user is the commissioner and the draft has started, and mounts `PausedOverlay` at the top of the page tree. The SSE subscription now also stays enabled while the draft is paused so clients pick up the resume event without a manual refetch.

Server-side pause / resume / undo land in the parallel `feat/draft-commissioner-controls` PR.

## Test plan

- [x] `deno task test:client` (127 tests, all green — new `CommissionerControls.test.tsx`, `PausedOverlay.test.tsx`, plus three new `DraftPage` tests)
- [x] `deno lint`
- [x] `deno fmt --check`
- [ ] Manual smoke once the server PR lands: pause as commissioner, verify overlay blocks everyone, resume, undo last pick through the confirmation modal