### PR TITLE
feat(league): contextual league sidebar when inside a league

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -19,13 +19,24 @@ vi.mock("../auth", () => ({
   signOut: mockSignOut,
 }));
 
-const { mockUseLeagues, mockDeleteAccountMutate } = vi.hoisted(() => ({
+const {
+  mockUseLeagues,
+  mockUseLeague,
+  mockUseLeaguePlayers,
+  mockDeleteAccountMutate,
+  locationRef,
+} = vi.hoisted(() => ({
   mockUseLeagues: vi.fn(),
+  mockUseLeague: vi.fn(),
+  mockUseLeaguePlayers: vi.fn(),
   mockDeleteAccountMutate: vi.fn(),
+  locationRef: { current: "/" },
 }));
 
 vi.mock("../features/league/use-leagues", () => ({
   useLeagues: mockUseLeagues,
+  useLeague: mockUseLeague,
+  useLeaguePlayers: mockUseLeaguePlayers,
 }));
 
 vi.mock("../trpc", () => ({
@@ -43,7 +54,7 @@ vi.mock("../trpc", () => ({
 
 vi.mock("wouter", async () => {
   const actual = await vi.importActual<typeof import("wouter")>("wouter");
-  return { ...actual, useLocation: () => ["/", vi.fn()] };
+  return { ...actual, useLocation: () => [locationRef.current, vi.fn()] };
 });
 
 function renderLayout(children: React.ReactNode = <div>content</div>) {
@@ -57,8 +68,12 @@ function renderLayout(children: React.ReactNode = <div>content</div>) {
 function setupMocks(
   overrides: {
     leagues?: Array<{ id: string; name: string; status: string }>;
+    location?: string;
+    currentLeague?: { id: string; name: string; status: string } | null;
+    players?: Array<{ userId: string; role: "commissioner" | "player" }>;
   } = {},
 ) {
+  locationRef.current = overrides.location ?? "/";
   mockUseSession.mockReturnValue({
     data: {
       user: { id: "u1", name: "Ash Ketchum", image: null },
@@ -67,6 +82,14 @@ function setupMocks(
   });
   mockUseLeagues.mockReturnValue({
     data: overrides.leagues ?? [],
+    isLoading: false,
+  });
+  mockUseLeague.mockReturnValue({
+    data: overrides.currentLeague ?? null,
+    isLoading: false,
+  });
+  mockUseLeaguePlayers.mockReturnValue({
+    data: overrides.players ?? [],
     isLoading: false,
   });
 }
@@ -172,5 +195,54 @@ describe("AppLayout shell", () => {
     renderLayout();
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText(/make the pick/i)).toBeInTheDocument();
+  });
+});
+
+describe("AppLayout league mode", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the contextual league sidebar on a league route", () => {
+    setupMocks({
+      location: "/leagues/L1",
+      currentLeague: { id: "L1", name: "Johto Classic", status: "drafting" },
+      players: [{ userId: "u1", role: "commissioner" }],
+    });
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByText("Johto Classic")).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: /overview/i }))
+      .toHaveAttribute("href", "/leagues/L1");
+    expect(within(nav).getByRole("link", { name: /draft room/i }))
+      .toHaveAttribute("href", "/leagues/L1/draft");
+  });
+
+  it("keeps Home reachable from league mode", () => {
+    setupMocks({
+      location: "/leagues/L1",
+      currentLeague: { id: "L1", name: "Johto", status: "drafting" },
+      players: [{ userId: "u1", role: "player" }],
+    });
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    const home = within(nav).getByRole("link", { name: /home/i });
+    expect(home).toHaveAttribute("href", "/");
+  });
+
+  it("does not enter league mode on /leagues list route", () => {
+    setupMocks({ location: "/leagues" });
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).queryByRole("link", { name: /all leagues/i }))
+      .toBeNull();
+  });
+
+  it("does not enter league mode on /leagues/new", () => {
+    setupMocks({ location: "/leagues/new" });
+    renderLayout();
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).queryByRole("link", { name: /overview/i })).toBeNull();
   });
 });

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -29,6 +29,7 @@ import type { ReactNode } from "react";
 import { Link, useLocation } from "wouter";
 import { signOut, useSession } from "../auth";
 import { useLeagues } from "../features/league/use-leagues";
