### PR TITLE
feat(home): remove Next up highlight banner from dashboard

### DIFF
--- a/client/src/features/league/HomeDashboard.test.tsx
+++ b/client/src/features/league/HomeDashboard.test.tsx
@@ -64,42 +64,6 @@ describe("HomeDashboard", () => {
     expect(screen.getByText(/welcome back, ash/i)).toBeInTheDocument();
   });
 
-  it("prompts to create a league when the user has none", () => {
-    setupMocks({ leagues: [] });
-    renderPage();
-    const banner = screen.getByTestId("next-action-banner");
-    expect(within(banner).getByText(/start your first league/i))
-      .toBeInTheDocument();
-  });
-
-  it("highlights a drafting league as the next action", () => {
-    setupMocks({
-      leagues: [
-        {
-          id: "L1",
-          name: "Kanto Rumble",
-          status: "setup",
-          playerCount: 2,
-          maxPlayers: 8,
-          userRole: "commissioner",
-        },
-        {
-          id: "L2",
-          name: "Johto Classic",
-          status: "drafting",
-          playerCount: 6,
-          maxPlayers: 8,
-          userRole: "member",
-        },
-      ],
-    });
-    renderPage();
-    const banner = screen.getByTestId("next-action-banner");
-    expect(within(banner).getByText(/johto classic/i)).toBeInTheDocument();
-    expect(within(banner).getByRole("link", { name: /go to draft/i }))
-      .toHaveAttribute("href", "/leagues/L2/draft");
-  });
-
   it("renders an active leagues strip with one card per league", () => {
     setupMocks({
       leagues: [

--- a/client/src/features/league/HomeDashboard.tsx
+++ b/client/src/features/league/HomeDashboard.tsx
@@ -1,6 +1,5 @@
 import {
   Badge,
-  Box,
   Button,
   Card,
   Container,
@@ -13,70 +12,12 @@ import {
   Title,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import {
-  IconCircleCheck,
-  IconPlus,
-  IconSparkles,
-  IconTicket,
-} from "@tabler/icons-react";
+import { IconCircleCheck, IconPlus, IconTicket } from "@tabler/icons-react";
 import { useMemo } from "react";
 import { Link } from "wouter";
 import { useSession } from "../../auth";
 import { JoinLeagueModal } from "./JoinLeagueModal";
 import { useLeagues } from "./use-leagues";
-
-type LeagueRow = NonNullable<ReturnType<typeof useLeagues>["data"]>[number];
-
-interface NextAction {
-  title: string;
-  body: string;
-  ctaLabel: string;
-  ctaHref: string;
-}
-
-function computeNextAction(
-  leagues: LeagueRow[],
-  userName: string,
-): NextAction {
-  const drafting = leagues.find((l) => l.status === "drafting");
-  if (drafting) {
-    return {
-      title: `You're drafting in ${drafting.name}`,
-      body: "Jump in — every pick counts.",
-      ctaLabel: "Go to draft",
-      ctaHref: `/leagues/${drafting.id}/draft`,
-    };
-  }
-
-  const setup = leagues.find((l) => l.status === "setup");
-  if (setup) {
-    return {
-      title: `${setup.name} is still in setup`,
-      body:
-        "Finish configuring the league and advance to drafting when you're ready.",
-      ctaLabel: "Open league",
-      ctaHref: `/leagues/${setup.id}`,
-    };
-  }
-
-  const competing = leagues.find((l) => l.status === "competing");
-  if (competing) {
-    return {
-      title: `${competing.name} season in progress`,
-      body: "Check in on the standings.",
-      ctaLabel: "View league",
-      ctaHref: `/leagues/${competing.id}`,
-    };
-  }
-
-  return {
-    title: `Start your first league, ${userName.split(" ")[0]}`,
-    body:
-      "Gather your friends, pick a format, and get drafting. Your adventure starts here.",
-    ctaLabel: "Create a league",
-    ctaHref: "/leagues/new",
-  };
-}
 
 const STATUS_COLOR: Record<string, string> = {
   setup: "gray",
@@ -92,50 +33,12 @@ export function HomeDashboard() {
 
   const userName = session?.user?.name ?? "Trainer";
   const data = useMemo(() => leagues.data ?? [], [leagues.data]);
-  const nextAction = useMemo(
-    () => computeNextAction(data, userName),
-    [data, userName],
-  );
 
   return (
     <Container size="lg" py="xl">
       <Group justify="space-between" mb="lg">
         <Title order={1}>Welcome back, {userName.split(" ")[0]}</Title>
       </Group>
-
-      <Paper
-        data-testid="next-action-banner"
-        withBorder
-        radius="md"
-        p="lg"
-        mb="xl"
-        style={{
-          background:
-            "linear-gradient(135deg, var(--mantine-color-mint-green-0), var(--mantine-color-body))",
-        }}
-      >
-        <Group justify="space-between" wrap="wrap" align="center">
-          <Group gap="md" wrap="nowrap" align="flex-start">
-            <Box c="mint-green" mt={4}>
-              <IconSparkles size={28} />
-            </Box>
-            <Stack gap={2}>
-              <Text size="sm" c="dimmed" fw={500} tt="uppercase">
-                Next up
-              </Text>
-              <Title order={3}>{nextAction.title}</Title>
-              <Text c="dimmed">{nextAction.body}</Text>
-            </Stack>
-          </Group>
-          <Button
-            component={Link}
-            href={nextAction.ctaHref}
-            size="md"
-          >
-            {nextAction.ctaLabel}
-          </Button>
-        </Group>
-      </Paper>
 
       <Group justify="space-between" mb="sm">
         <Title order={3}>Your active leagues</Title>


### PR DESCRIPTION
## Summary
- Drops the "Next up" highlight banner and the `computeNextAction` logic from the Home dashboard
- The active leagues strip and quick actions already surface the same entry points, so the banner added noise without a clear benefit
- Updates `HomeDashboard` tests to remove banner assertions

## Test plan
- [x] `deno task test:client`
- [x] `deno lint` on changed files