### PR TITLE
refactor(tasks): extract chained deno tasks into bin/ scripts

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+deno task setup
+deno task db:start
+deno task db:migrate:dev
+deno task seed:dev
+deno run -A npm:concurrently -n server,client -c blue,green \
+  "deno task dev:server" \
+  "deno task dev:client"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+[ -f .env ] || cp .env.example .env
+deno install

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+deno task test:server
+deno task test:client

--- a/bin/test-e2e
+++ b/bin/test-e2e
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+deno run --allow-net --allow-env --allow-read --allow-run --allow-sys e2e/setup.ts
+cd e2e && npx playwright test

--- a/deno.json
+++ b/deno.json
@@ -7,14 +7,14 @@
     "singleQuote": false
   },
   "tasks": {
-    "setup": "test -f .env || cp .env.example .env && deno install",
-    "dev": "deno task setup && deno task db:start && deno task db:migrate:dev && deno task seed:dev && deno run -A npm:concurrently -n server,client -c blue,green \"deno task dev:server\" \"deno task dev:client\"",
+    "setup": "./bin/setup",
+    "dev": "./bin/dev",
     "db:migrate:dev": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env db/migrate.ts",
     "seed:dev": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env cli.ts seed dev",
     "dev:server": "cd server && deno run --watch --allow-net --allow-env --allow-read --allow-sys --env main.ts | deno run -A npm:pino-pretty",
     "dev:client": "cd client && deno run -A npm:vite",
-    "test": "deno task test:server && deno task test:client",
-    "test:e2e": "deno run --allow-net --allow-env --allow-read --allow-run --allow-sys e2e/setup.ts && cd e2e && npx playwright test",
+    "test": "./bin/test",
+    "test:e2e": "./bin/test-e2e",
     "test:server": "deno test server/ --allow-env --allow-net --allow-read --allow-sys --env=.env.example",
     "test:client": "cd client && deno run -A npm:vitest run",
     "build": "cd client && deno task build",


### PR DESCRIPTION
## Summary
- Move the `&&`-chained `setup`, `dev`, `test`, and `test:e2e` tasks out of `deno.json` and into dedicated shell scripts under `bin/`.
- `deno task <name>` entrypoints are unchanged — they now just delegate to `./bin/<name>`.
- Each script uses `set -euo pipefail` and `cd`s to the repo root so it can be invoked from anywhere.

## Test plan
- [ ] `deno task setup` runs and creates `.env` + installs deps
- [ ] `deno task dev` boots db, migrates, seeds, and launches server+client
- [ ] `deno task test` runs server and client suites
- [ ] `deno task test:e2e` runs the e2e setup and Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)