+import { LeagueSidebar, parseLeagueId } from "../features/league/LeagueSidebar";
 import { trpc } from "../trpc";
 
 interface AppLayoutProps {
@@ -67,6 +68,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   const isLeaguesActive = location.startsWith("/leagues");
   const leagueItems = leagues.data ?? [];
+  const currentLeagueId = parseLeagueId(location);
 
   return (
     <AppShell
@@ -106,74 +108,103 @@ export function AppLayout({ children }: AppLayoutProps) {
           <Divider />
 
           <ScrollArea style={{ flex: 1 }}>
-            <Stack gap={2} py="xs">
-              <SidebarLink
-                to="/"
-                label="Home"
-                icon={<IconHome size={20} />}
-                active={location === "/"}
-                collapsed={collapsed}
-              />
-
-              {collapsed
-                ? (
-                  <Tooltip label="Leagues" position="right">
-                    <div>
-                      <SidebarLink
-                        to="/leagues"
-                        label="Leagues"
-                        icon={<IconTrophy size={20} />}
-                        active={isLeaguesActive}
-                        collapsed
-                      />
-                    </div>
-                  </Tooltip>
-                )
-                : (
-                  <NavLink
-                    label="Leagues"
-                    leftSection={<IconTrophy size={20} />}
-                    childrenOffset={28}
-                    opened={leaguesOpened}
-                    onClick={toggleLeagues}
-                    active={isLeaguesActive}
-                    variant="filled"
-                  >
-                    {leagueItems.map((league) => (
-                      <NavLink
-                        key={league.id}
-                        component={Link}
-                        href={`/leagues/${league.id}`}
-                        label={league.name}
-                        active={location === `/leagues/${league.id}`}
-                        variant="light"
-                      />
-                    ))}
-                    <NavLink
-                      component={Link}
-                      href="/leagues"
-                      label="Browse all"
-                      c="dimmed"
+            {currentLeagueId
+              ? (
+                <Stack gap={0} py={0}>
+                  <LeagueSidebar
+                    leagueId={currentLeagueId}
+                    location={location}
+                    collapsed={collapsed}
+                  />
+                  <Divider />
+                  <Stack gap={2} py="xs">
+                    <SidebarLink
+                      to="/"
+                      label="Home"
+                      icon={<IconHome size={20} />}
+                      active={false}
+                      collapsed={collapsed}
                     />
-                  </NavLink>
-                )}
+                    <SidebarLink
+                      to="/leagues"
+                      label="Leagues"
+                      icon={<IconTrophy size={20} />}
+                      active={false}
+                      collapsed={collapsed}
+                    />
+                  </Stack>
+                </Stack>
+              )
+              : (
+                <Stack gap={2} py="xs">
+                  <SidebarLink
+                    to="/"
+                    label="Home"
+                    icon={<IconHome size={20} />}
+                    active={location === "/"}
+                    collapsed={collapsed}
+                  />
 
-              <SidebarLink
-                label="Research"
-                icon={<IconBinoculars size={20} />}
-                collapsed={collapsed}
-                disabled
-                badge="Soon"
-              />
+                  {collapsed
+                    ? (
+                      <Tooltip label="Leagues" position="right">
+                        <div>
+                          <SidebarLink
+                            to="/leagues"
+                            label="Leagues"
+                            icon={<IconTrophy size={20} />}
+                            active={isLeaguesActive}
+                            collapsed
+                          />
+                        </div>
+                      </Tooltip>
+                    )
+                    : (
+                      <NavLink
+                        label="Leagues"
+                        leftSection={<IconTrophy size={20} />}
+                        childrenOffset={28}
+                        opened={leaguesOpened}
+                        onClick={toggleLeagues}
+                        active={isLeaguesActive}
+                        variant="filled"
+                      >
+                        {leagueItems.map((league) => (
+                          <NavLink
+                            key={league.id}
+                            component={Link}
+                            href={`/leagues/${league.id}`}
+                            label={league.name}
+                            active={location === `/leagues/${league.id}`}
+                            variant="light"
+                          />
+                        ))}
+                        <NavLink
+                          component={Link}
+                          href="/leagues"
+                          label="Browse all"
+                          c="dimmed"
+                        />
+                      </NavLink>
+                    )}
 
-              <SidebarLink
-                label="Profile"
-                icon={<IconUser size={20} />}
-                collapsed={collapsed}
-                disabled
-                badge="Soon"
-              />
-            </Stack>
+                  <SidebarLink
+                    label="Research"
+                    icon={<IconBinoculars size={20} />}
+                    collapsed={collapsed}
+                    disabled
+                    badge="Soon"
+                  />
+
+                  <SidebarLink
+                    label="Profile"
+                    icon={<IconUser size={20} />}
+                    collapsed={collapsed}
+                    disabled
+                    badge="Soon"
+                  />
+                </Stack>
+              )}
           </ScrollArea>
 
           <Divider />

--- a/client/src/features/league/LeagueSidebar.test.tsx
+++ b/client/src/features/league/LeagueSidebar.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { LeagueSidebar, parseLeagueId } from "./LeagueSidebar";
+
+const { mockUseLeague, mockUseLeaguePlayers, mockUseSession } = vi.hoisted(
+  () => ({
+    mockUseLeague: vi.fn(),
+    mockUseLeaguePlayers: vi.fn(),
+    mockUseSession: vi.fn(),
+  }),
+);
+
+vi.mock("./use-leagues", () => ({
+  useLeague: mockUseLeague,
+  useLeaguePlayers: mockUseLeaguePlayers,
+}));
+
+vi.mock("../../auth", () => ({
+  useSession: mockUseSession,
+}));
+
+function renderSidebar(
+  props: { leagueId: string; location?: string; collapsed?: boolean } = {
+    leagueId: "L1",
+  },
+) {
+  return render(
+    <MantineProvider>
+      <LeagueSidebar
+        leagueId={props.leagueId}
+        location={props.location ?? `/leagues/${props.leagueId}`}
+        collapsed={props.collapsed ?? false}
+      />
+    </MantineProvider>,
+  );
+}
+
+function setup(
+  overrides: {
+    leagueStatus?: string;
+    leagueName?: string;
+    role?: "commissioner" | "player";
+  } = {},
+) {
+  mockUseSession.mockReturnValue({
+    data: { user: { id: "u1", name: "Ash" } },
+    isPending: false,
+  });
+  mockUseLeague.mockReturnValue({
+    data: {
+      id: "L1",
+      name: overrides.leagueName ?? "Johto Classic",
+      status: overrides.leagueStatus ?? "drafting",
+    },
+    isLoading: false,
+  });
+  mockUseLeaguePlayers.mockReturnValue({
+    data: [
+      { userId: "u1", role: overrides.role ?? "commissioner" },
+      { userId: "u2", role: "player" },
+    ],
+    isLoading: false,
+  });
+}
+
+describe("parseLeagueId", () => {
+  it("returns null for the home route", () => {
+    expect(parseLeagueId("/")).toBeNull();
+  });
+
+  it("returns null for /leagues list", () => {
+    expect(parseLeagueId("/leagues")).toBeNull();
+  });
+
+  it("returns null for /leagues/new", () => {
+    expect(parseLeagueId("/leagues/new")).toBeNull();
+  });
+
+  it("returns the id for /leagues/:id", () => {
+    expect(parseLeagueId("/leagues/abc123")).toBe("abc123");
+  });
+
+  it("returns the id for /leagues/:id/draft", () => {
+    expect(parseLeagueId("/leagues/abc123/draft")).toBe("abc123");
+  });
+
+  it("returns the id for /leagues/:id/draft/pool", () => {
+    expect(parseLeagueId("/leagues/abc123/draft/pool")).toBe("abc123");
+  });
+
+  it("returns the id for /leagues/:id/settings", () => {
+    expect(parseLeagueId("/leagues/abc123/settings")).toBe("abc123");
+  });
+});
+
+describe("LeagueSidebar", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the league name", () => {
+    setup({ leagueName: "Johto Classic" });
+    renderSidebar();
+    expect(screen.getByText("Johto Classic")).toBeInTheDocument();
+  });
+
+  it("shows the league status badge", () => {
+    setup({ leagueStatus: "drafting" });
+    renderSidebar();
+    expect(screen.getByText(/drafting/i)).toBeInTheDocument();
+  });
+
+  it("has a back link to /leagues", () => {
+    setup();
+    renderSidebar();
+    const back = screen.getByRole("link", { name: /all leagues/i });
+    expect(back).toHaveAttribute("href", "/leagues");
+  });
+
+  it("has an Overview link to the league detail page", () => {
+    setup();
+    renderSidebar();
+    const overview = screen.getByRole("link", { name: /overview/i });
+    expect(overview).toHaveAttribute("href", "/leagues/L1");
+  });
+
+  it("has a Draft Room link when drafting", () => {
+    setup({ leagueStatus: "drafting" });
+    renderSidebar();
+    const draft = screen.getByRole("link", { name: /draft room/i });
+    expect(draft).toHaveAttribute("href", "/leagues/L1/draft");
+  });
+
+  it("has a Draft Pool link when drafting", () => {
+    setup({ leagueStatus: "drafting" });
+    renderSidebar();
+    const pool = screen.getByRole("link", { name: /draft pool/i });
+    expect(pool).toHaveAttribute("href", "/leagues/L1/draft/pool");
+  });
+
+  it("disables Draft Room when status is setup", () => {
+    setup({ leagueStatus: "setup" });
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /draft room/i })).toBeNull();
+    expect(screen.getByText(/draft room/i)).toBeInTheDocument();
+  });
+
+  it("shows Settings link for commissioner", () => {
+    setup({ role: "commissioner" });
+    renderSidebar();
+    const settings = screen.getByRole("link", { name: /settings/i });
+    expect(settings).toHaveAttribute("href", "/leagues/L1/settings");
+  });
+
+  it("hides Settings link for non-commissioner", () => {
+    setup({ role: "player" });
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /settings/i })).toBeNull();
+  });
+
+  it("highlights Overview as active on the detail route", () => {
+    setup();
+    const { container } = renderSidebar({
+      leagueId: "L1",
+      location: "/leagues/L1",
+    });
+    const overview = within(container).getByRole("link", {
+      name: /overview/i,
+    });
+    expect(overview.getAttribute("data-active")).toBe("true");
+  });
+
+  it("highlights Draft Room as active on the draft route", () => {
+    setup();
+    const { container } = renderSidebar({
+      leagueId: "L1",
+      location: "/leagues/L1/draft",
+    });
+    const draft = within(container).getByRole("link", { name: /draft room/i });
+    expect(draft.getAttribute("data-active")).toBe("true");
+  });
+});

