### PR TITLE
refactor(draft): move draft button to first column in pool table

### DIFF
--- a/client/src/features/draft/AvailablePoolTable.tsx
+++ b/client/src/features/draft/AvailablePoolTable.tsx
@@ -127,6 +127,27 @@ export function AvailablePoolTable({
   const columns = useMemo<MRT_ColumnDef<DraftPoolItem>[]>(
     () => [
       {
+        id: "draft",
+        header: "",
+        size: 90,
+        enableSorting: false,
+        enableColumnFilter: false,
+        enableResizing: false,
+        Cell: ({ row }) =>
+          isMyTurn
+            ? (
+              <Button
+                size="xs"
+                variant="light"
+                onClick={() => handleClickItem(row.original)}
+                aria-label={`Draft ${row.original.name}`}
+              >
+                Draft
+              </Button>
+            )
+            : null,
+      },
+      {
         id: "watchlist",
         header: "",
         size: 44,
@@ -290,27 +311,6 @@ export function AvailablePoolTable({
             {cell.getValue<number | null>() ?? "—"}
           </span>
         ),
-      },
-      {
-        id: "draft",
-        header: "",
-        size: 90,
-        enableSorting: false,
-        enableColumnFilter: false,
-        enableResizing: false,
-        Cell: ({ row }) =>
-          isMyTurn
-            ? (
-              <Button
-                size="xs"
-                variant="light"
-                onClick={() => handleClickItem(row.original)}
-                aria-label={`Draft ${row.original.name}`}
-              >
-                Draft
-              </Button>
-            )
-            : null,
       },
     ],
     [


### PR DESCRIPTION
## Summary
- Move the Draft action column to be the first column in the available pool table so the primary action is immediately visible.

## Test plan
- [x] `deno task test:client` (181 tests pass)
- [ ] Visually confirm the Draft button is the leftmost column in the draft pool view