### PR TITLE
feat(polish): trainer card and lifecycle stepper motion

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -28,6 +28,7 @@ import {
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { LifecycleStepper } from "./LifecycleStepper";
+import { TrainerCard } from "./TrainerCard";
 import {
   useAdvanceLeagueStatus,
   useDeleteLeague,
@@ -174,51 +175,40 @@ export function LeagueDetailPage() {
             <Grid.Col span={{ base: 12, md: 8 }}>
               <Stack gap="lg">
                 {/* Your team panel */}
-                <Card shadow="sm" padding="lg" radius="md" withBorder>
-                  <Group justify="space-between" mb="sm">
-                    <Group gap="xs">
-                      <IconSparkles
-                        size={18}
-                        color="var(--mantine-color-mint-green-6)"
-                      />
-                      <Title order={3}>Your team</Title>
-                    </Group>
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    <IconSparkles
+                      size={18}
+                      color="var(--mantine-color-mint-green-6)"
+                    />
+                    <Title order={3}>Your team</Title>
                   </Group>
                   {currentUserPlayer
                     ? (
-                      <Group gap="md">
-                        <Avatar
-                          src={currentUserPlayer.image}
-                          alt={currentUserPlayer.name}
-                          radius="xl"
-                          size="lg"
-                          color="mint-green"
-                        >
-                          {currentUserPlayer.name
-                            .split(" ")
-                            .map((n) => n[0])
-                            .join("")
-                            .toUpperCase()
-                            .slice(0, 2)}
-                        </Avatar>
-                        <Stack gap={2}>
-                          <Text fw={600}>{currentUserPlayer.name}</Text>
-                          <Text size="sm" c="dimmed" tt="capitalize">
-                            {currentUserPlayer.role}
-                          </Text>
-                        </Stack>
-                      </Group>
+                      <TrainerCard
+                        name={currentUserPlayer.name}
+                        image={currentUserPlayer.image}
+                        role={currentUserPlayer.role}
+                        subtitle={league.data.name}
+                      />
                     )
                     : (
-                      <Text c="dimmed" size="sm">
-                        Join this league to see your trainer card here.
-                      </Text>
+                      <Card
+                        shadow="sm"
+                        padding="lg"
+                        radius="md"
+                        withBorder
+                      >
+                        <Text c="dimmed" size="sm">
+                          Join this league to see your trainer card here.
+                        </Text>
+                      </Card>
                     )}
-                  <Text c="dimmed" size="sm" mt="md">
-                    No picks yet. Your roster will appear here once the draft
+                  <Text c="dimmed" size="xs" pl={4}>
+                    No picks yet. Your roster will slide in once the draft
                     begins.
                   </Text>
-                </Card>
+                </Stack>
 
                 {/* Players / who's in */}
                 <Card shadow="sm" padding="lg" radius="md" withBorder>

--- a/client/src/features/league/LifecycleStepper.tsx
+++ b/client/src/features/league/LifecycleStepper.tsx
@@ -10,6 +10,19 @@ const PHASES: { id: Phase; label: string }[] = [
   { id: "complete", label: "Complete" },
 ];
 
+// Inline keyframe for the current-phase pulse. Kept here so the stepper is
+// self-contained and tree-shakeable.
+const STEPPER_KEYFRAMES = `
+@keyframes mtp-lifecycle-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(49, 202, 120, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(49, 202, 120, 0);
+  }
+}
+`;
+
 interface LifecycleStepperProps {
   currentPhase: Phase | string;
 }
@@ -17,57 +30,63 @@ interface LifecycleStepperProps {
 export function LifecycleStepper({ currentPhase }: LifecycleStepperProps) {
   const currentIndex = PHASES.findIndex((p) => p.id === currentPhase);
   return (
-    <Group gap="xs" wrap="nowrap" role="group" aria-label="League lifecycle">
-      {PHASES.map((phase, index) => {
-        const isCurrent = index === currentIndex;
-        const isPast = index < currentIndex;
-        const isFuture = index > currentIndex;
-        return (
-          <Group key={phase.id} gap="xs" wrap="nowrap">
-            <Box
-              w={24}
-              h={24}
-              style={{
-                borderRadius: "50%",
-                background: isPast
-                  ? "var(--mantine-color-mint-green-6)"
-                  : isCurrent
-                  ? "var(--mantine-color-mint-green-6)"
-                  : "var(--mantine-color-gray-3)",
-                color: isFuture ? "var(--mantine-color-gray-7)" : "white",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: 12,
-                fontWeight: 700,
-                transition: "background 200ms ease",
-              }}
-              data-active={isCurrent || undefined}
-              data-complete={isPast || undefined}
-            >
-              {isPast ? <IconCheck size={14} /> : index + 1}
-            </Box>
-            <Text
-              size="sm"
-              fw={isCurrent ? 700 : 500}
-              c={isFuture ? "dimmed" : undefined}
-            >
-              {phase.label}
-            </Text>
-            {index < PHASES.length - 1 && (
+    <>
+      <style>{STEPPER_KEYFRAMES}</style>
+      <Group gap="xs" wrap="nowrap" role="group" aria-label="League lifecycle">
+        {PHASES.map((phase, index) => {
+          const isCurrent = index === currentIndex;
+          const isPast = index < currentIndex;
+          const isFuture = index > currentIndex;
+          return (
+            <Group key={phase.id} gap="xs" wrap="nowrap">
               <Box
-                w={24}
-                h={2}
+                w={26}
+                h={26}
                 style={{
-                  background: isPast
+                  borderRadius: "50%",
+                  background: isPast || isCurrent
                     ? "var(--mantine-color-mint-green-6)"
                     : "var(--mantine-color-gray-3)",
+                  color: isFuture ? "var(--mantine-color-gray-7)" : "white",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  transition: "background 200ms ease, transform 200ms ease",
+                  transform: isCurrent ? "scale(1.08)" : "scale(1)",
+                  animation: isCurrent
+                    ? "mtp-lifecycle-pulse 2400ms ease-out infinite"
+                    : undefined,
                 }}
-              />
-            )}
-          </Group>
-        );
-      })}
-    </Group>
+                data-active={isCurrent || undefined}
+                data-complete={isPast || undefined}
+              >
+                {isPast ? <IconCheck size={14} /> : index + 1}
+              </Box>
+              <Text
+                size="sm"
+                fw={isCurrent ? 700 : 500}
+                c={isFuture ? "dimmed" : undefined}
+              >
+                {phase.label}
+              </Text>
+              {index < PHASES.length - 1 && (
+                <Box
+                  w={24}
+                  h={2}
+                  style={{
+                    background: isPast
+                      ? "var(--mantine-color-mint-green-6)"
+                      : "var(--mantine-color-gray-3)",
+                    transition: "background 400ms ease",
+                  }}
+                />
+              )}
+            </Group>
+          );
+        })}
+      </Group>
+    </>
   );
 }

--- a/client/src/features/league/TrainerCard.test.tsx
+++ b/client/src/features/league/TrainerCard.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { TrainerCard } from "./TrainerCard";
+
+function renderCard(props: Parameters<typeof TrainerCard>[0]) {
+  return render(
+    <MantineProvider>
+      <TrainerCard {...props} />
+    </MantineProvider>,
+  );
+}
+
+describe("TrainerCard", () => {
+  afterEach(() => cleanup());
+
+  it("renders the trainer name", () => {
+    renderCard({ name: "Ash Ketchum" });
+    expect(screen.getByText("Ash Ketchum")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Unclaimed' when name is null", () => {
+    renderCard({ name: null });
+    expect(screen.getByText(/unclaimed/i)).toBeInTheDocument();
+  });
+
+  it("shows the role badge when provided", () => {
+    renderCard({ name: "Ash Ketchum", role: "commissioner" });
+    expect(screen.getByText(/commissioner/i)).toBeInTheDocument();
+  });
+
+  it("shows the subtitle when provided", () => {
+    renderCard({ name: "Ash Ketchum", subtitle: "Johto Classic" });
+    expect(screen.getByText("Johto Classic")).toBeInTheDocument();
+  });
+
+  it("has a trainer-card test id for external assertions", () => {
+    renderCard({ name: "Ash" });
+    expect(screen.getByTestId("trainer-card")).toBeInTheDocument();
+  });
+});

--- a/client/src/features/league/TrainerCard.tsx
+++ b/client/src/features/league/TrainerCard.tsx
@@ -1,0 +1,89 @@
+import { Avatar, Badge, Box, Group, Stack, Text } from "@mantine/core";
+import { IconIdBadge2 } from "@tabler/icons-react";
+
+interface TrainerCardProps {
+  name: string | null;
+  image?: string | null;
+  role?: string;
+  subtitle?: string;
+}
+
+function initialsOf(name: string | null): string {
+  if (!name) return "??";
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+/**
+ * Distinctive "trainer card" styled panel for the player's identity in a
+ * league. Uses a gradient border + mint-green accent to evoke a Pokemon
+ * trainer ID without being cartoonish.
+ */
+export function TrainerCard(
+  { name, image, role, subtitle }: TrainerCardProps,
+) {
+  return (
+    <Box
+      data-testid="trainer-card"
+      p={2}
+      style={{
+        borderRadius: 14,
+        background:
+          "linear-gradient(135deg, var(--mantine-color-mint-green-6), var(--mantine-color-mint-green-3))",
+      }}
+    >
+      <Box
+        p="md"
+        style={{
+          borderRadius: 12,
+          background: "var(--mantine-color-body)",
+        }}
+      >
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Group gap="md" wrap="nowrap">
+            <Avatar
+              src={image ?? undefined}
+              alt={name ?? "trainer"}
+              radius="md"
+              size="lg"
+              color="mint-green"
+              style={{
+                border: "2px solid var(--mantine-color-mint-green-6)",
+              }}
+            >
+              {initialsOf(name)}
+            </Avatar>
+            <Stack gap={2}>
+              <Text fw={700} size="lg" lh={1.1}>
+                {name ?? "Unclaimed"}
+              </Text>
+              {subtitle && (
+                <Text size="xs" c="dimmed">
+                  {subtitle}
+                </Text>
+              )}
+              {role && (
+                <Badge
+                  size="xs"
+                  variant="light"
+                  color="mint-green"
+                  tt="capitalize"
+                  mt={4}
+                >
+                  {role}
+                </Badge>
+              )}
+            </Stack>
+          </Group>
+          <Box c="mint-green">
+            <IconIdBadge2 size={22} />
+          </Box>
+        </Group>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 5 of the dashboard redesign vision ([docs/product/006-ui-ux-dashboard-vision.md](docs/product/006-ui-ux-dashboard-vision.md)). Small game-feel polish to push the league hub from "web app" toward "game lobby" without re-skinning anything.

- **\`TrainerCard.tsx\`** — extracted Your-team panel with a gradient mint-green outer border, retro trainer-ID vibe, and an ID badge icon accent. Supports a null-name fallback so it can be reused later for spectator or pre-join states.
- **LifecycleStepper pulse** — the current phase's dot scales up 8% and runs a 2.4s CSS pulse (mint-green, ease-out). Past and future dots are untouched. Pulse is inline \`@keyframes\` so the stepper stays self-contained and tree-shakeable.
- **Smoother phase transitions** — connector lines now animate their background on phase advance, so when \`advanceStatus\` fires the stepper visually fills in rather than snapping.

Explicitly out of scope per the vision doc: pixel art, sound effects, per-league theming, gamification loops (XP/badges). Mint-green stays the single brand accent.

## Test plan

- [x] New \`TrainerCard.test.tsx\` — 5 cases: renders name, 'Unclaimed' fallback, role badge, subtitle, testid.
- [x] Existing \`LeagueDetailPage.test.tsx\` — all 19 existing cases still green after swapping inline avatar block for \`<TrainerCard />\`.
- [x] Full client suite: \`deno task test:client\` — 153 passing.
- [x] \`deno task build\` — succeeds.
- [x] \`deno lint\` — clean.
- [ ] Manual after merge: load a league hub, confirm trainer card renders with gradient border; confirm stepper's current phase pulses; advance a league status and confirm connector animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)