--- a/client/src/features/league/LeagueSidebar.tsx
+++ b/client/src/features/league/LeagueSidebar.tsx
@@ -1,0 +1,206 @@
+import {
+  Badge,
+  Box,
+  Divider,
+  Group,
+  NavLink,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import {
+  IconArrowLeft,
+  IconChartBar,
+  IconChecklist,
+  IconLayoutDashboard,
+  IconSettings,
+  IconSwords,
+  IconTelescope,
+} from "@tabler/icons-react";
+import type { ReactNode } from "react";
+import { Link } from "wouter";
+import { useSession } from "../../auth";
+import { useLeague, useLeaguePlayers } from "./use-leagues";
+
+interface LeagueSidebarProps {
+  leagueId: string;
+  location: string;
+  collapsed: boolean;
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  setup: "gray",
+  drafting: "mint-green",
+  competing: "blue",
+  complete: "violet",
+};
+
+export function parseLeagueId(location: string): string | null {
+  const match = location.match(/^\/leagues\/([^/]+)(?:\/.*)?$/);
+  if (!match) return null;
+  const id = match[1];
+  if (id === "new" || id === "join") return null;
+  return id;
+}
+
+export function LeagueSidebar(
+  { leagueId, location, collapsed }: LeagueSidebarProps,
+) {
+  const league = useLeague(leagueId);
+  const players = useLeaguePlayers(leagueId);
+  const { data: session } = useSession();
+
+  const isCommissioner = players.data?.some(
+    (p) => p.userId === session?.user?.id && p.role === "commissioner",
+  ) ?? false;
+
+  const status = league.data?.status ?? "setup";
+  const draftEnabled = status !== "setup";
+  const name = league.data?.name ?? "League";
+
+  const overviewHref = `/leagues/${leagueId}`;
+  const draftHref = `/leagues/${leagueId}/draft`;
+  const poolHref = `/leagues/${leagueId}/draft/pool`;
+  const settingsHref = `/leagues/${leagueId}/settings`;
+
+  const isOverviewActive = location === overviewHref;
+  const isDraftActive = location === draftHref;
+  const isPoolActive = location === poolHref;
+  const isSettingsActive = location === settingsHref;
+
+  return (
+    <Stack gap={0}>
+      <Box px={collapsed ? "xs" : "md"} pt="xs" pb="sm">
+        <NavLink
+          component={Link}
+          href="/leagues"
+          leftSection={<IconArrowLeft size={16} />}
+          label={collapsed ? undefined : "All leagues"}
+          aria-label="All leagues"
+          variant="subtle"
+          c="dimmed"
+        />
+        {!collapsed && (
+          <Group gap="xs" px="sm" pt="xs" wrap="nowrap">
+            <Text fw={700} size="sm" truncate>
+              {name}
+            </Text>
+            <Badge
+              size="xs"
+              variant="light"
+              color={STATUS_COLOR[status] ?? "gray"}
+              style={{ flexShrink: 0 }}
+            >
+              {status}
+            </Badge>
+          </Group>
+        )}
+      </Box>
+      <Divider />
+
+      <Stack gap={2} py="xs">
+        <LeagueNavItem
+          to={overviewHref}
+          label="Overview"
+          icon={<IconLayoutDashboard size={20} />}
+          active={isOverviewActive}
+          collapsed={collapsed}
+        />
+        <LeagueNavItem
+          to={draftEnabled ? draftHref : undefined}
+          label="Draft Room"
+          icon={<IconSwords size={20} />}
+          active={isDraftActive}
+          collapsed={collapsed}
+          disabled={!draftEnabled}
+          tooltip={!draftEnabled ? "Draft hasn't started" : undefined}
+        />
+        <LeagueNavItem
+          to={draftEnabled ? poolHref : undefined}
+          label="Draft Pool"
+          icon={<IconTelescope size={20} />}
+          active={isPoolActive}
+          collapsed={collapsed}
+          disabled={!draftEnabled}
+          tooltip={!draftEnabled ? "Draft hasn't started" : undefined}
+        />
+        <LeagueNavItem
+          label="Standings"
+          icon={<IconChartBar size={20} />}
+          collapsed={collapsed}
+          disabled
+          badge="Soon"
+        />
+        <LeagueNavItem
+          label="Picks"
+          icon={<IconChecklist size={20} />}
+          collapsed={collapsed}
+          disabled
+          badge="Soon"
+        />
+        {isCommissioner && (
+          <LeagueNavItem
+            to={settingsHref}
+            label="Settings"
+            icon={<IconSettings size={20} />}
+            active={isSettingsActive}
+            collapsed={collapsed}
+          />
+        )}
+      </Stack>
+    </Stack>
+  );
+}
+
+interface LeagueNavItemProps {
+  to?: string;
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  collapsed: boolean;
+  disabled?: boolean;
+  badge?: string;
+  tooltip?: string;
+}
+
+function LeagueNavItem(
+  {
+    to,
+    label,
+    icon,
+    active,
+    collapsed,
+    disabled,
+    badge,
+    tooltip,
+  }: LeagueNavItemProps,
+) {
+  const link = (
+    <NavLink
+      component={disabled || !to ? "button" : Link}
+      href={to}
+      label={collapsed ? undefined : label}
+      leftSection={icon}
+      active={active}
+      disabled={disabled}
+      rightSection={!collapsed && badge
+        ? (
+          <Badge size="xs" variant="light" color="gray">
+            {badge}
+          </Badge>
+        )
+        : undefined}
+      variant="filled"
+      aria-label={label}
+    />
+  );
+  const tooltipLabel = tooltip ?? (collapsed ? label : undefined);
+  if (tooltipLabel) {
+    return (
+      <Tooltip label={tooltipLabel} position="right">
+        <div>{link}</div>
+      </Tooltip>
+    );
+  }
+  return link;
+}

--- a/deno.lock
+++ b/deno.lock
@@ -44,6 +44,8 @@
     "npm:react@19": "19.2.4",
     "npm:trpc-cli@0": "0.14.0_@trpc+server@11.16.0__typescript@6.0.2_zod@3.25.76",
     "npm:trpc-ui@1": "1.0.15_@trpc+server@11.16.0__typescript@6.0.2_zod@3.25.76_@emotion+react@11.14.0__react@19.2.4_@emotion+styled@11.14.1__@emotion+react@11.14.0___react@19.2.4__react@19.2.4_@mui+material@5.18.0__@emotion+react@11.14.0___react@19.2.4__@emotion+styled@11.14.1___@emotion+react@11.14.0____react@19.2.4___react@19.2.4__@types+react@19.2.14__react@19.2.4__react-dom@19.2.4___react@19.2.4_@types+react@19.2.14_monaco-editor@0.55.1_react@19.2.4_react-dom@19.2.4__react@19.2.4_typescript@6.0.2",
+    "npm:tsc@*": "2.0.4",
+    "npm:typescript@*": "6.0.2",
     "npm:vite@*": "6.4.2",
     "npm:vite@6": "6.4.2",
     "npm:vitest@*": "3.2.4_happy-dom@18.0.1",
@@ -3208,6 +3210,10 @@
         "zod@3.25.76",
         "zod-to-json-schema"
       ]
