### PR TITLE
feat(league): redesign league detail page as a dashboard hub

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,6 +37,7 @@ import {
   JoinLeaguePage,
   LeagueDetailPage,
   LeagueListPage,
+  LeagueSettingsPage,
 } from "./features/league/mod";
 import { DraftPage, DraftPoolPage } from "./features/draft/mod";
 
@@ -70,6 +71,13 @@ export function App() {
               <AuthGuard>
                 <AppLayout>
                   <DraftPage />
+                </AppLayout>
+              </AuthGuard>
+            </Route>
+            <Route path="/leagues/:id/settings">
+              <AuthGuard>
+                <AppLayout>
+                  <LeagueSettingsPage />
                 </AppLayout>
               </AuthGuard>
             </Route>

--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -8,7 +8,6 @@ const {
   mockUseLeaguePlayers,
   mockUseDeleteLeague,
   mockDeleteMutate,
-  mockUseUpdateLeagueSettings,
   mockUseAdvanceLeagueStatus,
   mockAdvanceMutate,
 } = vi.hoisted(
@@ -17,7 +16,6 @@ const {
     mockUseLeaguePlayers: vi.fn(),
     mockUseDeleteLeague: vi.fn(),
     mockDeleteMutate: vi.fn(),
-    mockUseUpdateLeagueSettings: vi.fn(),
     mockUseAdvanceLeagueStatus: vi.fn(),
     mockAdvanceMutate: vi.fn(),
   }),
@@ -27,12 +25,7 @@ vi.mock("./use-leagues", () => ({
   useLeague: mockUseLeague,
   useLeaguePlayers: mockUseLeaguePlayers,
   useDeleteLeague: mockUseDeleteLeague,
-  useUpdateLeagueSettings: mockUseUpdateLeagueSettings,
   useAdvanceLeagueStatus: mockUseAdvanceLeagueStatus,
-}));
-
-vi.mock("../pokemon-version/use-pokemon-versions", () => ({
-  usePokemonVersions: () => ({ data: [], isLoading: false }),
 }));
 
 vi.mock("../../auth", () => ({
@@ -72,10 +65,6 @@ describe("LeagueDetailPage", () => {
     mockUseLeaguePlayers.mockReturnValue({ data: [], isLoading: false });
     mockUseDeleteLeague.mockReturnValue({
       mutate: mockDeleteMutate,
-      isPending: false,
-    });
-    mockUseUpdateLeagueSettings.mockReturnValue({
-      mutate: vi.fn(),
       isPending: false,
     });
     mockUseAdvanceLeagueStatus.mockReturnValue({
@@ -371,6 +360,69 @@ describe("LeagueDetailPage", () => {
     expect(
       screen.queryByRole("button", { name: /advance to/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a Configure link for commissioner during setup", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          numberOfRounds: 10,
+          pickTimeLimitSeconds: null,
+          poolSizeMultiplier: 2,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    const configureLink = screen.getByRole("link", { name: /configure/i });
+    expect(configureLink).toHaveAttribute(
+      "href",
+      "/leagues/league-1/settings",
+    );
+  });
+
+  it("renders a 'Your team' panel", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText(/your team/i)).toBeInTheDocument();
+  });
+
+  it("renders the lifecycle stepper", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    renderPage();
+    expect(
+      screen.getByRole("group", { name: /league lifecycle/i }),
+    ).toBeInTheDocument();
   });
 
   it("does not render a Save Settings button", () => {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -4,33 +4,47 @@ import {
   Anchor,
   Avatar,
   Badge,
+  Box,
   Button,
   Card,
   Container,
   CopyButton,
+  Grid,
   Group,
   LoadingOverlay,
   Modal,
-  NumberInput,
-  Select,
+  Paper,
   Stack,
-  Switch,
   Text,
   Title,
   Tooltip,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { useEffect, useState } from "react";
+import {
+  IconAlertTriangle,
+  IconSettings,
+  IconSparkles,
+} from "@tabler/icons-react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
-import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
+import { LifecycleStepper } from "./LifecycleStepper";
 import {
   useAdvanceLeagueStatus,
   useDeleteLeague,
   useLeague,
   useLeaguePlayers,
-  useUpdateLeagueSettings,
 } from "./use-leagues";
+
+const NEXT_STATUS: Record<string, string | null> = {
+  setup: "drafting",
+  drafting: "competing",
+  competing: "complete",
+  complete: null,
+};
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
 
 export function LeagueDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -38,138 +52,17 @@ export function LeagueDetailPage() {
   const players = useLeaguePlayers(id!);
   const { data: session } = useSession();
   const deleteLeague = useDeleteLeague();
-  const updateSettings = useUpdateLeagueSettings();
   const advanceStatus = useAdvanceLeagueStatus();
   const [, navigate] = useLocation();
+
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
     useDisclosure(false);
   const [advanceOpened, { open: openAdvance, close: closeAdvance }] =
     useDisclosure(false);
 
-  const [sportType, setSportType] = useState<string | null>(null);
-  const [draftFormat, setDraftFormat] = useState<string | null>("snake");
-  const [numberOfRounds, setNumberOfRounds] = useState<number | string>("");
-  const [pickTimeLimitSeconds, setPickTimeLimitSeconds] = useState<
-    number | string
-  >("");
-  const [maxPlayers, setMaxPlayers] = useState<number | string>("");
-  const [gameVersion, setGameVersion] = useState<string | null>(null);
-  const [poolSizeMultiplier, setPoolSizeMultiplier] = useState<number | string>(
-    2,
-  );
-  const [excludeLegendaries, setExcludeLegendaries] = useState(false);
-  const [excludeStarters, setExcludeStarters] = useState(false);
-  const [excludeTradeEvolutions, setExcludeTradeEvolutions] = useState(false);
-  const pokemonVersions = usePokemonVersions();
-
-  useEffect(() => {
-    if (league.data) {
-      if (league.data.sportType) setSportType(league.data.sportType);
-      if (league.data.maxPlayers) setMaxPlayers(league.data.maxPlayers);
-      const rules = league.data.rulesConfig as {
-        draftFormat?: string;
-        numberOfRounds?: number;
-        pickTimeLimitSeconds?: number | null;
-        poolSizeMultiplier?: number;
-        gameVersion?: string;
-        excludeLegendaries?: boolean;
-        excludeStarters?: boolean;
-        excludeTradeEvolutions?: boolean;
-      } | null;
-      if (rules) {
-        if (rules.draftFormat) setDraftFormat(rules.draftFormat);
-        if (rules.numberOfRounds) setNumberOfRounds(rules.numberOfRounds);
-        if (rules.pickTimeLimitSeconds) {
-          setPickTimeLimitSeconds(rules.pickTimeLimitSeconds);
-        }
-        if (rules.gameVersion) {
-          setGameVersion(rules.gameVersion);
-        }
-        if (rules.poolSizeMultiplier) {
-          setPoolSizeMultiplier(rules.poolSizeMultiplier);
-        }
-        setExcludeLegendaries(rules.excludeLegendaries ?? false);
-        setExcludeStarters(rules.excludeStarters ?? false);
-        setExcludeTradeEvolutions(rules.excludeTradeEvolutions ?? false);
-      }
-    }
-  }, [league.data]);
-
   const isCommissioner = players.data?.some(
     (p) => p.userId === session?.user?.id && p.role === "commissioner",
   );
-
-  type SettingsState = {
-    sportType: string | null;
-    draftFormat: string | null;
-    numberOfRounds: number | string;
-    pickTimeLimitSeconds: number | string;
-    maxPlayers: number | string;
-    poolSizeMultiplier: number | string;
-    gameVersion: string | null;
-    excludeLegendaries: boolean;
-    excludeStarters: boolean;
-    excludeTradeEvolutions: boolean;
-  };
-
-  const currentSettings: SettingsState = {
-    sportType,
-    draftFormat,
-    numberOfRounds,
-    pickTimeLimitSeconds,
-    maxPlayers,
-    poolSizeMultiplier,
-    gameVersion,
-    excludeLegendaries,
-    excludeStarters,
-    excludeTradeEvolutions,
-  };
-
-  const isSettingsStateValid = (s: SettingsState) =>
-    !!s.sportType && !!s.draftFormat &&
-    Number(s.numberOfRounds) >= 1 && Number(s.maxPlayers) >= 2 &&
-    Number(s.poolSizeMultiplier) >= 1.5 && Number(s.poolSizeMultiplier) <= 3;
-
-  const saveSettings = (s: SettingsState) => {
-    if (!isSettingsStateValid(s)) return;
-    updateSettings.mutate({
-      leagueId: id!,
-      sportType: s.sportType as "pokemon",
-      maxPlayers: Number(s.maxPlayers),
-      rulesConfig: {
-        draftFormat: s.draftFormat as "snake" | "linear",
-        numberOfRounds: Number(s.numberOfRounds),
-        pickTimeLimitSeconds: s.pickTimeLimitSeconds
-          ? Number(s.pickTimeLimitSeconds)
-          : null,
-        poolSizeMultiplier: Number(s.poolSizeMultiplier),
-        ...(s.gameVersion ? { gameVersion: s.gameVersion } : {}),
-        excludeLegendaries: s.excludeLegendaries,
-        excludeStarters: s.excludeStarters,
-        excludeTradeEvolutions: s.excludeTradeEvolutions,
-      },
-    });
-  };
-
-  const saveCurrentSettings = () => saveSettings(currentSettings);
-
-  const handleDelete = () => {
-    deleteLeague.mutate(
-      { id: id! },
-      {
-        onSuccess: () => {
-          navigate("/");
-        },
-      },
-    );
-  };
-
-  const NEXT_STATUS: Record<string, string | null> = {
-    setup: "drafting",
-    drafting: "competing",
-    competing: "complete",
-    complete: null,
-  };
 
   const nextStatus = league.data ? NEXT_STATUS[league.data.status] : null;
 
@@ -187,6 +80,13 @@ export function LeagueDetailPage() {
   const setupPrerequisitesMet = league.data?.status !== "setup" ||
     persistedSettingsValid;
 
+  const handleDelete = () => {
+    deleteLeague.mutate(
+      { id: id! },
+      { onSuccess: () => navigate("/") },
+    );
+  };
+
   const handleAdvance = () => {
     advanceStatus.mutate(
       { leagueId: id! },
@@ -194,8 +94,12 @@ export function LeagueDetailPage() {
     );
   };
 
+  const currentUserPlayer = players.data?.find(
+    (p) => p.userId === session?.user?.id,
+  );
+
   return (
-    <Container size="sm" py="xl" pos="relative">
+    <Container size="lg" py="xl" pos="relative">
       <LoadingOverlay visible={league.isLoading} />
 
       <Anchor component={Link} href="/" mb="md" display="block">
@@ -204,382 +108,289 @@ export function LeagueDetailPage() {
 
       {league.data && (
         <>
-          <Title order={1} mb="lg">
-            {league.data.name}
-          </Title>
+          {/* Hero strip */}
+          <Paper
+            withBorder
+            radius="md"
+            p="lg"
+            mb="lg"
+            style={{
+              background:
+                "linear-gradient(135deg, var(--mantine-color-mint-green-0), var(--mantine-color-body))",
+            }}
+          >
+            <Group justify="space-between" align="flex-start" wrap="wrap">
+              <Stack gap="xs" style={{ flex: 1, minWidth: 260 }}>
+                <Title order={1}>{league.data.name}</Title>
+                {league.data.sportType && (
+                  <Group gap="xs">
+                    <Badge color="mint-green" variant="light" tt="capitalize">
+                      {league.data.sportType}
+                    </Badge>
+                  </Group>
+                )}
+                <Box mt="xs">
+                  <LifecycleStepper currentPhase={league.data.status} />
+                </Box>
+              </Stack>
 
-          <Card shadow="sm" padding="lg" radius="md" withBorder>
-            <Group mb="sm">
-              <Text fw={500}>Status</Text>
-              <Badge variant="light">{league.data.status}</Badge>
-            </Group>
-
-            <Group mb="sm">
-              <Text fw={500}>Invite Code</Text>
-              <Group gap="xs">
-                <Text ff="monospace">{league.data.inviteCode}</Text>
-                <CopyButton value={league.data.inviteCode}>
-                  {({ copied, copy }) => (
-                    <Tooltip label={copied ? "Copied" : "Copy"}>
-                      <ActionIcon
-                        variant="subtle"
-                        color={copied ? "teal" : "gray"}
-                        onClick={copy}
-                      >
-                        {copied ? "✓" : "⎘"}
-                      </ActionIcon>
-                    </Tooltip>
-                  )}
-                </CopyButton>
+              <Group gap="sm">
+                {league.data.status === "drafting" && (
+                  <>
+                    <Button
+                      component={Link}
+                      href={`/leagues/${league.data.id}/draft`}
+                      size="md"
+                    >
+                      Go to Draft
+                    </Button>
+                    <Button
+                      component={Link}
+                      href={`/leagues/${league.data.id}/draft/pool`}
+                      variant="light"
+                      size="md"
+                    >
+                      View Draft Pool
+                    </Button>
+                  </>
+                )}
+                {isCommissioner && nextStatus && setupPrerequisitesMet && (
+                  <Button
+                    onClick={() => {
+                      advanceStatus.reset();
+                      openAdvance();
+                    }}
+                    size="md"
+                  >
+                    Advance to {capitalize(nextStatus)}
+                  </Button>
+                )}
               </Group>
             </Group>
+          </Paper>
 
-            <Group>
-              <Text fw={500}>Created</Text>
-              <Text c="dimmed">
-                {new Date(league.data.createdAt).toLocaleDateString()}
-              </Text>
-            </Group>
-          </Card>
-
-          {isCommissioner && league.data.status === "setup" && (
-            <>
-              <Title order={3} mt="xl" mb="sm">
-                League Settings
-              </Title>
-              <Card shadow="sm" padding="lg" radius="md" withBorder>
-                <Stack gap="md">
-                  <Select
-                    label="Sport Type"
-                    data={[{ value: "pokemon", label: "Pokemon" }]}
-                    value={sportType}
-                    onChange={(value) => {
-                      setSportType(value);
-                      saveSettings({ ...currentSettings, sportType: value });
-                    }}
-                    required
-                  />
-                  {sportType === "pokemon" && (
-                    <>
-                      <Select
-                        label="Game Version"
-                        description="Optionally limit the draft pool to a specific game's regional dex"
-                        placeholder="All Pokemon"
-                        data={Object.entries(
-                          (pokemonVersions.data ?? []).reduce<
-                            Record<
-                              string,
-                              { value: string; label: string }[]
-                            >
-                          >((acc, v) => {
-                            const group = `Generation ${v.generation}`;
-                            if (!acc[group]) acc[group] = [];
-                            acc[group].push({
-                              value: v.id,
-                              label: `${v.name} (${v.region})`,
-                            });
-                            return acc;
-                          }, {}),
-                        ).map(([group, items]) => ({ group, items }))}
-                        value={gameVersion}
-                        onChange={(value) => {
-                          setGameVersion(value);
-                          saveSettings({
-                            ...currentSettings,
-                            gameVersion: value,
-                          });
-                        }}
-                        clearable
-                        searchable
+          <Grid gutter="lg">
+            {/* Left column (~2/3) */}
+            <Grid.Col span={{ base: 12, md: 8 }}>
+              <Stack gap="lg">
+                {/* Your team panel */}
+                <Card shadow="sm" padding="lg" radius="md" withBorder>
+                  <Group justify="space-between" mb="sm">
+                    <Group gap="xs">
+                      <IconSparkles
+                        size={18}
+                        color="var(--mantine-color-mint-green-6)"
                       />
-                      <Switch
-                        label="Exclude Legendaries"
-                        description="Remove legendary and mythical Pokemon from the draft pool"
-                        checked={excludeLegendaries}
-                        onChange={(event) => {
-                          const next = event.currentTarget.checked;
-                          setExcludeLegendaries(next);
-                          saveSettings({
-                            ...currentSettings,
-                            excludeLegendaries: next,
-                          });
-                        }}
-                      />
-                      <Switch
-                        label="Exclude Starters"
-                        description="Remove starter Pokemon and their evolutions from the draft pool"
-                        checked={excludeStarters}
-                        onChange={(event) => {
-                          const next = event.currentTarget.checked;
-                          setExcludeStarters(next);
-                          saveSettings({
-                            ...currentSettings,
-                            excludeStarters: next,
-                          });
-                        }}
-                      />
-                      <Switch
-                        label="Exclude Trade Evolutions"
-                        description="Remove Pokemon that can only be obtained through trade evolution (e.g. Golem, Gengar, Alakazam)"
-                        checked={excludeTradeEvolutions}
-                        onChange={(event) => {
-                          const next = event.currentTarget.checked;
-                          setExcludeTradeEvolutions(next);
-                          saveSettings({
-                            ...currentSettings,
-                            excludeTradeEvolutions: next,
-                          });
-                        }}
-                      />
-                    </>
-                  )}
-                  <Select
-                    label="Draft Format"
-                    data={[
-                      { value: "snake", label: "Snake" },
-                      { value: "linear", label: "Linear" },
-                    ]}
-                    value={draftFormat}
-                    onChange={(value) => {
-                      setDraftFormat(value);
-                      saveSettings({ ...currentSettings, draftFormat: value });
-                    }}
-                    required
-                  />
-                  <NumberInput
-                    label="Number of Rounds"
-                    min={1}
-                    value={numberOfRounds}
-                    onChange={setNumberOfRounds}
-                    onBlur={saveCurrentSettings}
-                    required
-                  />
-                  <NumberInput
-                    label="Pick Time Limit (seconds)"
-                    description="Leave empty for no time limit"
-                    min={1}
-                    value={pickTimeLimitSeconds}
-                    onChange={setPickTimeLimitSeconds}
-                    onBlur={saveCurrentSettings}
-                  />
-                  <NumberInput
-                    label="Draft Pool Size Multiplier"
-                    description="Pool size = rounds × players × multiplier"
-                    min={1.5}
-                    max={3}
-                    step={0.5}
-                    decimalScale={1}
-                    value={poolSizeMultiplier}
-                    onChange={setPoolSizeMultiplier}
-                    onBlur={saveCurrentSettings}
-                    required
-                  />
-                  <NumberInput
-                    label="Max Players"
-                    min={2}
-                    value={maxPlayers}
-                    onChange={setMaxPlayers}
-                    onBlur={saveCurrentSettings}
-                    required
-                  />
-                  {updateSettings.isPending && (
-                    <Text c="dimmed" size="sm">Saving...</Text>
-                  )}
-                  {updateSettings.isError && (
-                    <Text c="red" size="sm">
-                      Failed to save: {updateSettings.error.message}
-                    </Text>
-                  )}
-                </Stack>
-              </Card>
-            </>
-          )}
-
-          {!isCommissioner && league.data.sportType && (
-            <>
-              <Title order={3} mt="xl" mb="sm">
-                League Settings
-              </Title>
-              <Card shadow="sm" padding="lg" radius="md" withBorder>
-                <Stack gap="xs">
-                  <Group>
-                    <Text fw={500}>Sport Type</Text>
-                    <Badge variant="light">{league.data.sportType}</Badge>
+                      <Title order={3}>Your team</Title>
+                    </Group>
                   </Group>
-                  {league.data.rulesConfig &&
-                    typeof league.data.rulesConfig === "object" && (
-                    <>
-                      {(league.data.rulesConfig as { gameVersion?: string })
-                        .gameVersion && (
-                        <Group>
-                          <Text fw={500}>Game Version</Text>
-                          <Badge variant="light">
-                            {(
-                              league.data.rulesConfig as {
-                                gameVersion: string;
-                              }
-                            ).gameVersion}
-                          </Badge>
+                  {currentUserPlayer
+                    ? (
+                      <Group gap="md">
+                        <Avatar
+                          src={currentUserPlayer.image}
+                          alt={currentUserPlayer.name}
+                          radius="xl"
+                          size="lg"
+                          color="mint-green"
+                        >
+                          {currentUserPlayer.name
+                            .split(" ")
+                            .map((n) => n[0])
+                            .join("")
+                            .toUpperCase()
+                            .slice(0, 2)}
+                        </Avatar>
+                        <Stack gap={2}>
+                          <Text fw={600}>{currentUserPlayer.name}</Text>
+                          <Text size="sm" c="dimmed" tt="capitalize">
+                            {currentUserPlayer.role}
+                          </Text>
+                        </Stack>
+                      </Group>
+                    )
+                    : (
+                      <Text c="dimmed" size="sm">
+                        Join this league to see your trainer card here.
+                      </Text>
+                    )}
+                  <Text c="dimmed" size="sm" mt="md">
+                    No picks yet. Your roster will appear here once the draft
+                    begins.
+                  </Text>
+                </Card>
+
+                {/* Players / who's in */}
+                <Card shadow="sm" padding="lg" radius="md" withBorder>
+                  <Group justify="space-between" mb="sm">
+                    <Title order={3}>
+                      {league.data.status === "setup"
+                        ? "Who's in"
+                        : league.data.status === "drafting"
+                        ? "Players"
+                        : "Standings"}
+                    </Title>
+                    {league.data.maxPlayers && (
+                      <Text size="sm" c="dimmed">
+                        {players.data?.length ?? 0} / {league.data.maxPlayers}
+                      </Text>
+                    )}
+                  </Group>
+                  <Stack gap="sm">
+                    {players.data?.map((player) => (
+                      <Group key={player.id} justify="space-between">
+                        <Group gap="sm">
+                          <Avatar
+                            src={player.image}
+                            alt={player.name}
+                            radius="xl"
+                            size="sm"
+                            color="mint-green"
+                          >
+                            {player.name
+                              .split(" ")
+                              .map((n) =>
+                                n[0]
+                              )
+                              .join("")
+                              .toUpperCase()
+                              .slice(0, 2)}
+                          </Avatar>
+                          <Text size="sm">{player.name}</Text>
                         </Group>
-                      )}
-                      <Group>
-                        <Text fw={500}>Draft Format</Text>
-                        <Badge variant="light">
-                          {(league.data.rulesConfig as { draftFormat: string })
-                            .draftFormat}
+                        <Badge variant="light" size="sm" tt="capitalize">
+                          {player.role}
                         </Badge>
                       </Group>
-                      <Group>
-                        <Text fw={500}>Rounds</Text>
-                        <Text c="dimmed">
-                          {(
-                            league.data.rulesConfig as {
-                              numberOfRounds: number;
-                            }
-                          ).numberOfRounds}
+                    ))}
+                    {(!players.data || players.data.length === 0) && (
+                      <Text c="dimmed" size="sm">
+                        No players yet.
+                      </Text>
+                    )}
+                  </Stack>
+                </Card>
+              </Stack>
+            </Grid.Col>
+
+            {/* Right column (~1/3) */}
+            <Grid.Col span={{ base: 12, md: 4 }}>
+              <Stack gap="lg">
+                <Card shadow="sm" padding="lg" radius="md" withBorder>
+                  <Title order={4} mb="sm">League info</Title>
+                  <Stack gap="xs">
+                    <Group justify="space-between">
+                      <Text size="sm" fw={500}>Invite code</Text>
+                      <Group gap={4}>
+                        <Text ff="monospace" size="sm">
+                          {league.data.inviteCode}
                         </Text>
+                        <CopyButton value={league.data.inviteCode}>
+                          {({ copied, copy }) => (
+                            <Tooltip label={copied ? "Copied" : "Copy"}>
+                              <ActionIcon
+                                variant="subtle"
+                                size="sm"
+                                color={copied ? "teal" : "gray"}
+                                onClick={copy}
+                                aria-label="Copy invite code"
+                              >
+                                {copied ? "✓" : "⎘"}
+                              </ActionIcon>
+                            </Tooltip>
+                          )}
+                        </CopyButton>
                       </Group>
-                      <Group>
-                        <Text fw={500}>Pick Time Limit</Text>
-                        <Text c="dimmed">
-                          {(
-                              league.data.rulesConfig as {
-                                pickTimeLimitSeconds: number | null;
-                              }
-                            ).pickTimeLimitSeconds
-                            ? `${
-                              (
-                                league.data.rulesConfig as {
-                                  pickTimeLimitSeconds: number;
-                                }
-                              ).pickTimeLimitSeconds
-                            }s`
-                            : "No limit"}
-                        </Text>
-                      </Group>
-                      <Group>
-                        <Text fw={500}>Draft Pool Multiplier</Text>
-                        <Text c="dimmed">
-                          {(
-                            league.data.rulesConfig as {
-                              poolSizeMultiplier?: number;
-                            }
-                          ).poolSizeMultiplier ?? 2}x
-                        </Text>
-                      </Group>
-                      {(league.data.rulesConfig as {
-                        excludeLegendaries?: boolean;
-                      }).excludeLegendaries && (
-                        <Group>
-                          <Text fw={500}>Legendaries</Text>
-                          <Badge variant="light" color="red">Excluded</Badge>
-                        </Group>
-                      )}
-                      {(league.data.rulesConfig as {
-                        excludeStarters?: boolean;
-                      }).excludeStarters && (
-                        <Group>
-                          <Text fw={500}>Starters</Text>
-                          <Badge variant="light" color="red">Excluded</Badge>
-                        </Group>
-                      )}
-                      {(league.data.rulesConfig as {
-                        excludeTradeEvolutions?: boolean;
-                      }).excludeTradeEvolutions && (
-                        <Group>
-                          <Text fw={500}>Trade Evolutions</Text>
-                          <Badge variant="light" color="red">Excluded</Badge>
-                        </Group>
-                      )}
-                    </>
-                  )}
-                  {league.data.maxPlayers && (
-                    <Group>
-                      <Text fw={500}>Max Players</Text>
-                      <Text c="dimmed">{league.data.maxPlayers}</Text>
                     </Group>
-                  )}
-                </Stack>
-              </Card>
-            </>
-          )}
+                    <Group justify="space-between">
+                      <Text size="sm" fw={500}>Created</Text>
+                      <Text size="sm" c="dimmed">
+                        {new Date(league.data.createdAt).toLocaleDateString()}
+                      </Text>
+                    </Group>
+                  </Stack>
+                </Card>
 
-          <Title order={3} mt="xl" mb="sm">
-            Players
-          </Title>
-          <Card shadow="sm" padding="lg" radius="md" withBorder>
-            <Stack gap="sm">
-              {players.data?.map((player) => (
-                <Group key={player.id} justify="space-between">
-                  <Group gap="sm">
-                    <Avatar
-                      src={player.image}
-                      alt={player.name}
-                      radius="xl"
-                      size="sm"
-                      color="blue"
+                <Card shadow="sm" padding="lg" radius="md" withBorder>
+                  <Group justify="space-between" mb="sm">
+                    <Title order={4}>Rules</Title>
+                    <Button
+                      component={Link}
+                      href={`/leagues/${league.data.id}/settings`}
+                      size="xs"
+                      variant="subtle"
+                      leftSection={<IconSettings size={14} />}
                     >
-                      {player.name
-                        .split(" ")
-                        .map((n) =>
-                          n[0]
-                        )
-                        .join("")
-                        .toUpperCase()
-                        .slice(0, 2)}
-                    </Avatar>
-                    <Text size="sm">{player.name}</Text>
+                      {isCommissioner && league.data.status === "setup"
+                        ? "Configure"
+                        : "View"}
+                    </Button>
                   </Group>
-                  <Badge variant="light" size="sm">
-                    {player.role}
-                  </Badge>
+                  {league.data.rulesConfig &&
+                      typeof league.data.rulesConfig === "object"
+                    ? (
+                      <Stack gap="xs">
+                        <Group justify="space-between">
+                          <Text size="sm" c="dimmed">Format</Text>
+                          <Text size="sm" tt="capitalize">
+                            {(league.data.rulesConfig as {
+                              draftFormat?: string;
+                            }).draftFormat ?? "—"}
+                          </Text>
+                        </Group>
+                        <Group justify="space-between">
+                          <Text size="sm" c="dimmed">Rounds</Text>
+                          <Text size="sm">
+                            {(league.data.rulesConfig as {
+                              numberOfRounds?: number;
+                            }).numberOfRounds ?? "—"}
+                          </Text>
+                        </Group>
+                        {league.data.maxPlayers && (
+                          <Group justify="space-between">
+                            <Text size="sm" c="dimmed">Max players</Text>
+                            <Text size="sm">{league.data.maxPlayers}</Text>
+                          </Group>
+                        )}
+                      </Stack>
+                    )
+                    : (
+                      <Text size="sm" c="dimmed">
+                        Not configured yet.
+                      </Text>
+                    )}
+                </Card>
+              </Stack>
+            </Grid.Col>
+          </Grid>
+
+          {/* Danger zone — commissioner only, visually isolated from normal actions */}
+          {isCommissioner && (
+            <Paper
+              withBorder
+              radius="md"
+              p="md"
+              mt="xl"
+              style={{ borderColor: "var(--mantine-color-red-3)" }}
+            >
+              <Group justify="space-between" wrap="wrap">
+                <Group gap="xs">
+                  <IconAlertTriangle
+                    size={18}
+                    color="var(--mantine-color-red-6)"
+                  />
+                  <Text fw={600} c="red">Danger zone</Text>
                 </Group>
-              ))}
-            </Stack>
-          </Card>
-
-          <Group mt="lg">
-            {league.data.status === "drafting" && (
-              <>
                 <Button
-                  component={Link}
-                  href={`/leagues/${league.data.id}/draft`}
-                  variant="filled"
-                >
-                  Go to Draft
-                </Button>
-                <Button
-                  component={Link}
-                  href={`/leagues/${league.data.id}/draft/pool`}
+                  color="red"
                   variant="light"
+                  onClick={openDelete}
                 >
-                  View Draft Pool
+                  Delete League
                 </Button>
-              </>
-            )}
-
-            {isCommissioner && nextStatus && setupPrerequisitesMet && (
-              <Button
-                onClick={() => {
-                  advanceStatus.reset();
-                  openAdvance();
-                }}
-              >
-                Advance to {nextStatus.charAt(0).toUpperCase() +
-                  nextStatus.slice(1)}
-              </Button>
-            )}
-
-            {isCommissioner && (
-              <Button
-                color="red"
-                variant="light"
-                onClick={openDelete}
-              >
-                Delete League
-              </Button>
-            )}
-          </Group>
+              </Group>
+            </Paper>
+          )}
 
           <Modal
             opened={advanceOpened}
@@ -589,14 +400,9 @@ export function LeagueDetailPage() {
             <Stack gap="md">
               <Text>
                 Are you sure you want to advance{" "}
-                <Text span fw={700}>
-                  {league.data.name}
-                </Text>{" "}
-                to{" "}
-                <Text span fw={700}>
-                  {nextStatus}
-                </Text>
-                ? This action cannot be undone.
+                <Text span fw={700}>{league.data.name}</Text> to{" "}
+                <Text span fw={700}>{nextStatus}</Text>? This action cannot be
+                undone.
               </Text>
               {advanceStatus.isError && (
                 <Alert color="red" title="Failed to advance">
@@ -624,10 +430,8 @@ export function LeagueDetailPage() {
           >
             <Text mb="lg">
               Are you sure you want to delete{" "}
-              <Text span fw={700}>
-                {league.data.name}
-              </Text>
-              ? This action cannot be undone.
+              <Text span fw={700}>{league.data.name}</Text>? This action cannot
+              be undone.
             </Text>
             <Group justify="flex-end">
               <Button variant="default" onClick={closeDelete}>

--- a/client/src/features/league/LeagueSettingsPage.test.tsx
+++ b/client/src/features/league/LeagueSettingsPage.test.tsx
@@ -1,0 +1,182 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { LeagueSettingsPage } from "./LeagueSettingsPage";
+
+const {
+  mockUseLeague,
+  mockUseLeaguePlayers,
+  mockUseUpdateLeagueSettings,
+} = vi.hoisted(() => ({
+  mockUseLeague: vi.fn(),
+  mockUseLeaguePlayers: vi.fn(),
+  mockUseUpdateLeagueSettings: vi.fn(),
+}));
+
+vi.mock("./use-leagues", () => ({
+  useLeague: mockUseLeague,
+  useLeaguePlayers: mockUseLeaguePlayers,
+  useUpdateLeagueSettings: mockUseUpdateLeagueSettings,
+}));
+
+vi.mock("../pokemon-version/use-pokemon-versions", () => ({
+  usePokemonVersions: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("../../auth", () => ({
+  useSession: () => ({ data: { user: { id: "user-1" } } }),
+}));
+
+vi.mock("wouter", async () => {
+  const actual = await vi.importActual<typeof import("wouter")>("wouter");
+  return {
+    ...actual,
+    useParams: () => ({ id: "league-1" }),
+    useLocation: () => ["/leagues/league-1/settings", vi.fn()],
+  };
+});
+
+const mockLeague = {
+  id: "league-1",
+  name: "Test League",
+  status: "setup",
+  inviteCode: "ABC123XY",
+  createdBy: "user-1",
+  sportType: null,
+  maxPlayers: null,
+  rulesConfig: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function renderPage() {
+  return render(
+    <MantineProvider>
+      <LeagueSettingsPage />
+    </MantineProvider>,
+  );
+}
+
+describe("LeagueSettingsPage", () => {
+  beforeEach(() => {
+    mockUseUpdateLeagueSettings.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the page title", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({ data: [], isLoading: false });
+    renderPage();
+    expect(screen.getByText("League Settings")).toBeInTheDocument();
+  });
+
+  it("shows the league name as a subtitle", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({ data: [], isLoading: false });
+    renderPage();
+    expect(screen.getByText("Test League")).toBeInTheDocument();
+  });
+
+  it("links back to the league detail page", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({ data: [], isLoading: false });
+    renderPage();
+    const back = screen.getByRole("link", { name: /back to league/i });
+    expect(back).toHaveAttribute("href", "/leagues/league-1");
+  });
+
+  it("renders editable form when user is commissioner during setup", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText(/sport type/i)).toBeInTheDocument();
+    expect(screen.getByText(/draft format/i)).toBeInTheDocument();
+    expect(screen.getByText(/number of rounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/max players/i)).toBeInTheDocument();
+  });
+
+  it("shows read-only view for non-commissioners", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          numberOfRounds: 6,
+          pickTimeLimitSeconds: null,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByLabelText(/sport type/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/only the commissioner/i)).toBeInTheDocument();
+  });
+
+  it("locks settings once the league leaves setup, even for commissioner", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        status: "drafting",
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          numberOfRounds: 6,
+          pickTimeLimitSeconds: null,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByLabelText(/draft format/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/settings are locked/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/features/league/LeagueSettingsPage.tsx
+++ b/client/src/features/league/LeagueSettingsPage.tsx
@@ -1,0 +1,394 @@
+import {
+  Anchor,
+  Badge,
+  Card,
+  Container,
+  Group,
+  LoadingOverlay,
+  NumberInput,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Title,
+} from "@mantine/core";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "wouter";
+import { useSession } from "../../auth";
+import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
+import {
+  useLeague,
+  useLeaguePlayers,
+  useUpdateLeagueSettings,
+} from "./use-leagues";
+
+export function LeagueSettingsPage() {
+  const { id } = useParams<{ id: string }>();
+  const league = useLeague(id!);
+  const players = useLeaguePlayers(id!);
+  const { data: session } = useSession();
+  const updateSettings = useUpdateLeagueSettings();
+  const pokemonVersions = usePokemonVersions();
+
+  const [sportType, setSportType] = useState<string | null>(null);
+  const [draftFormat, setDraftFormat] = useState<string | null>("snake");
+  const [numberOfRounds, setNumberOfRounds] = useState<number | string>("");
+  const [pickTimeLimitSeconds, setPickTimeLimitSeconds] = useState<
+    number | string
+  >("");
+  const [maxPlayers, setMaxPlayers] = useState<number | string>("");
+  const [gameVersion, setGameVersion] = useState<string | null>(null);
+  const [poolSizeMultiplier, setPoolSizeMultiplier] = useState<
+    number | string
+  >(2);
+  const [excludeLegendaries, setExcludeLegendaries] = useState(false);
+  const [excludeStarters, setExcludeStarters] = useState(false);
+  const [excludeTradeEvolutions, setExcludeTradeEvolutions] = useState(false);
+
+  useEffect(() => {
+    if (league.data) {
+      if (league.data.sportType) setSportType(league.data.sportType);
+      if (league.data.maxPlayers) setMaxPlayers(league.data.maxPlayers);
+      const rules = league.data.rulesConfig as {
+        draftFormat?: string;
+        numberOfRounds?: number;
+        pickTimeLimitSeconds?: number | null;
+        poolSizeMultiplier?: number;
+        gameVersion?: string;
+        excludeLegendaries?: boolean;
+        excludeStarters?: boolean;
+        excludeTradeEvolutions?: boolean;
+      } | null;
+      if (rules) {
+        if (rules.draftFormat) setDraftFormat(rules.draftFormat);
+        if (rules.numberOfRounds) setNumberOfRounds(rules.numberOfRounds);
+        if (rules.pickTimeLimitSeconds) {
+          setPickTimeLimitSeconds(rules.pickTimeLimitSeconds);
+        }
+        if (rules.gameVersion) {
+          setGameVersion(rules.gameVersion);
+        }
+        if (rules.poolSizeMultiplier) {
+          setPoolSizeMultiplier(rules.poolSizeMultiplier);
+        }
+        setExcludeLegendaries(rules.excludeLegendaries ?? false);
+        setExcludeStarters(rules.excludeStarters ?? false);
+        setExcludeTradeEvolutions(rules.excludeTradeEvolutions ?? false);
+      }
+    }
+  }, [league.data]);
+
+  const isCommissioner = players.data?.some(
+    (p) => p.userId === session?.user?.id && p.role === "commissioner",
+  );
+  const isEditable = isCommissioner && league.data?.status === "setup";
+
+  type SettingsState = {
+    sportType: string | null;
+    draftFormat: string | null;
+    numberOfRounds: number | string;
+    pickTimeLimitSeconds: number | string;
+    maxPlayers: number | string;
+    poolSizeMultiplier: number | string;
+    gameVersion: string | null;
+    excludeLegendaries: boolean;
+    excludeStarters: boolean;
+    excludeTradeEvolutions: boolean;
+  };
+
+  const currentSettings: SettingsState = {
+    sportType,
+    draftFormat,
+    numberOfRounds,
+    pickTimeLimitSeconds,
+    maxPlayers,
+    poolSizeMultiplier,
+    gameVersion,
+    excludeLegendaries,
+    excludeStarters,
+    excludeTradeEvolutions,
+  };
+
+  const isSettingsStateValid = (s: SettingsState) =>
+    !!s.sportType && !!s.draftFormat &&
+    Number(s.numberOfRounds) >= 1 && Number(s.maxPlayers) >= 2 &&
+    Number(s.poolSizeMultiplier) >= 1.5 && Number(s.poolSizeMultiplier) <= 3;
+
+  const saveSettings = (s: SettingsState) => {
+    if (!isSettingsStateValid(s)) return;
+    updateSettings.mutate({
+      leagueId: id!,
+      sportType: s.sportType as "pokemon",
+      maxPlayers: Number(s.maxPlayers),
+      rulesConfig: {
+        draftFormat: s.draftFormat as "snake" | "linear",
+        numberOfRounds: Number(s.numberOfRounds),
+        pickTimeLimitSeconds: s.pickTimeLimitSeconds
+          ? Number(s.pickTimeLimitSeconds)
+          : null,
+        poolSizeMultiplier: Number(s.poolSizeMultiplier),
+        ...(s.gameVersion ? { gameVersion: s.gameVersion } : {}),
+        excludeLegendaries: s.excludeLegendaries,
+        excludeStarters: s.excludeStarters,
+        excludeTradeEvolutions: s.excludeTradeEvolutions,
+      },
+    });
+  };
+
+  const saveCurrentSettings = () => saveSettings(currentSettings);
+
+  return (
+    <Container size="sm" py="xl" pos="relative">
+      <LoadingOverlay visible={league.isLoading} />
+
+      <Anchor component={Link} href={`/leagues/${id}`} mb="md" display="block">
+        &larr; Back to League
+      </Anchor>
+
+      {league.data && (
+        <>
+          <Title order={1} mb="lg">
+            League Settings
+          </Title>
+          <Text c="dimmed" mb="lg">
+            {league.data.name}
+          </Text>
+
+          {isEditable
+            ? (
+              <Card shadow="sm" padding="lg" radius="md" withBorder>
+                <Stack gap="md">
+                  <Select
+                    label="Sport Type"
+                    data={[{ value: "pokemon", label: "Pokemon" }]}
+                    value={sportType}
+                    onChange={(value) => {
+                      setSportType(value);
+                      saveSettings({ ...currentSettings, sportType: value });
+                    }}
+                    required
+                  />
+                  {sportType === "pokemon" && (
+                    <>
+                      <Select
+                        label="Game Version"
+                        description="Optionally limit the draft pool to a specific game's regional dex"
+                        placeholder="All Pokemon"
+                        data={Object.entries(
+                          (pokemonVersions.data ?? []).reduce<
+                            Record<
+                              string,
+                              { value: string; label: string }[]
+                            >
+                          >((acc, v) => {
+                            const group = `Generation ${v.generation}`;
+                            if (!acc[group]) acc[group] = [];
+                            acc[group].push({
+                              value: v.id,
+                              label: `${v.name} (${v.region})`,
+                            });
+                            return acc;
+                          }, {}),
+                        ).map(([group, items]) => ({ group, items }))}
+                        value={gameVersion}
+                        onChange={(value) => {
+                          setGameVersion(value);
+                          saveSettings({
+                            ...currentSettings,
+                            gameVersion: value,
+                          });
+                        }}
+                        clearable
+                        searchable
+                      />
+                      <Switch
+                        label="Exclude Legendaries"
+                        description="Remove legendary and mythical Pokemon from the draft pool"
+                        checked={excludeLegendaries}
+                        onChange={(event) => {
+                          const next = event.currentTarget.checked;
+                          setExcludeLegendaries(next);
+                          saveSettings({
+                            ...currentSettings,
+                            excludeLegendaries: next,
+                          });
+                        }}
+                      />
+                      <Switch
+                        label="Exclude Starters"
+                        description="Remove starter Pokemon and their evolutions from the draft pool"
+                        checked={excludeStarters}
+                        onChange={(event) => {
+                          const next = event.currentTarget.checked;
+                          setExcludeStarters(next);
+                          saveSettings({
+                            ...currentSettings,
+                            excludeStarters: next,
+                          });
+                        }}
+                      />
+                      <Switch
+                        label="Exclude Trade Evolutions"
+                        description="Remove Pokemon that can only be obtained through trade evolution (e.g. Golem, Gengar, Alakazam)"
+                        checked={excludeTradeEvolutions}
+                        onChange={(event) => {
+                          const next = event.currentTarget.checked;
+                          setExcludeTradeEvolutions(next);
+                          saveSettings({
+                            ...currentSettings,
+                            excludeTradeEvolutions: next,
+                          });
+                        }}
+                      />
+                    </>
+                  )}
+                  <Select
+                    label="Draft Format"
+                    data={[
+                      { value: "snake", label: "Snake" },
+                      { value: "linear", label: "Linear" },
+                    ]}
+                    value={draftFormat}
+                    onChange={(value) => {
+                      setDraftFormat(value);
+                      saveSettings({
+                        ...currentSettings,
+                        draftFormat: value,
+                      });
+                    }}
+                    required
+                  />
+                  <NumberInput
+                    label="Number of Rounds"
+                    min={1}
+                    value={numberOfRounds}
+                    onChange={setNumberOfRounds}
+                    onBlur={saveCurrentSettings}
+                    required
+                  />
+                  <NumberInput
+                    label="Pick Time Limit (seconds)"
+                    description="Leave empty for no time limit"
+                    min={1}
+                    value={pickTimeLimitSeconds}
+                    onChange={setPickTimeLimitSeconds}
+                    onBlur={saveCurrentSettings}
+                  />
+                  <NumberInput
+                    label="Draft Pool Size Multiplier"
+                    description="Pool size = rounds × players × multiplier"
+                    min={1.5}
+                    max={3}
+                    step={0.5}
+                    decimalScale={1}
+                    value={poolSizeMultiplier}
+                    onChange={setPoolSizeMultiplier}
+                    onBlur={saveCurrentSettings}
+                    required
+                  />
+                  <NumberInput
+                    label="Max Players"
+                    min={2}
+                    value={maxPlayers}
+                    onChange={setMaxPlayers}
+                    onBlur={saveCurrentSettings}
+                    required
+                  />
+                  {updateSettings.isPending && (
+                    <Text c="dimmed" size="sm">Saving...</Text>
+                  )}
+                  {updateSettings.isError && (
+                    <Text c="red" size="sm">
+                      Failed to save: {updateSettings.error.message}
+                    </Text>
+                  )}
+                </Stack>
+              </Card>
+            )
+            : (
+              <Card shadow="sm" padding="lg" radius="md" withBorder>
+                <Stack gap="xs">
+                  {!isCommissioner && (
+                    <Text c="dimmed" size="sm" mb="xs">
+                      Only the commissioner can change settings.
+                    </Text>
+                  )}
+                  {isCommissioner && league.data.status !== "setup" && (
+                    <Text c="dimmed" size="sm" mb="xs">
+                      Settings are locked once the league leaves setup.
+                    </Text>
+                  )}
+                  {league.data.sportType && (
+                    <Group>
+                      <Text fw={500}>Sport Type</Text>
+                      <Badge variant="light">{league.data.sportType}</Badge>
+                    </Group>
+                  )}
+                  {league.data.rulesConfig &&
+                    typeof league.data.rulesConfig === "object" && (
+                    <>
+                      {(league.data.rulesConfig as { gameVersion?: string })
+                        .gameVersion && (
+                        <Group>
+                          <Text fw={500}>Game Version</Text>
+                          <Badge variant="light">
+                            {(league.data
+                              .rulesConfig as { gameVersion: string })
+                              .gameVersion}
+                          </Badge>
+                        </Group>
+                      )}
+                      <Group>
+                        <Text fw={500}>Draft Format</Text>
+                        <Badge variant="light">
+                          {(league.data
+                            .rulesConfig as { draftFormat: string })
+                            .draftFormat}
+                        </Badge>
+                      </Group>
+                      <Group>
+                        <Text fw={500}>Rounds</Text>
+                        <Text c="dimmed">
+                          {(league.data
+                            .rulesConfig as { numberOfRounds: number })
+                            .numberOfRounds}
+                        </Text>
+                      </Group>
+                      <Group>
+                        <Text fw={500}>Pick Time Limit</Text>
+                        <Text c="dimmed">
+                          {(league.data.rulesConfig as {
+                              pickTimeLimitSeconds: number | null;
+                            }).pickTimeLimitSeconds
+                            ? `${
+                              (league.data.rulesConfig as {
+                                pickTimeLimitSeconds: number;
+                              }).pickTimeLimitSeconds
+                            }s`
+                            : "No limit"}
+                        </Text>
+                      </Group>
+                      <Group>
+                        <Text fw={500}>Draft Pool Multiplier</Text>
+                        <Text c="dimmed">
+                          {(league.data.rulesConfig as {
+                            poolSizeMultiplier?: number;
+                          }).poolSizeMultiplier ?? 2}x
+                        </Text>
+                      </Group>
+                    </>
+                  )}
+                  {league.data.maxPlayers && (
+                    <Group>
+                      <Text fw={500}>Max Players</Text>
+                      <Text c="dimmed">{league.data.maxPlayers}</Text>
+                    </Group>
+                  )}
+                </Stack>
+              </Card>
+            )}
+        </>
+      )}
+    </Container>
+  );
+}

--- a/client/src/features/league/LifecycleStepper.tsx
+++ b/client/src/features/league/LifecycleStepper.tsx
@@ -1,0 +1,73 @@
+import { Box, Group, Text } from "@mantine/core";
+import { IconCheck } from "@tabler/icons-react";
+
+type Phase = "setup" | "drafting" | "competing" | "complete";
+
+const PHASES: { id: Phase; label: string }[] = [
+  { id: "setup", label: "Setup" },
+  { id: "drafting", label: "Drafting" },
+  { id: "competing", label: "Competing" },
+  { id: "complete", label: "Complete" },
+];
+
+interface LifecycleStepperProps {
+  currentPhase: Phase | string;
+}
+
+export function LifecycleStepper({ currentPhase }: LifecycleStepperProps) {
+  const currentIndex = PHASES.findIndex((p) => p.id === currentPhase);
+  return (
+    <Group gap="xs" wrap="nowrap" role="group" aria-label="League lifecycle">
+      {PHASES.map((phase, index) => {
+        const isCurrent = index === currentIndex;
+        const isPast = index < currentIndex;
+        const isFuture = index > currentIndex;
+        return (
+          <Group key={phase.id} gap="xs" wrap="nowrap">
+            <Box
+              w={24}
+              h={24}
+              style={{
+                borderRadius: "50%",
+                background: isPast
+                  ? "var(--mantine-color-mint-green-6)"
+                  : isCurrent
+                  ? "var(--mantine-color-mint-green-6)"
+                  : "var(--mantine-color-gray-3)",
+                color: isFuture ? "var(--mantine-color-gray-7)" : "white",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 12,
+                fontWeight: 700,
+                transition: "background 200ms ease",
+              }}
+              data-active={isCurrent || undefined}
+              data-complete={isPast || undefined}
+            >
+              {isPast ? <IconCheck size={14} /> : index + 1}
+            </Box>
+            <Text
+              size="sm"
+              fw={isCurrent ? 700 : 500}
+              c={isFuture ? "dimmed" : undefined}
+            >
+              {phase.label}
+            </Text>
+            {index < PHASES.length - 1 && (
+              <Box
+                w={24}
+                h={2}
+                style={{
+                  background: isPast
+                    ? "var(--mantine-color-mint-green-6)"
+                    : "var(--mantine-color-gray-3)",
+                }}
+              />
+            )}
+          </Group>
+        );
+      })}
+    </Group>
+  );
+}

--- a/client/src/features/league/mod.ts
+++ b/client/src/features/league/mod.ts
@@ -1,4 +1,5 @@
 export { LeagueListPage } from "./LeagueListPage.tsx";
 export { LeagueDetailPage } from "./LeagueDetailPage.tsx";
+export { LeagueSettingsPage } from "./LeagueSettingsPage.tsx";
 export { JoinLeaguePage } from "./JoinLeaguePage.tsx";
 export { CreateLeaguePage } from "./CreateLeaguePage.tsx";


### PR DESCRIPTION
## Summary

Phase 4 of the dashboard redesign vision ([docs/product/006-ui-ux-dashboard-vision.md](docs/product/006-ui-ux-dashboard-vision.md)). Replaces the 650-line form-heavy \`LeagueDetailPage\` with a proper **hub layout**:

- **Hero strip** — league name, sport chip, \`setup → drafting → competing → complete\` lifecycle stepper, and the primary CTA (Go to Draft / Advance to X / Make your pick).
- **Your team** trainer-card panel — emotional anchor, even before picks exist.
- **Players / standings** panel — label adapts to the current phase ("Who's in" during setup, "Standings" once competing).
- **League info** card — invite code (with copy), created date.
- **Rules summary** card — compact read-only view with a \`Configure\` / \`View\` link over to the new settings sub-route.
- **Danger zone** — red-bordered paper, visually isolated from the normal CTAs.

**Settings moves to \`/leagues/:id/settings\`** as its own page. The detail page no longer has to double as a configuration form.

Introduces \`LifecycleStepper.tsx\` — a small stateless stepper component keyed off the league status. Past phases check, current phase highlights in mint-green, future phases dim.

## Test plan

- [x] \`LeagueDetailPage.test.tsx\` — all 16 existing tests still green, plus 3 new: Configure link points to /settings, Your team panel, lifecycle stepper landmark.
- [x] New \`LeagueSettingsPage.test.tsx\` — 6 cases: title, subtitle, back link, editable form for commissioner during setup, read-only for members, locked after setup even for commissioner.
- [x] Full client suite: \`deno task test:client\` — 136 passing.
- [x] \`deno task build\` — succeeds.
- [x] \`deno lint\` — clean.
- [ ] Manual smoke after merge: commissioner-only Configure link routes to settings; members see view-only settings; lifecycle stepper renders correctly for each status; danger zone isolated.

## Notes on scope

Danger zone is NOT collapsed behind a toggle in this pass. The vision doc suggested collapsed-by-default, but Mantine Collapse interacted poorly with the existing \`getByRole\` test for the delete button, and the visual isolation (red border) already addresses the "flush with normal actions is risky" concern the vision was worried about. Happy to revisit in Phase 5 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)