### PR TITLE
feat(shell): add persistent left sidebar to AppShell

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -1,0 +1,176 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { AppLayout } from "./AppLayout";
+
+const { mockUseSession, mockSignOut } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockSignOut: vi.fn(),
+}));
+
+vi.mock("../auth", () => ({
+  useSession: mockUseSession,
+  signOut: mockSignOut,
+}));
+
+const { mockUseLeagues, mockDeleteAccountMutate } = vi.hoisted(() => ({
+  mockUseLeagues: vi.fn(),
+  mockDeleteAccountMutate: vi.fn(),
+}));
+
+vi.mock("../features/league/use-leagues", () => ({
+  useLeagues: mockUseLeagues,
+}));
+
+vi.mock("../trpc", () => ({
+  trpc: {
+    user: {
+      deleteAccount: {
+        useMutation: () => ({
+          mutate: mockDeleteAccountMutate,
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("wouter", async () => {
+  const actual = await vi.importActual<typeof import("wouter")>("wouter");
+  return { ...actual, useLocation: () => ["/", vi.fn()] };
+});
+
+function renderLayout(children: React.ReactNode = <div>content</div>) {
+  return render(
+    <MantineProvider>
+      <AppLayout>{children}</AppLayout>
+    </MantineProvider>,
+  );
+}
+
+function setupMocks(
+  overrides: {
+    leagues?: Array<{ id: string; name: string; status: string }>;
+  } = {},
+) {
+  mockUseSession.mockReturnValue({
+    data: {
+      user: { id: "u1", name: "Ash Ketchum", image: null },
+    },
+    isPending: false,
+  });
+  mockUseLeagues.mockReturnValue({
+    data: overrides.leagues ?? [],
+    isLoading: false,
+  });
+}
+
+describe("AppLayout shell", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders children in the main region", () => {
+    setupMocks();
+    renderLayout(<div data-testid="page-content">hello</div>);
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
+
+  it("renders a navigation landmark (sidebar)", () => {
+    setupMocks();
+    renderLayout();
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  it("has a Home nav link pointing to /", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    const homeLink = within(nav).getByRole("link", { name: /home/i });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("has a Leagues section in the sidebar", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText(/leagues/i)).toBeInTheDocument();
+  });
+
+  it("lists the user's leagues as children under Leagues", () => {
+    setupMocks({
+      leagues: [
+        {
+          id: "L1",
+          name: "Johto Classic",
+          status: "setup",
+        },
+        {
+          id: "L2",
+          name: "Kanto Rumble",
+          status: "drafting",
+        },
+      ],
+    });
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    const johto = within(nav).getByRole("link", { name: /johto classic/i });
+    expect(johto).toHaveAttribute("href", "/leagues/L1");
+    const kanto = within(nav).getByRole("link", { name: /kanto rumble/i });
+    expect(kanto).toHaveAttribute("href", "/leagues/L2");
+  });
+
+  it("shows a Research entry in the sidebar", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText(/research/i)).toBeInTheDocument();
+  });
+
+  it("shows a Profile entry in the sidebar", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText(/profile/i)).toBeInTheDocument();
+  });
+
+  it("renders the user's name in the sidebar footer", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText("Ash Ketchum")).toBeInTheDocument();
+  });
+
+  it("exposes Sign out via the user menu in the sidebar", async () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    fireEvent.click(within(nav).getByRole("button", { name: /ash ketchum/i }));
+    expect(await screen.findByRole("menuitem", { name: /sign out/i }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete account/i }))
+      .toBeInTheDocument();
+  });
+
+  it("has a sidebar collapse toggle", () => {
+    setupMocks();
+    renderLayout();
+    expect(
+      screen.getByRole("button", { name: /collapse sidebar|expand sidebar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the old top-left brand text in the header", () => {
+    setupMocks();
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText(/make the pick/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,95 +1,265 @@
 import {
+  ActionIcon,
   AppShell,
   Avatar,
+  Badge,
+  Box,
   Button,
+  Divider,
   Group,
   Menu,
   Modal,
+  NavLink,
+  ScrollArea,
   Stack,
   Text,
+  Tooltip,
   UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import {
+  IconBinoculars,
+  IconChevronLeft,
+  IconChevronRight,
+  IconHome,
+  IconTrophy,
+  IconUser,
+} from "@tabler/icons-react";
 import type { ReactNode } from "react";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { signOut, useSession } from "../auth";
+import { useLeagues } from "../features/league/use-leagues";
 import { trpc } from "../trpc";
 
 interface AppLayoutProps {
   children: ReactNode;
 }
 
+const NAVBAR_EXPANDED_WIDTH = 260;
+const NAVBAR_COLLAPSED_WIDTH = 72;
+
 export function AppLayout({ children }: AppLayoutProps) {
   const { data: session } = useSession();
   const user = session?.user;
-  const initials = user?.name
-    ?.split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
+  const [location] = useLocation();
+  const [collapsed, { toggle: toggleCollapsed }] = useDisclosure(false);
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
     useDisclosure(false);
+  const [leaguesOpened, { toggle: toggleLeagues }] = useDisclosure(true);
+
+  const leagues = useLeagues();
   const deleteAccount = trpc.user.deleteAccount.useMutation({
     onSuccess: () => {
       globalThis.location.replace("/login");
     },
   });
 
+  const initials = user?.name
+    ?.split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  const navbarWidth = collapsed
+    ? NAVBAR_COLLAPSED_WIDTH
+    : NAVBAR_EXPANDED_WIDTH;
+
+  const isLeaguesActive = location.startsWith("/leagues") || location === "/";
+  const leagueItems = leagues.data ?? [];
+
   return (
-    <AppShell header={{ height: 60 }} padding="md">
+    <AppShell
+      header={{ height: 52 }}
+      navbar={{
+        width: navbarWidth,
+        breakpoint: "sm",
+        collapsed: { mobile: true, desktop: false },
+      }}
+      padding="md"
+    >
       <AppShell.Header>
         <Group h="100%" px="md" justify="space-between">
-          <Text
-            fw={700}
-            size="lg"
-            component={Link}
-            to="/"
-            td="none"
-            c="inherit"
-          >
-            Make the Pick
+          <Text size="sm" c="dimmed">
+            {breadcrumbForLocation(location)}
           </Text>
-
-          {user && (
-            <Menu shadow="md" width={200} position="bottom-end">
-              <Menu.Target>
-                <UnstyledButton>
-                  <Group gap="xs">
-                    <Avatar
-                      src={user.image}
-                      alt={user.name}
-                      radius="xl"
-                      size="sm"
-                      color="blue"
-                    >
-                      {initials}
-                    </Avatar>
-                    <Text size="sm">{user.name}</Text>
-                  </Group>
-                </UnstyledButton>
-              </Menu.Target>
-
-              <Menu.Dropdown>
-                <Menu.Item
-                  onClick={() =>
-                    signOut({
-                      fetchOptions: {
-                        onSuccess: () => globalThis.location.replace("/login"),
-                      },
-                    })}
-                >
-                  Sign out
-                </Menu.Item>
-                <Menu.Divider />
-                <Menu.Item color="red" onClick={openDelete}>
-                  Delete account
-                </Menu.Item>
-              </Menu.Dropdown>
-            </Menu>
-          )}
         </Group>
       </AppShell.Header>
+
+      <AppShell.Navbar p={0}>
+        <Stack gap={0} h="100%">
+          <Box px={collapsed ? "xs" : "md"} py="md">
+            {collapsed
+              ? (
+                <Tooltip label="Make the Pick" position="right">
+                  <Text fw={800} size="lg" ta="center">
+                    M
+                  </Text>
+                </Tooltip>
+              )
+              : (
+                <Text fw={800} size="lg">
+                  Make the Pick
+                </Text>
+              )}
+          </Box>
+          <Divider />
+
+          <ScrollArea style={{ flex: 1 }}>
+            <Stack gap={2} py="xs">
+              <SidebarLink
+                to="/"
+                label="Home"
+                icon={<IconHome size={20} />}
+                active={location === "/"}
+                collapsed={collapsed}
+              />
+
+              {collapsed
+                ? (
+                  <Tooltip label="Leagues" position="right">
+                    <div>
+                      <SidebarLink
+                        to="/"
+                        label="Leagues"
+                        icon={<IconTrophy size={20} />}
+                        active={isLeaguesActive}
+                        collapsed
+                      />
+                    </div>
+                  </Tooltip>
+                )
+                : (
+                  <NavLink
+                    label="Leagues"
+                    leftSection={<IconTrophy size={20} />}
+                    childrenOffset={28}
+                    opened={leaguesOpened}
+                    onClick={toggleLeagues}
+                    active={isLeaguesActive}
+                    variant="filled"
+                  >
+                    {leagueItems.map((league) => (
+                      <NavLink
+                        key={league.id}
+                        component={Link}
+                        href={`/leagues/${league.id}`}
+                        label={league.name}
+                        active={location === `/leagues/${league.id}`}
+                        variant="light"
+                      />
+                    ))}
+                    <NavLink
+                      component={Link}
+                      href="/"
+                      label="Browse all"
+                      c="dimmed"
+                    />
+                  </NavLink>
+                )}
+
+              <SidebarLink
+                label="Research"
+                icon={<IconBinoculars size={20} />}
+                collapsed={collapsed}
+                disabled
+                badge="Soon"
+              />
+
+              <SidebarLink
+                label="Profile"
+                icon={<IconUser size={20} />}
+                collapsed={collapsed}
+                disabled
+                badge="Soon"
+              />
+            </Stack>
+          </ScrollArea>
+
+          <Divider />
+          <Box p="xs">
+            {user && (
+              <Group
+                justify={collapsed ? "center" : "space-between"}
+                wrap="nowrap"
+                gap="xs"
+              >
+                <Menu
+                  shadow="md"
+                  width={220}
+                  position={collapsed ? "right-end" : "top-start"}
+                  withinPortal
+                >
+                  <Menu.Target>
+                    <UnstyledButton
+                      aria-label={user.name ?? "Account menu"}
+                      style={{ flex: 1, minWidth: 0 }}
+                    >
+                      <Group gap="xs" wrap="nowrap">
+                        <Avatar
+                          src={user.image}
+                          alt={user.name}
+                          radius="xl"
+                          size="sm"
+                          color="mint-green"
+                          title={user.name}
+                        >
+                          {initials}
+                        </Avatar>
+                        {!collapsed && (
+                          <Text size="sm" truncate>
+                            {user.name}
+                          </Text>
+                        )}
+                      </Group>
+                    </UnstyledButton>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item
+                      onClick={() =>
+                        signOut({
+                          fetchOptions: {
+                            onSuccess: () =>
+                              globalThis.location.replace("/login"),
+                          },
+                        })}
+                    >
+                      Sign out
+                    </Menu.Item>
+                    <Menu.Divider />
+                    <Menu.Item color="red" onClick={openDelete}>
+                      Delete account
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+
+                {!collapsed && (
+                  <ActionIcon
+                    variant="subtle"
+                    size="lg"
+                    onClick={toggleCollapsed}
+                    aria-label="Collapse sidebar"
+                  >
+                    <IconChevronLeft size={18} />
+                  </ActionIcon>
+                )}
+              </Group>
+            )}
+            {collapsed && (
+              <Box mt="xs" ta="center">
+                <ActionIcon
+                  variant="subtle"
+                  size="lg"
+                  onClick={toggleCollapsed}
+                  aria-label="Expand sidebar"
+                >
+                  <IconChevronRight size={18} />
+                </ActionIcon>
+              </Box>
+            )}
+          </Box>
+        </Stack>
+      </AppShell.Navbar>
 
       <AppShell.Main>{children}</AppShell.Main>
 
@@ -119,4 +289,59 @@ export function AppLayout({ children }: AppLayoutProps) {
       </Modal>
     </AppShell>
   );
+}
+
+interface SidebarLinkProps {
+  to?: string;
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  collapsed: boolean;
+  disabled?: boolean;
+  badge?: string;
+}
+
+function SidebarLink(
+  { to, label, icon, active, collapsed, disabled, badge }: SidebarLinkProps,
+) {
+  const link = (
+    <NavLink
+      component={disabled || !to ? "button" : Link}
+      href={to}
+      label={collapsed ? undefined : label}
+      leftSection={icon}
+      active={active}
+      disabled={disabled}
+      rightSection={!collapsed && badge
+        ? (
+          <Badge size="xs" variant="light" color="gray">
+            {badge}
+          </Badge>
+        )
+        : undefined}
+      variant="filled"
+      aria-label={label}
+    />
+  );
+  if (collapsed) {
+    return (
+      <Tooltip label={label} position="right">
+        <div>{link}</div>
+      </Tooltip>
+    );
+  }
+  return link;
+}
+
+function breadcrumbForLocation(location: string): string {
+  if (location === "/") return "Home";
+  if (location === "/leagues/new") return "Leagues / New";
+  const leagueMatch = location.match(/^\/leagues\/([^/]+)(\/.*)?$/);
+  if (leagueMatch) {
+    const rest = leagueMatch[2] ?? "";
+    if (rest === "/draft") return "Leagues / Draft Room";
+    if (rest === "/draft/pool") return "Leagues / Draft Pool";
+    return "Leagues";
+  }
+  return "";
 }


### PR DESCRIPTION
## Summary

Phase 1 of the dashboard redesign vision ([docs/product/006-ui-ux-dashboard-vision.md](docs/product/006-ui-ux-dashboard-vision.md)). Converts `AppLayout` into a Mantine `AppShell` with a persistent, collapsible **left sidebar**: Home, Leagues (expandable with the user's leagues), Research, Profile. Account menu moves from the top header into the sidebar footer. Header strip becomes a thin contextual breadcrumb.

- Establishes the IA spine the rest of the redesign (leagues table, home dashboard, league dashboard) will hang off of.
- No route changes yet — Research/Profile are visible but disabled with a "Soon" badge so there are no dead links.
- Collapse/expand toggle with tooltips in icon-only state.

## Test plan

- [x] New `AppLayout.test.tsx` covers: navigation landmark, Home link, Leagues section with user leagues, Research/Profile entries, user name + menu in sidebar footer, collapse toggle. 11 cases, all green.
- [x] Full client suite: \`deno task test:client\` — 138 passing.
- [x] Client build: \`deno task build\` — succeeds.
- [x] \`deno lint\` — clean.
- [ ] Manual smoke-test after merge: navigate between routes, collapse/expand, sign out, delete-account modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)