### PR TITLE
feat(leagues): replace league card stack with a sortable leagues table

### DIFF
--- a/client/src/features/league/LeagueListPage.test.tsx
+++ b/client/src/features/league/LeagueListPage.test.tsx
@@ -3,12 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import { LeagueListPage } from "./LeagueListPage";
 
-const { mockUseLeagues, mockUseJoinLeague } = vi.hoisted(
-  () => ({
-    mockUseLeagues: vi.fn(),
-    mockUseJoinLeague: vi.fn(),
-  }),
-);
+const { mockUseLeagues, mockUseJoinLeague } = vi.hoisted(() => ({
+  mockUseLeagues: vi.fn(),
+  mockUseJoinLeague: vi.fn(),
+}));
 
 const { mockNavigate } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -35,21 +33,29 @@ function renderPage() {
 const mockLeagues = [
   {
     id: "1",
-    name: "League One",
-    status: "setup",
+    name: "Johto Classic",
+    status: "drafting",
     inviteCode: "ABC123XY",
     createdBy: "user1",
+    sportType: "pokemon",
+    maxPlayers: 8,
     rulesConfig: null,
+    playerCount: 4,
+    userRole: "commissioner" as const,
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
   },
   {
     id: "2",
-    name: "League Two",
+    name: "Kanto Rumble",
     status: "setup",
     inviteCode: "DEF456ZZ",
     createdBy: "user2",
+    sportType: "pokemon",
+    maxPlayers: 6,
     rulesConfig: null,
+    playerCount: 2,
+    userRole: "member" as const,
     createdAt: "2026-01-02T00:00:00Z",
     updatedAt: "2026-01-02T00:00:00Z",
   },
@@ -80,58 +86,60 @@ describe("LeagueListPage", () => {
     expect(screen.getByText("My Leagues")).toBeInTheDocument();
   });
 
-  it("shows loading overlay when data is loading", () => {
-    setupMocks({ isLoading: true });
-    renderPage();
-    expect(
-      document.querySelector(
-        "[data-mantine-loading-overlay],.mantine-LoadingOverlay-root",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("shows empty state when there are no leagues", () => {
+  it("shows a warm empty state when there are no leagues", () => {
     setupMocks({ data: [] });
     renderPage();
     expect(
-      screen.getByText(/you haven't joined any leagues yet/i),
+      screen.getByText(/your adventure starts here/i),
     ).toBeInTheDocument();
   });
 
-  it("renders league cards when data exists", () => {
+  it("renders a row per league in the table", () => {
     setupMocks({ data: mockLeagues });
     renderPage();
-    expect(screen.getByText("League One")).toBeInTheDocument();
-    expect(screen.getByText("League Two")).toBeInTheDocument();
+    expect(screen.getByText("Johto Classic")).toBeInTheDocument();
+    expect(screen.getByText("Kanto Rumble")).toBeInTheDocument();
+  });
+
+  it("renders a status badge for each league", () => {
+    setupMocks({ data: mockLeagues });
+    renderPage();
+    expect(screen.getByText(/drafting/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/setup/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders player count like 4 / 8", () => {
+    setupMocks({ data: mockLeagues });
+    renderPage();
+    expect(screen.getByText("4 / 8")).toBeInTheDocument();
+    expect(screen.getByText("2 / 6")).toBeInTheDocument();
+  });
+
+  it("renders the user's role for each league", () => {
+    setupMocks({ data: mockLeagues });
+    renderPage();
+    expect(screen.getByText(/commissioner/i)).toBeInTheDocument();
+    expect(screen.getByText(/^member$/i)).toBeInTheDocument();
   });
 
   it("has a Create League link pointing to /leagues/new", () => {
     setupMocks();
     renderPage();
     const link = screen.getByRole("link", { name: /create league/i });
-    expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/leagues/new");
   });
 
-  it("has a Join League button", () => {
-    setupMocks();
-    renderPage();
-    expect(
-      screen.getByRole("button", { name: /join league/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("clicking Join League button locks scroll (opens modal)", () => {
+  it("has a Join League button that opens the modal", () => {
     setupMocks();
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /join league/i }));
     expect(document.body).toHaveAttribute("data-scroll-locked");
   });
 
-  it("navigates to league detail when a league card is clicked", () => {
+  it("navigates to a league detail when its row is clicked", () => {
     setupMocks({ data: mockLeagues });
     renderPage();
-    fireEvent.click(screen.getByText("League One"));
+    fireEvent.click(screen.getByText("Johto Classic"));
     expect(mockNavigate).toHaveBeenCalledWith("/leagues/1");
   });
 });

--- a/client/src/features/league/LeagueListPage.tsx
+++ b/client/src/features/league/LeagueListPage.tsx
@@ -1,60 +1,217 @@
 import {
+  Badge,
+  Box,
   Button,
-  Card,
   Container,
   Group,
   LoadingOverlay,
+  Paper,
   Stack,
   Text,
   Title,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { IconPlus, IconTicket, IconTrophy } from "@tabler/icons-react";
+import {
+  MantineReactTable,
+  type MRT_ColumnDef,
+  useMantineReactTable,
+} from "mantine-react-table";
+import { useMemo } from "react";
 import { Link, useLocation } from "wouter";
-import { useLeagues } from "./use-leagues";
 import { JoinLeagueModal } from "./JoinLeagueModal";
+import { useLeagues } from "./use-leagues";
+
+type LeagueRow = NonNullable<ReturnType<typeof useLeagues>["data"]>[number];
+
+const STATUS_COLOR: Record<string, string> = {
+  setup: "gray",
+  drafting: "mint-green",
+  competing: "blue",
+  complete: "grape",
+};
+
+function formatRelativeDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function nextActionFor(league: LeagueRow): string {
+  switch (league.status) {
+    case "setup":
+      return "Waiting to start";
+    case "drafting":
+      return "Draft in progress";
+    case "competing":
+      return "Season active";
+    case "complete":
+      return "Season complete";
+    default:
+      return "";
+  }
+}
 
 export function LeagueListPage() {
   const leagues = useLeagues();
   const [, navigate] = useLocation();
   const [joinOpened, joinHandlers] = useDisclosure(false);
 
+  const data = useMemo(() => leagues.data ?? [], [leagues.data]);
+
+  const columns = useMemo<MRT_ColumnDef<LeagueRow>[]>(
+    () => [
+      {
+        accessorKey: "name",
+        header: "Name",
+        Cell: ({ row }) => (
+          <Text fw={600} size="sm">
+            {row.original.name}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: "sportType",
+        header: "Game",
+        Cell: ({ row }) => (
+          <Text size="sm" c="dimmed" tt="capitalize">
+            {row.original.sportType ?? "—"}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        Cell: ({ row }) => (
+          <Badge
+            color={STATUS_COLOR[row.original.status] ?? "gray"}
+            variant="light"
+            tt="capitalize"
+          >
+            {row.original.status}
+          </Badge>
+        ),
+      },
+      {
+        id: "players",
+        header: "Players",
+        accessorFn: (row) =>
+          `${row.playerCount ?? 0} / ${row.maxPlayers ?? "—"}`,
+        Cell: ({ row }) => (
+          <Text size="sm">
+            {row.original.playerCount ?? 0} / {row.original.maxPlayers ?? "—"}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: "userRole",
+        header: "Your role",
+        Cell: ({ row }) => (
+          <Text size="sm" tt="capitalize">
+            {row.original.userRole ?? "member"}
+          </Text>
+        ),
+      },
+      {
+        id: "nextAction",
+        header: "Next action",
+        accessorFn: (row) => nextActionFor(row),
+        Cell: ({ row }) => (
+          <Text size="sm" c="dimmed">
+            {nextActionFor(row.original)}
+          </Text>
+        ),
+      },
+      {
+        accessorKey: "createdAt",
+        header: "Created",
+        Cell: ({ row }) => (
+          <Text size="sm" c="dimmed">
+            {formatRelativeDate(String(row.original.createdAt))}
+          </Text>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const table = useMantineReactTable({
+    columns,
+    data,
+    enableColumnResizing: false,
+    enablePagination: false,
+    enableTopToolbar: true,
+    enableBottomToolbar: false,
+    enableColumnActions: false,
+    enableDensityToggle: false,
+    enableHiding: false,
+    enableFullScreenToggle: false,
+    enableGlobalFilter: true,
+    initialState: {
+      density: "xs",
+      showGlobalFilter: true,
+    },
+    state: {
+      isLoading: leagues.isLoading,
+    },
+    mantineTableBodyRowProps: ({ row }) => ({
+      onClick: () => navigate(`/leagues/${row.original.id}`),
+      style: { cursor: "pointer" },
+    }),
+  });
+
+  const isEmpty = !leagues.isLoading && data.length === 0;
+
   return (
-    <Container size="sm" py="xl" pos="relative">
+    <Container size="lg" py="xl" pos="relative">
       <LoadingOverlay visible={leagues.isLoading} />
       <Group justify="space-between" mb="lg">
         <Title order={1}>My Leagues</Title>
         <Group>
-          <Button component={Link} href="/leagues/new">Create League</Button>
-          <Button variant="outline" onClick={joinHandlers.open}>
+          <Button
+            component={Link}
+            href="/leagues/new"
+            leftSection={<IconPlus size={16} />}
+          >
+            Create League
+          </Button>
+          <Button
+            variant="outline"
+            leftSection={<IconTicket size={16} />}
+            onClick={joinHandlers.open}
+          >
             Join League
           </Button>
         </Group>
       </Group>
 
-      {!leagues.isLoading && leagues.data?.length === 0 && (
-        <Text c="dimmed" ta="center" py="xl">
-          You haven't joined any leagues yet.
-        </Text>
-      )}
-
-      <Stack>
-        {leagues.data?.map((league) => (
-          <Card
-            key={league.id}
-            shadow="sm"
-            padding="lg"
-            radius="md"
-            withBorder
-            style={{ cursor: "pointer" }}
-            onClick={() => navigate(`/leagues/${league.id}`)}
-          >
-            <Text fw={500}>{league.name}</Text>
-            <Text size="sm" c="dimmed">
-              Status: {league.status}
-            </Text>
-          </Card>
-        ))}
-      </Stack>
+      {isEmpty
+        ? (
+          <Paper p="xl" radius="md" withBorder ta="center">
+            <Stack align="center" gap="xs">
+              <Box c="mint-green">
+                <IconTrophy size={42} />
+              </Box>
+              <Title order={3}>No leagues yet</Title>
+              <Text c="dimmed" maw={420}>
+                Your adventure starts here. Create a league to invite friends,
+                or join one with an invite code.
+              </Text>
+              <Group mt="sm">
+                <Button component={Link} href="/leagues/new">
+                  Create your first league
+                </Button>
+                <Button variant="outline" onClick={joinHandlers.open}>
+                  Join with invite code
+                </Button>
+              </Group>
+            </Stack>
+          </Paper>
+        )
+        : <MantineReactTable table={table} />}
 
       <JoinLeagueModal opened={joinOpened} onClose={joinHandlers.close} />
     </Container>

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -1,4 +1,4 @@
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import type { db } from "../../db/mod.ts";
 import { league, leaguePlayer, user } from "../../db/mod.ts";
 import { logger } from "../../logger.ts";
@@ -9,6 +9,11 @@ const log = logger.child({ module: "league.repository" });
 
 type LeagueRow = typeof league.$inferSelect;
 type LeaguePlayerRow = typeof leaguePlayer.$inferSelect;
+
+export type LeagueListRow = LeagueRow & {
+  playerCount: number;
+  userRole: "commissioner" | "member";
+};
 
 export function createLeagueRepository(db: Database) {
   return {
@@ -67,15 +72,27 @@ export function createLeagueRepository(db: Database) {
       return result ?? null;
     },
 
-    async findAllByUserId(userId: string): Promise<LeagueRow[]> {
+    async findAllByUserId(userId: string): Promise<LeagueListRow[]> {
       log.debug({ userId }, "finding all leagues for user");
+      const playerCountSql = sql<number>`(
+        SELECT COUNT(*)::int FROM ${leaguePlayer} lp
+        WHERE lp.league_id = ${league.id}
+      )`.as("player_count");
       const rows = await db
-        .select({ league })
+        .select({
+          league,
+          userRole: leaguePlayer.role,
+          playerCount: playerCountSql,
+        })
         .from(league)
         .innerJoin(leaguePlayer, eq(league.id, leaguePlayer.leagueId))
         .where(eq(leaguePlayer.userId, userId));
       log.debug({ userId, count: rows.length }, "findAllByUserId result");
-      return rows.map((row) => row.league);
+      return rows.map((row) => ({
+        ...row.league,
+        userRole: row.userRole as "commissioner" | "member",
+        playerCount: Number(row.playerCount),
+      }));
     },
 
     async addPlayer(

--- a/server/features/league/league.repository_test.ts
+++ b/server/features/league/league.repository_test.ts
@@ -504,3 +504,57 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name:
+    "leagueRepository.findAllByUserId: includes playerCount and userRole for each league",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository(db);
+    const commissionerId = crypto.randomUUID();
+    const memberId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, commissionerId);
+      await createTestUser(db, memberId);
+
+      // commissionerId owns "Owned League" — 2 players total after member joins
+      const owned = await repo.createWithCommissioner(commissionerId, {
+        name: "Owned League",
+        inviteCode: "OWNED001",
+        ...defaultSettings,
+      });
+      await repo.addPlayer(owned.id, memberId);
+
+      // memberId owns "Other League" on their own — 1 player total
+      const other = await repo.createWithCommissioner(memberId, {
+        name: "Other League",
+        inviteCode: "OTHER001",
+        ...defaultSettings,
+      });
+
+      const commissionerLeagues = await repo.findAllByUserId(commissionerId);
+      assertEquals(commissionerLeagues.length, 1);
+      assertEquals(commissionerLeagues[0].id, owned.id);
+      assertEquals(commissionerLeagues[0].playerCount, 2);
+      assertEquals(commissionerLeagues[0].userRole, "commissioner");
+
+      const memberLeagues = await repo.findAllByUserId(memberId);
+      assertEquals(memberLeagues.length, 2);
+      const ownedFromMember = memberLeagues.find((l) => l.id === owned.id);
+      const otherFromMember = memberLeagues.find((l) => l.id === other.id);
+      assertEquals(ownedFromMember?.playerCount, 2);
+      assertEquals(ownedFromMember?.userRole, "member");
+      assertEquals(otherFromMember?.playerCount, 1);
+      assertEquals(otherFromMember?.userRole, "commissioner");
+    } finally {
+      await db.delete(leaguePlayer);
+      await db.delete(league);
+      await db.delete(user).where(eq(user.id, commissionerId));
+      await db.delete(user).where(eq(user.id, memberId));
+      await client.end();
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Phase 2 of the dashboard redesign vision ([docs/product/006-ui-ux-dashboard-vision.md](docs/product/006-ui-ux-dashboard-vision.md)). Replaces the stack-of-cards landing view with a **mantine-react-table** leagues table — the same pattern already in use on the draft pool page.

**Columns:** Name · Game · Status (badge) · Players (4 / 8) · Your role · Next action · Created.

To populate Players and Your-role columns, \`league.list\` now joins the roster count and the caller's role directly in SQL rather than firing N extra requests from the client.

Empty state gets a warmer "Your adventure starts here" callout per the vision doc.

## Test plan

- [x] New repository integration test covers \`findAllByUserId\` returning \`playerCount\` + \`userRole\` for commissioner vs member.
- [x] Updated \`LeagueListPage.test.tsx\` covers the table rendering, status badges, player counts, user role, row click, create/join buttons, and the new empty state copy.
- [x] Full server suite (\`deno task test:server\`) — 187 passing.
- [x] Full client suite (\`deno task test:client\`) — 128 passing.
- [x] \`deno task build\` — succeeds.
- [x] \`deno lint\` — clean.
- [ ] Manual smoke after merge: create a league, confirm row appears with correct player count/role; click row → detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)