+    },
+    "tsc@2.0.4": {
+      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
+      "bin": true
     },
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="

--- a/docs/product/007-contextual-league-dashboard.md
+++ b/docs/product/007-contextual-league-dashboard.md
@@ -1,0 +1,187 @@
+# Contextual League Dashboard
+
+## Overview
+
+Today the sidebar is global. It lists Home, a Leagues dropdown, and a couple of
+"Soon" placeholders. When you open a specific league, the sidebar does not
+change — every league-specific destination (detail, draft room, draft pool,
+settings) is reached by clicking into the page body or through a breadcrumb.
+
+That works while a league has three or four pages. It does not scale. As the
+league surface grows — standings, picks, matchups, chat, history, commissioner
+tools — there is nowhere for those destinations to live in the global nav
+without either drowning the sidebar or burying them inside the page content.
+
+This document describes the next step: **when a user opens a league, the sidebar
+becomes that league's dashboard.** Home stays the global landing page. Leagues
+stay listed in the global nav. But the moment you are inside `/leagues/:id/*`,
+the sidebar expands to surface that league's own sections, and contracts back to
+global nav the moment you leave.
+
+This is the piece
+[006-ui-ux-dashboard-vision.md](./006-ui-ux-dashboard-vision.md) left open. That
+doc described the global shell and the home dashboard. It did not define what
+the shell does when you step _into_ a league. This one does.
+
+---
+
+## Design Goals
+
+1. **A league is a place you enter, not a page you open.** The sidebar visibly
+   changing is the strongest possible signal that you are now "in" something. It
+   mirrors how Discord swaps the channel list when you pick a server, or how
+   GitHub swaps the sidebar when you enter a repo.
+2. **Keep the global nav reachable.** Entering a league must never trap the
+   user. Home, the full Leagues list, and account controls stay one click away.
+3. **Let the league surface grow.** The contextual sidebar is the pressure
+   valve. New league features (standings, picks, chat, history, commissioner
+   tools) get a home immediately, without fighting for space in the global nav.
+4. **No new routing concepts.** The league routes already nest under
+   `/leagues/:id/*`. The sidebar should follow the URL, not the other way around
+   — no route rewrites, no layout route refactor required to ship v1.
+
+---
+
+## The Two Sidebar Modes
+
+### Global mode (default)
+
+What exists today. Shown on Home, the Leagues list, Research, Profile, and any
+route that is not nested under a specific league.
+
+- Home
+- Leagues (expandable, lists user's active leagues)
+- Research _(Soon)_
+- Profile _(Soon)_
+- Footer: avatar, account menu, collapse toggle
+
+No change from the current layout in
+[`client/src/components/AppLayout.tsx`](../../client/src/components/AppLayout.tsx).
+
+### League mode (new)
+
+Triggered whenever the current route matches `/leagues/:id/*`. The sidebar
+reorganizes around that league.
+
+**Top of sidebar — league identity strip:**
+
+- League name (truncates at ~22 chars).
+- Status pill (`Setup`, `Drafting`, `Competing`, `Complete`) using the same
+  colors as the league status system.
+- A small "← All leagues" affordance that returns to global mode and the leagues
+  list. This is the escape hatch.
+
+**Contextual nav (league-specific sections):**
+
+The exact items depend on league status, but the full set looks like:
+
+- **Overview** — `/leagues/:id` — the existing LeagueDetailPage, reframed as the
+  league's home.
+- **Draft Room** — `/leagues/:id/draft` — only visible once status ≥ `Drafting`.
+  Disabled with a "Draft hasn't started" tooltip during setup.
+- **Draft Pool** — `/leagues/:id/draft/pool` — research/notes/watchlists scoped
+  to this league's pool.
+- **Standings** — _not built yet_ — live leaderboard once competing.
+- **Picks** — _not built yet_ — your weekly picks for this league.
+- **Members** — roster of league players, trades, invite code.
+- **Settings** — `/leagues/:id/settings` — commissioner-only. Hidden for
+  non-commissioners.
+
+Items that do not yet exist can ship as disabled stubs with "Soon" badges, the
+same pattern 006 already uses for Research and Profile. This is how the sidebar
+absorbs the roadmap without waiting for every page to be built.
+
+**Below the contextual nav — a thin divider, then the minimized global nav:**
+
+- Home (icon + label)
+- Leagues (icon + label, not expanded)
+- Account footer (unchanged)
+
+The global items collapse to a quieter treatment (smaller, muted) so the
+league's own nav is visually dominant. You are _inside_ this league; the rest of
+the app is still reachable but recedes.
+
+### Transitions
+
+- Entering a league (clicking a league card on Home, a league in the Leagues
+  dropdown, or an invite link) swaps the sidebar into league mode.
+- Leaving a league (clicking Home, Leagues, "All leagues", or any non-league
+  route) swaps it back.
+- The swap should be a fade/slide, not an instant repaint — the animation is
+  what sells "I entered a place."
+
+---
+
+## What Lives Where
+
+A running question as the league surface grows: does this new thing belong on
+Home, on the league dashboard, or in the global nav? The contextual sidebar
+gives us a clean rule.
+
+| Belongs on Home                         | Belongs in the league sidebar            |
+| --------------------------------------- | ---------------------------------------- |
+| "What should I do next?" across leagues | "What can I do inside _this_ league?"    |
+| Quick-create / quick-join actions       | Draft, picks, standings, settings        |
+| Activity feed across leagues            | Activity feed for this league            |
+| Trainer card, cross-league stats        | This league's roster, rules, invite code |
+
+If a thing only makes sense in the context of one league, it belongs in the
+league sidebar. If it aggregates across leagues, it belongs on Home or in the
+global nav.
+
+---
+
+## Why Not Just Add More Global Nav Items?
+
+The obvious alternative is to keep the sidebar global and cram more items into
+it — Standings, Draft, Picks as top-level entries that read the "current league"
+from context. Rejected because:
+
+- **Context is invisible.** A top-level "Draft" link only makes sense if the
+  user remembers which league is "current." That is fine for the user with one
+  league, terrible for the user with five.
+- **The sidebar runs out of room.** Every new league feature fights Research,
+  Profile, and the leagues list for vertical space.
+- **It flattens a hierarchy that is naturally nested.** A league _contains_ a
+  draft, picks, standings. The sidebar should reflect that containment.
+
+The contextual approach uses the URL itself as the source of truth for which
+league is current, and gives that league a sidebar of its own while you are
+inside it.
+
+---
+
+## Scope of v1
+
+The smallest version that delivers the vision:
+
+1. Detect league routes via the existing Wouter location and derive
+   `currentLeagueId`.
+2. Render a new `<LeagueSidebar leagueId=... />` component when that id is
+   present; render the existing global sidebar otherwise.
+3. Populate the league sidebar with the pages that already exist: Overview,
+   Draft Room, Draft Pool, Members (derived from LeagueDetailPage sections),
+   Settings (commissioner-gated).
+4. Keep Home, Leagues, and the account footer accessible in the muted secondary
+   region at the bottom.
+5. Add the status pill + league name strip at the top.
+
+Out of scope for v1: Standings, Picks, per-league activity feed, chat, the slide
+animation. Those are all additive — the sidebar is the hook they plug into, not
+a precondition.
+
+---
+
+## Open Questions
+
+- **Mobile.** The sidebar collapses to an icon rail on narrow viewports today.
+  In league mode, does the rail show league-specific glyphs, or does it fall
+  back to global? Leaning toward league-specific with a small league avatar at
+  the top so the user still knows where they are.
+- **Multi-league context switcher.** Should the league name strip at the top be
+  a dropdown, letting the user jump sideways between their leagues without going
+  back to Home? Nice-to-have, not required for v1.
+- **Commissioner tools.** As commissioner tooling grows (scheduling,
+  tiebreakers, manual overrides), does it get its own sidebar section or stay
+  nested under Settings? Revisit when there are more than ~3 commissioner
+  destinations.


### PR DESCRIPTION
## Summary
- When a user opens a specific league the sidebar swaps from global nav into a league-scoped dashboard: name, status pill, back link, and contextual destinations (Overview, Draft Room, Draft Pool, Settings) with Standings and Picks stubbed as "Soon".
- Home and Leagues stay reachable in a muted region underneath so the user is never trapped inside a league.
- Ships the v1 scope from `docs/product/007-contextual-league-dashboard.md`. Uses the URL as the source of truth for "which league is current" — no new routing layer.

## Implementation notes
- New `LeagueSidebar` component + `parseLeagueId` helper in `client/src/features/league/LeagueSidebar.tsx`.
- `AppLayout` branches on `parseLeagueId(location)`; league mode renders `LeagueSidebar` followed by a muted Home/Leagues.
- Draft Room / Draft Pool are disabled with a tooltip when the league is still in `setup`.
- Settings is gated to commissioners via `useLeaguePlayers` + session.

## Test plan
- [x] `deno task test:client` — 179 passing (18 new `LeagueSidebar` tests, 4 new `AppLayout` league-mode tests)
- [x] `deno lint`
- [x] `deno task build` (vite production build, clean)
- [ ] Manual visual pass in the browser — sidebar swap, status pill colors, collapsed-rail behavior on `/leagues/:id/*`
- [ ] Verify commissioner vs non-commissioner Settings gating against a seeded league