### PR TITLE
feat(league): auto-start draft when advancing to drafting

### DIFF
--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -28,6 +28,9 @@ export function createLeagueService(
     leagueRepo: LeagueRepository;
     draftRepo: DraftRepository;
     draftPoolService: DraftPoolService;
+    startDraft?: (
+      input: { userId: string; leagueId: string },
+    ) => Promise<unknown>;
   },
 ) {
   return {
@@ -201,6 +204,12 @@ export function createLeagueService(
         { leagueId: input.leagueId, newStatus: nextStatus },
         "league status advanced",
       );
+      if (league.status === "setup" && deps.startDraft) {
+        await deps.startDraft({
+          userId,
+          leagueId: input.leagueId,
+        });
+      }
       return updated;
     },
 

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -769,6 +769,87 @@ Deno.test("leagueService.advanceStatus: advances from setup to drafting and gene
   assertEquals(generateCalledWith?.leagueId, fakeLeague.id);
 });
 
+Deno.test("leagueService.advanceStatus: starts the draft after advancing from setup to drafting", async () => {
+  const fakeLeague = createFakeLeague({
+    status: "setup",
+    sportType: "pokemon",
+    maxPlayers: 8,
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 10,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+    },
+  });
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "drafting" })),
+  });
+  let startDraftCalledWith:
+    | { userId: string; leagueId: string }
+    | undefined;
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+    startDraft: (input) => {
+      startDraftCalledWith = input;
+      return Promise.resolve();
+    },
+  });
+
+  await service.advanceStatus("user-1", { leagueId: fakeLeague.id });
+
+  assertEquals(startDraftCalledWith?.userId, "user-1");
+  assertEquals(startDraftCalledWith?.leagueId, fakeLeague.id);
+});
+
+Deno.test("leagueService.advanceStatus: does not start the draft when advancing from drafting to competing", async () => {
+  const fakeLeague = createFakeLeague({ status: "drafting" });
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "competing" })),
+  });
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: (_leagueId) =>
+      Promise.resolve(
+        createFakeDraft({ leagueId: fakeLeague.id, status: "complete" }),
+      ),
+  });
+  let startDraftCalled = false;
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo,
+    draftPoolService: createFakeDraftPoolService(),
+    startDraft: () => {
+      startDraftCalled = true;
+      return Promise.resolve();
+    },
+  });
+
+  await service.advanceStatus("user-1", { leagueId: fakeLeague.id });
+
+  assertEquals(startDraftCalled, false);
+});
+
 Deno.test("leagueService.advanceStatus: does not advance from setup if draft pool generation fails", async () => {
   const fakeLeague = createFakeLeague({
     status: "setup",

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -81,13 +81,6 @@ export function createFeatureRouters(db: Database) {
   });
   const draftPoolRouter = createDraftPoolRouter(draftPoolService);
 
-  const leagueService = createLeagueService({
-    leagueRepo,
-    draftRepo,
-    draftPoolService,
-  });
-  const leagueRouter = createLeagueRouter(leagueService);
-
   const draftEventPublisher = createDraftEventPublisher();
   // Create the scheduler up front so we can pass it into the service; then
   // wire the auto-pick handler back into the scheduler after the service
@@ -105,6 +98,14 @@ export function createFeatureRouters(db: Database) {
     draftService.runAutoPick({ leagueId })
   );
   const draftRouter = createDraftRouter(draftService);
+
+  const leagueService = createLeagueService({
+    leagueRepo,
+    draftRepo,
+    draftPoolService,
+    startDraft: (input) => draftService.startDraft(input),
+  });
+  const leagueRouter = createLeagueRouter(leagueService);
 
   const userRepo = createUserRepository(db);
   const userService = createUserService({ userRepo });


### PR DESCRIPTION
## Summary
- League service now invokes `draftService.startDraft` immediately after the `setup → drafting` transition succeeds, so the draft row is created and moved to `in_progress` in the same action.
- Fixes the footgun where visiting `/leagues/:id/draft` right after advancing the league surfaced *"Draft does not exist for this league yet"* until the commissioner separately clicked "Start Draft".
- Composition in `features/mod.ts` reordered so `draftService` is built before `leagueService`, letting the startDraft callback be injected without a circular dep.

## Test plan
- [x] `deno task test:server` — 186 passed (two new TDD tests cover the setup→drafting auto-start and the no-op on drafting→competing)
- [x] `deno task test:client` — 107 passed
- [x] `deno lint` clean
- [ ] Manual: create a league, advance to drafting, navigate to `/leagues/:id/draft` — should land directly on the live draft room