### PR TITLE
fix(league): replace danger zone with subtle delete action

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -20,11 +20,7 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import {
-  IconAlertTriangle,
-  IconSettings,
-  IconSparkles,
-} from "@tabler/icons-react";
+import { IconSettings, IconSparkles } from "@tabler/icons-react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { LifecycleStepper } from "./LifecycleStepper";
@@ -354,32 +350,17 @@ export function LeagueDetailPage() {
             </Grid.Col>
           </Grid>
 
-          {/* Danger zone — commissioner only, visually isolated from normal actions */}
           {isCommissioner && (
-            <Paper
-              withBorder
-              radius="md"
-              p="md"
-              mt="xl"
-              style={{ borderColor: "var(--mantine-color-red-3)" }}
-            >
-              <Group justify="space-between" wrap="wrap">
-                <Group gap="xs">
-                  <IconAlertTriangle
-                    size={18}
-                    color="var(--mantine-color-red-6)"
-                  />
-                  <Text fw={600} c="red">Danger zone</Text>
-                </Group>
-                <Button
-                  color="red"
-                  variant="light"
-                  onClick={openDelete}
-                >
-                  Delete League
-                </Button>
-              </Group>
-            </Paper>
+            <Group justify="flex-end" mt="xl">
+              <Button
+                color="red"
+                variant="subtle"
+                size="xs"
+                onClick={openDelete}
+              >
+                Delete league
+              </Button>
+            </Group>
           )}
 
           <Modal


### PR DESCRIPTION
## Summary
- Remove the "Danger zone" panel from the league detail page — its visual weight was disproportionate for a single action and clashed with the dashboard layout.
- Replace it with a small, subtle red text button at the bottom of the page. Still commissioner-only, still opens the existing delete confirmation modal.

## Test plan
- [x] `deno task test:client` passes (159/159)
- [ ] Visually confirm the delete button is present at the bottom of the league detail page for commissioners and hidden for non-commissioners
- [ ] Confirm the delete confirmation modal still opens and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)