### PR TITLE
fix(league): remove redundant Home/Leagues links in league sidebar

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -219,7 +219,7 @@ describe("AppLayout league mode", () => {
       .toHaveAttribute("href", "/leagues/L1/draft");
   });
 
-  it("keeps Home reachable from league mode", () => {
+  it("omits Home and Leagues nav links in league mode (redundant with All leagues)", () => {
     setupMocks({
       location: "/leagues/L1",
       currentLeague: { id: "L1", name: "Johto", status: "drafting" },
@@ -227,8 +227,10 @@ describe("AppLayout league mode", () => {
     });
     renderLayout();
     const nav = screen.getByRole("navigation");
-    const home = within(nav).getByRole("link", { name: /home/i });
-    expect(home).toHaveAttribute("href", "/");
+    expect(within(nav).queryByRole("link", { name: /^home$/i })).toBeNull();
+    expect(within(nav).queryByRole("link", { name: /^leagues$/i })).toBeNull();
+    expect(within(nav).getByRole("link", { name: /all leagues/i }))
+      .toHaveAttribute("href", "/leagues");
   });
 
   it("does not enter league mode on /leagues list route", () => {

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -110,30 +110,11 @@ export function AppLayout({ children }: AppLayoutProps) {
           <ScrollArea style={{ flex: 1 }}>
             {currentLeagueId
               ? (
-                <Stack gap={0} py={0}>
-                  <LeagueSidebar
-                    leagueId={currentLeagueId}
-                    location={location}
-                    collapsed={collapsed}
-                  />
-                  <Divider />
-                  <Stack gap={2} py="xs">
-                    <SidebarLink
-                      to="/"
-                      label="Home"
-                      icon={<IconHome size={20} />}
-                      active={false}
-                      collapsed={collapsed}
-                    />
-                    <SidebarLink
-                      to="/leagues"
-                      label="Leagues"
-                      icon={<IconTrophy size={20} />}
-                      active={false}
-                      collapsed={collapsed}
-                    />
-                  </Stack>
-                </Stack>
+                <LeagueSidebar
+                  leagueId={currentLeagueId}
+                  location={location}
+                  collapsed={collapsed}
+                />
               )
               : (
                 <Stack gap={2} py="xs">


### PR DESCRIPTION
## Summary
- In league mode, the bottom Home and Leagues nav items duplicated the "All leagues" back link at the top of the league sidebar. Removed them so league mode has one clear way out.
- Updated the AppLayout test that asserted Home is reachable in league mode to instead assert Home/Leagues are absent and "All leagues" remains.

## Test plan
- [x] `deno task test:client -- AppLayout`
- [ ] Visually verify league dashboard sidebar has no duplicate nav