### PR TITLE
feat(home): add Home dashboard as the default landing route

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -32,11 +32,11 @@ afterEach(() => {
   cleanup();
 });
 
-test("renders My Leagues title on the landing page", () => {
+test("renders the Home dashboard welcome banner on the landing page", () => {
   mockUseLeagues.mockReturnValue({ data: [], isLoading: false });
   mockUseCreateLeague.mockReturnValue({ mutate: vi.fn(), isPending: false });
   mockUseJoinLeague.mockReturnValue({ mutate: vi.fn(), isPending: false });
 
   render(<App />);
-  expect(screen.getByText("My Leagues")).toBeInTheDocument();
+  expect(screen.getByText(/welcome back, test/i)).toBeInTheDocument();
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,7 @@ import { AppLayout } from "./components/AppLayout";
 import { LoginPage } from "./pages/LoginPage";
 import {
   CreateLeaguePage,
+  HomeDashboard,
   JoinLeaguePage,
   LeagueDetailPage,
   LeagueListPage,
@@ -88,10 +89,17 @@ export function App() {
                 </AppLayout>
               </AuthGuard>
             </Route>
-            <Route>
+            <Route path="/leagues">
               <AuthGuard>
                 <AppLayout>
                   <LeagueListPage />
+                </AppLayout>
+              </AuthGuard>
+            </Route>
+            <Route>
+              <AuthGuard>
+                <AppLayout>
+                  <HomeDashboard />
                 </AppLayout>
               </AuthGuard>
             </Route>

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -65,7 +65,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     ? NAVBAR_COLLAPSED_WIDTH
     : NAVBAR_EXPANDED_WIDTH;
 
-  const isLeaguesActive = location.startsWith("/leagues") || location === "/";
+  const isLeaguesActive = location.startsWith("/leagues");
   const leagueItems = leagues.data ?? [];
 
   return (
@@ -120,7 +120,7 @@ export function AppLayout({ children }: AppLayoutProps) {
                   <Tooltip label="Leagues" position="right">
                     <div>
                       <SidebarLink
-                        to="/"
+                        to="/leagues"
                         label="Leagues"
                         icon={<IconTrophy size={20} />}
                         active={isLeaguesActive}
@@ -151,7 +151,7 @@ export function AppLayout({ children }: AppLayoutProps) {
                     ))}
                     <NavLink
                       component={Link}
-                      href="/"
+                      href="/leagues"
                       label="Browse all"
                       c="dimmed"
                     />

--- a/client/src/features/league/CreateLeaguePage.tsx
+++ b/client/src/features/league/CreateLeaguePage.tsx
@@ -83,7 +83,7 @@ export function CreateLeaguePage() {
 
   return (
     <Container size="sm" py="xl">
-      <Anchor component={Link} href="/" mb="md" display="block">
+      <Anchor component={Link} href="/leagues" mb="md" display="block">
         &larr; Back to Leagues
       </Anchor>
 

--- a/client/src/features/league/HomeDashboard.test.tsx
+++ b/client/src/features/league/HomeDashboard.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { HomeDashboard } from "./HomeDashboard";
+
+const { mockUseLeagues, mockUseSession, mockUseJoinLeague } = vi.hoisted(
+  () => ({
+    mockUseLeagues: vi.fn(),
+    mockUseSession: vi.fn(),
+    mockUseJoinLeague: vi.fn(),
+  }),
+);
+
+vi.mock("./use-leagues", () => ({
+  useLeagues: mockUseLeagues,
+  useJoinLeague: mockUseJoinLeague,
+}));
+
+vi.mock("../../auth", () => ({
+  useSession: mockUseSession,
+}));
+
+function renderPage() {
+  return render(
+    <MantineProvider>
+      <HomeDashboard />
+    </MantineProvider>,
+  );
+}
+
+function setupMocks(
+  overrides: {
+    leagues?: Array<{
+      id: string;
+      name: string;
+      status: string;
+      playerCount?: number;
+      maxPlayers?: number | null;
+      userRole?: "commissioner" | "member";
+    }>;
+    isLoading?: boolean;
+  } = {},
+) {
+  mockUseSession.mockReturnValue({
+    data: { user: { id: "u1", name: "Ash Ketchum" } },
+    isPending: false,
+  });
+  mockUseLeagues.mockReturnValue({
+    data: overrides.leagues ?? [],
+    isLoading: overrides.isLoading ?? false,
+  });
+  mockUseJoinLeague.mockReturnValue({ mutate: vi.fn(), isPending: false });
+}
+
+describe("HomeDashboard", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("greets the user by name", () => {
+    setupMocks();
+    renderPage();
+    expect(screen.getByText(/welcome back, ash/i)).toBeInTheDocument();
+  });
+
+  it("prompts to create a league when the user has none", () => {
+    setupMocks({ leagues: [] });
+    renderPage();
+    const banner = screen.getByTestId("next-action-banner");
+    expect(within(banner).getByText(/start your first league/i))
+      .toBeInTheDocument();
+  });
+
+  it("highlights a drafting league as the next action", () => {
+    setupMocks({
+      leagues: [
+        {
+          id: "L1",
+          name: "Kanto Rumble",
+          status: "setup",
+          playerCount: 2,
+          maxPlayers: 8,
+          userRole: "commissioner",
+        },
+        {
+          id: "L2",
+          name: "Johto Classic",
+          status: "drafting",
+          playerCount: 6,
+          maxPlayers: 8,
+          userRole: "member",
+        },
+      ],
+    });
+    renderPage();
+    const banner = screen.getByTestId("next-action-banner");
+    expect(within(banner).getByText(/johto classic/i)).toBeInTheDocument();
+    expect(within(banner).getByRole("link", { name: /go to draft/i }))
+      .toHaveAttribute("href", "/leagues/L2/draft");
+  });
+
+  it("renders an active leagues strip with one card per league", () => {
+    setupMocks({
+      leagues: [
+        {
+          id: "L1",
+          name: "Kanto Rumble",
+          status: "setup",
+          playerCount: 2,
+          maxPlayers: 8,
+          userRole: "commissioner",
+        },
+        {
+          id: "L2",
+          name: "Johto Classic",
+          status: "drafting",
+          playerCount: 6,
+          maxPlayers: 8,
+          userRole: "member",
+        },
+      ],
+    });
+    renderPage();
+    const strip = screen.getByTestId("active-leagues-strip");
+    expect(within(strip).getByText("Kanto Rumble")).toBeInTheDocument();
+    expect(within(strip).getByText("Johto Classic")).toBeInTheDocument();
+  });
+
+  it("has quick actions for Create League and Join by invite", () => {
+    setupMocks();
+    renderPage();
+    expect(screen.getByRole("link", { name: /create league/i }))
+      .toHaveAttribute("href", "/leagues/new");
+    expect(screen.getByRole("button", { name: /join by invite code/i }))
+      .toBeInTheDocument();
+  });
+
+  it("has a link to browse all leagues", () => {
+    setupMocks();
+    renderPage();
+    expect(screen.getByRole("link", { name: /browse all leagues/i }))
+      .toHaveAttribute("href", "/leagues");
+  });
+});

--- a/client/src/features/league/HomeDashboard.tsx
+++ b/client/src/features/league/HomeDashboard.tsx
@@ -1,0 +1,250 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Container,
+  Grid,
+  Group,
+  Paper,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import {
+  IconCircleCheck,
+  IconPlus,
+  IconSparkles,
+  IconTicket,
+} from "@tabler/icons-react";
+import { useMemo } from "react";
+import { Link } from "wouter";
+import { useSession } from "../../auth";
+import { JoinLeagueModal } from "./JoinLeagueModal";
+import { useLeagues } from "./use-leagues";
+
+type LeagueRow = NonNullable<ReturnType<typeof useLeagues>["data"]>[number];
+
+interface NextAction {
+  title: string;
+  body: string;
+  ctaLabel: string;
+  ctaHref: string;
+}
+
+function computeNextAction(
+  leagues: LeagueRow[],
+  userName: string,
+): NextAction {
+  const drafting = leagues.find((l) => l.status === "drafting");
+  if (drafting) {
+    return {
+      title: `You're drafting in ${drafting.name}`,
+      body: "Jump in — every pick counts.",
+      ctaLabel: "Go to draft",
+      ctaHref: `/leagues/${drafting.id}/draft`,
+    };
+  }
+
+  const setup = leagues.find((l) => l.status === "setup");
+  if (setup) {
+    return {
+      title: `${setup.name} is still in setup`,
+      body:
+        "Finish configuring the league and advance to drafting when you're ready.",
+      ctaLabel: "Open league",
+      ctaHref: `/leagues/${setup.id}`,
+    };
+  }
+
+  const competing = leagues.find((l) => l.status === "competing");
+  if (competing) {
+    return {
+      title: `${competing.name} season in progress`,
+      body: "Check in on the standings.",
+      ctaLabel: "View league",
+      ctaHref: `/leagues/${competing.id}`,
+    };
+  }
+
+  return {
+    title: `Start your first league, ${userName.split(" ")[0]}`,
+    body:
+      "Gather your friends, pick a format, and get drafting. Your adventure starts here.",
+    ctaLabel: "Create a league",
+    ctaHref: "/leagues/new",
+  };
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  setup: "gray",
+  drafting: "mint-green",
+  competing: "blue",
+  complete: "grape",
+};
+
+export function HomeDashboard() {
+  const { data: session } = useSession();
+  const leagues = useLeagues();
+  const [joinOpened, joinHandlers] = useDisclosure(false);
+
+  const userName = session?.user?.name ?? "Trainer";
+  const data = useMemo(() => leagues.data ?? [], [leagues.data]);
+  const nextAction = useMemo(
+    () => computeNextAction(data, userName),
+    [data, userName],
+  );
+
+  return (
+    <Container size="lg" py="xl">
+      <Group justify="space-between" mb="lg">
+        <Title order={1}>Welcome back, {userName.split(" ")[0]}</Title>
+      </Group>
+
+      <Paper
+        data-testid="next-action-banner"
+        withBorder
+        radius="md"
+        p="lg"
+        mb="xl"
+        style={{
+          background:
+            "linear-gradient(135deg, var(--mantine-color-mint-green-0), var(--mantine-color-body))",
+        }}
+      >
+        <Group justify="space-between" wrap="wrap" align="center">
+          <Group gap="md" wrap="nowrap" align="flex-start">
+            <Box c="mint-green" mt={4}>
+              <IconSparkles size={28} />
+            </Box>
+            <Stack gap={2}>
+              <Text size="sm" c="dimmed" fw={500} tt="uppercase">
+                Next up
+              </Text>
+              <Title order={3}>{nextAction.title}</Title>
+              <Text c="dimmed">{nextAction.body}</Text>
+            </Stack>
+          </Group>
+          <Button
+            component={Link}
+            href={nextAction.ctaHref}
+            size="md"
+          >
+            {nextAction.ctaLabel}
+          </Button>
+        </Group>
+      </Paper>
+
+      <Group justify="space-between" mb="sm">
+        <Title order={3}>Your active leagues</Title>
+        <Button
+          component={Link}
+          href="/leagues"
+          variant="subtle"
+          size="xs"
+        >
+          Browse all leagues
+        </Button>
+      </Group>
+
+      {data.length === 0
+        ? (
+          <Paper withBorder radius="md" p="lg" mb="xl">
+            <Text c="dimmed" ta="center">
+              You haven't joined any leagues yet.
+            </Text>
+          </Paper>
+        )
+        : (
+          <ScrollArea type="auto" mb="xl" data-testid="active-leagues-strip">
+            <Group gap="md" wrap="nowrap" pb="sm">
+              {data.map((league) => (
+                <Card
+                  key={league.id}
+                  component={Link}
+                  href={`/leagues/${league.id}`}
+                  shadow="sm"
+                  padding="lg"
+                  radius="md"
+                  withBorder
+                  miw={260}
+                  style={{
+                    textDecoration: "none",
+                    color: "inherit",
+                    cursor: "pointer",
+                  }}
+                >
+                  <Stack gap="xs">
+                    <Group justify="space-between">
+                      <Text fw={600} truncate>{league.name}</Text>
+                      <Badge
+                        size="sm"
+                        variant="light"
+                        color={STATUS_COLOR[league.status] ?? "gray"}
+                        tt="capitalize"
+                      >
+                        {league.status}
+                      </Badge>
+                    </Group>
+                    <Text size="xs" c="dimmed" tt="capitalize">
+                      {league.userRole ?? "member"} ·{" "}
+                      {league.playerCount ?? 0}/{league.maxPlayers ?? "—"}{" "}
+                      players
+                    </Text>
+                  </Stack>
+                </Card>
+              ))}
+            </Group>
+          </ScrollArea>
+        )}
+
+      <Grid gutter="lg">
+        <Grid.Col span={{ base: 12, md: 7 }}>
+          <Card shadow="sm" padding="lg" radius="md" withBorder>
+            <Title order={4} mb="sm">Recent activity</Title>
+            <Stack gap="xs">
+              <Group gap="xs">
+                <IconCircleCheck
+                  size={16}
+                  color="var(--mantine-color-mint-green-6)"
+                />
+                <Text size="sm" c="dimmed">
+                  Activity feed will light up here once your leagues get
+                  rolling.
+                </Text>
+              </Group>
+            </Stack>
+          </Card>
+        </Grid.Col>
+
+        <Grid.Col span={{ base: 12, md: 5 }}>
+          <Card shadow="sm" padding="lg" radius="md" withBorder>
+            <Title order={4} mb="sm">Quick actions</Title>
+            <Stack gap="sm">
+              <Button
+                component={Link}
+                href="/leagues/new"
+                leftSection={<IconPlus size={16} />}
+                fullWidth
+              >
+                Create League
+              </Button>
+              <Button
+                variant="outline"
+                leftSection={<IconTicket size={16} />}
+                onClick={joinHandlers.open}
+                fullWidth
+              >
+                Join by invite code
+              </Button>
+            </Stack>
+          </Card>
+        </Grid.Col>
+      </Grid>
+
+      <JoinLeagueModal opened={joinOpened} onClose={joinHandlers.close} />
+    </Container>
+  );
+}

--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -111,7 +111,7 @@ describe("LeagueDetailPage", () => {
     renderPage();
     const backLink = screen.getByRole("link", { name: /back to leagues/i });
     expect(backLink).toBeInTheDocument();
-    expect(backLink).toHaveAttribute("href", "/");
+    expect(backLink).toHaveAttribute("href", "/leagues");
   });
 
   it("calls useLeague with the id from route params", () => {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -83,7 +83,7 @@ export function LeagueDetailPage() {
   const handleDelete = () => {
     deleteLeague.mutate(
       { id: id! },
-      { onSuccess: () => navigate("/") },
+      { onSuccess: () => navigate("/leagues") },
     );
   };
 
@@ -102,7 +102,7 @@ export function LeagueDetailPage() {
     <Container size="lg" py="xl" pos="relative">
       <LoadingOverlay visible={league.isLoading} />
 
-      <Anchor component={Link} href="/" mb="md" display="block">
+      <Anchor component={Link} href="/leagues" mb="md" display="block">
         &larr; Back to Leagues
       </Anchor>
 

--- a/client/src/features/league/mod.ts
+++ b/client/src/features/league/mod.ts
@@ -1,3 +1,4 @@
+export { HomeDashboard } from "./HomeDashboard.tsx";
 export { LeagueListPage } from "./LeagueListPage.tsx";
 export { LeagueDetailPage } from "./LeagueDetailPage.tsx";
 export { LeagueSettingsPage } from "./LeagueSettingsPage.tsx";


### PR DESCRIPTION
## Summary

Phase 3 of the dashboard redesign vision ([docs/product/006-ui-ux-dashboard-vision.md](docs/product/006-ui-ux-dashboard-vision.md)).

- New \`HomeDashboard\` component at \`/\`. Leagues table moves to \`/leagues\`.
- **Next up** banner picks the single highest-priority CTA across the user's leagues (drafting > setup > competing > "create one"). 
- **Active leagues strip** — horizontal mini-cards, tap through to the league hub.
- **Quick actions** — Create League + Join by invite code.
- Activity feed is a placeholder card for now — real activity plumbing is a later pass.
- Sidebar "Browse all" and in-page back links now point at \`/leagues\` instead of \`/\`. Delete-league redirects to \`/leagues\` so the user sees that it's actually gone.

## Test plan

- [x] New \`HomeDashboard.test.tsx\` — 6 cases: greets user, prompts create-league when empty, highlights drafting as next action with correct href, renders leagues strip, quick actions, browse-all link.
- [x] \`App.test.tsx\` updated to assert the Home welcome banner on \`/\` instead of "My Leagues".
- [x] \`LeagueDetailPage.test.tsx\` back-link assertion updated to \`/leagues\`.
- [x] Full client suite: \`deno task test:client\` — 154 passing.
- [x] \`deno task build\` — succeeds.
- [x] \`deno lint\` — clean.
- [ ] Manual after merge: \`/\` renders the home banner, \`/leagues\` renders the table, sidebar's Browse-all resolves correctly, back-from-detail lands on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)