### PR TITLE
fix(league): remove gradient accent from detail hero

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -109,17 +109,7 @@ export function LeagueDetailPage() {
 
       {league.data && (
         <>
-          {/* Hero strip */}
-          <Paper
-            withBorder
-            radius="md"
-            p="lg"
-            mb="lg"
-            style={{
-              background:
-                "linear-gradient(135deg, var(--mantine-color-mint-green-0), var(--mantine-color-body))",
-            }}
-          >
+          <Paper withBorder radius="md" p="lg" mb="lg">
             <Group justify="space-between" align="flex-start" wrap="wrap">
               <Stack gap="xs" style={{ flex: 1, minWidth: 260 }}>
                 <Title order={1}>{league.data.name}</Title>


### PR DESCRIPTION
## Summary
- Drops the mint-green `linear-gradient` background from the league detail hero Paper so it matches the other bordered dashboard surfaces.

## Test plan
- [x] `deno task test:client` (159 passed)
- [ ] Visually confirm the league detail hero renders as a plain bordered Paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)