### PR TITLE
feat(pool): add availability pill derived from regional dex position

### DIFF
--- a/client/src/features/draft/DraftPoolPage.test.tsx
+++ b/client/src/features/draft/DraftPoolPage.test.tsx
@@ -62,6 +62,7 @@ const mockPool = {
       draftPoolId: "pool-1",
       name: "Pikachu",
       thumbnailUrl: "https://example.com/pikachu.png",
+      availability: "early",
       metadata: {
         pokemonId: 25,
         types: ["electric"],
@@ -81,6 +82,7 @@ const mockPool = {
       draftPoolId: "pool-1",
       name: "Charizard",
       thumbnailUrl: "https://example.com/charizard.png",
+      availability: "late",
       metadata: {
         pokemonId: 6,
         types: ["fire", "flying"],
@@ -149,6 +151,7 @@ describe("DraftPoolPage", () => {
     const headerTexts = headers.map((h) => h.textContent);
     expect(headerTexts).toContain("Name");
     expect(headerTexts).toContain("Type");
+    expect(headerTexts).toContain("Availability");
     expect(headerTexts).toContain("HP");
     expect(headerTexts).toContain("Attack");
     expect(headerTexts).toContain("Defense");
@@ -182,6 +185,20 @@ describe("DraftPoolPage", () => {
     expect(screen.getByText("electric")).toBeInTheDocument();
     expect(screen.getByText("fire")).toBeInTheDocument();
     expect(screen.getByText("flying")).toBeInTheDocument();
+  });
+
+  it("shows availability pills for each pokemon", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    const pikachuRow = rows.find((row) => within(row).queryByText("Pikachu"));
+    const charizardRow = rows.find((row) =>
+      within(row).queryByText("Charizard")
+    );
+    expect(pikachuRow).toBeDefined();
+    expect(charizardRow).toBeDefined();
+    expect(within(pikachuRow!).getByText("Early")).toBeInTheDocument();
+    expect(within(charizardRow!).getByText("Late")).toBeInTheDocument();
   });
 
   it("displays thumbnail images for each pokemon", () => {

--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -12,7 +12,10 @@ import {
 import { WatchlistPanel } from "./WatchlistPanel";
 import { PoolItemNoteIcon } from "./PoolItemNoteIcon";
 import { IconStar, IconStarFilled } from "@tabler/icons-react";
-import type { DraftPoolItem } from "@make-the-pick/shared";
+import type {
+  DraftPoolItem,
+  PoolItemAvailability,
+} from "@make-the-pick/shared";
 import { Link, useParams } from "wouter";
 import { useLeague } from "../league/use-leagues";
 import { useDraftPool } from "./use-draft";
@@ -64,6 +67,22 @@ function getStatTotal(item: DraftPoolItem): number | null {
 }
 
 const ALL_POKEMON_TYPES = Object.keys(POKEMON_TYPE_COLORS);
+
+const AVAILABILITY_META: Record<
+  PoolItemAvailability,
+  { label: string; color: string; order: number }
+> = {
+  early: { label: "Early", color: "teal", order: 0 },
+  mid: { label: "Mid", color: "yellow", order: 1 },
+  late: { label: "Late", color: "red", order: 2 },
+};
+
+const AVAILABILITY_FILTER_OPTIONS = (
+  ["early", "mid", "late"] as PoolItemAvailability[]
+).map((value) => ({
+  value,
+  label: AVAILABILITY_META[value].label,
+}));
 
 export function DraftPoolPage() {
   const { id } = useParams<{ id: string }>();
@@ -202,6 +221,42 @@ export function DraftPoolPage() {
               </Group>
             )
             : null,
+      },
+      {
+        id: "availability",
+        accessorFn: (row) => row.availability,
+        header: "Availability",
+        grow: false,
+        filterVariant: "multi-select",
+        mantineFilterMultiSelectProps: {
+          data: AVAILABILITY_FILTER_OPTIONS,
+        },
+        sortingFn: (rowA, rowB) => {
+          const a = rowA.original.availability;
+          const b = rowB.original.availability;
+          const aOrder = a
+            ? AVAILABILITY_META[a].order
+            : Number.MAX_SAFE_INTEGER;
+          const bOrder = b
+            ? AVAILABILITY_META[b].order
+            : Number.MAX_SAFE_INTEGER;
+          return aOrder - bOrder;
+        },
+        filterFn: (row, _columnId, filterValues: string[]) => {
+          if (!filterValues || filterValues.length === 0) return true;
+          const value = row.original.availability;
+          return value !== null && filterValues.includes(value);
+        },
+        Cell: ({ row }) => {
+          const value = row.original.availability;
+          if (!value) return <span style={{ color: "#999" }}>—</span>;
+          const meta = AVAILABILITY_META[value];
+          return (
+            <Badge size="md" variant="light" color={meta.color}>
+              {meta.label}
+            </Badge>
+          );
+        },
       },
       {
         accessorFn: (row) => row.metadata?.baseStats?.hp ?? null,

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -38,6 +38,8 @@ export {
   draftPoolSchema,
   type GenerateDraftPoolInput,
   generateDraftPoolSchema,
+  type PoolItemAvailability,
+  poolItemAvailabilitySchema,
 } from "./schemas/mod.ts";
 export { type HealthResponse, healthResponseSchema } from "./schemas/mod.ts";
 export {

--- a/packages/shared/schemas/draft-pool.ts
+++ b/packages/shared/schemas/draft-pool.ts
@@ -1,5 +1,10 @@
 import type { z } from "zod";
-import { array, nullable, number, object, string } from "zod";
+import { array, enum as enum_, nullable, number, object, string } from "zod";
+
+export const poolItemAvailabilitySchema: z.ZodEnum<["early", "mid", "late"]> =
+  enum_(["early", "mid", "late"]);
+
+export type PoolItemAvailability = z.infer<typeof poolItemAvailabilitySchema>;
 
 export const draftPoolItemMetadataSchema: z.ZodObject<{
   pokemonId: z.ZodNumber;
@@ -35,12 +40,14 @@ export const draftPoolItemSchema: z.ZodObject<{
   name: z.ZodString;
   thumbnailUrl: z.ZodNullable<z.ZodString>;
   metadata: z.ZodNullable<typeof draftPoolItemMetadataSchema>;
+  availability: z.ZodNullable<typeof poolItemAvailabilitySchema>;
 }> = object({
   id: string().uuid(),
   draftPoolId: string().uuid(),
   name: string(),
   thumbnailUrl: nullable(string()),
   metadata: draftPoolItemMetadataSchema.nullable(),
+  availability: poolItemAvailabilitySchema.nullable(),
 });
 
 export type DraftPoolItem = z.infer<typeof draftPoolItemSchema>;

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -38,6 +38,8 @@ export {
   draftPoolSchema,
   type GenerateDraftPoolInput,
   generateDraftPoolSchema,
+  type PoolItemAvailability,
+  poolItemAvailabilitySchema,
 } from "./draft-pool.ts";
 export { type HealthResponse, healthResponseSchema } from "./health.ts";
 export {

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -1,6 +1,8 @@
 import type {
+  DraftPoolItemMetadata,
   Pokemon,
   PokemonVersion,
+  PoolItemAvailability,
   RegionalPokedexEntry,
 } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
@@ -19,6 +21,79 @@ interface RulesConfig {
   excludeLegendaries?: boolean;
   excludeStarters?: boolean;
   excludeTradeEvolutions?: boolean;
+}
+
+interface StoredPoolItem {
+  id: string;
+  draftPoolId: string;
+  name: string;
+  thumbnailUrl: string | null;
+  metadata: unknown;
+}
+
+interface AugmentedPoolItem {
+  id: string;
+  draftPoolId: string;
+  name: string;
+  thumbnailUrl: string | null;
+  metadata: DraftPoolItemMetadata | null;
+  availability: PoolItemAvailability | null;
+}
+
+export function computeAvailabilityBucket(
+  dexNumber: number,
+  dexSize: number,
+): PoolItemAvailability {
+  const earlyCutoff = Math.ceil(dexSize / 3);
+  const midCutoff = Math.ceil((dexSize * 2) / 3);
+  if (dexNumber <= earlyCutoff) return "early";
+  if (dexNumber <= midCutoff) return "mid";
+  return "late";
+}
+
+function augmentItemsWithAvailability(
+  items: StoredPoolItem[],
+  regionalDex: RegionalPokedexEntry[] | undefined,
+): AugmentedPoolItem[] {
+  const dexByPokemonId = new Map<number, number>();
+  const dexSize = regionalDex?.length ?? 0;
+  if (regionalDex) {
+    for (const entry of regionalDex) {
+      dexByPokemonId.set(entry.pokemonId, entry.dexNumber);
+    }
+  }
+
+  return items.map((item) => {
+    const metadata = item.metadata as DraftPoolItemMetadata | null;
+    let availability: PoolItemAvailability | null = null;
+    if (metadata && dexSize > 0) {
+      const dexNumber = dexByPokemonId.get(metadata.pokemonId);
+      if (dexNumber !== undefined) {
+        availability = computeAvailabilityBucket(dexNumber, dexSize);
+      }
+    }
+    return {
+      id: item.id,
+      draftPoolId: item.draftPoolId,
+      name: item.name,
+      thumbnailUrl: item.thumbnailUrl,
+      metadata,
+      availability,
+    };
+  });
+}
+
+function resolveRegionalDexForLeague(
+  rulesConfig: RulesConfig | null,
+  pokemonVersions: PokemonVersion[] | undefined,
+  regionalPokedexes: Record<string, RegionalPokedexEntry[]> | undefined,
+): RegionalPokedexEntry[] | undefined {
+  if (!rulesConfig?.gameVersion) return undefined;
+  const version = pokemonVersions?.find((v) =>
+    v.id === rulesConfig.gameVersion
+  );
+  if (!version) return undefined;
+  return regionalPokedexes?.[version.versionGroup];
 }
 
 function fisherYatesShuffle<T>(
@@ -208,7 +283,14 @@ export function createDraftPoolService(deps: {
         "draft pool generated",
       );
 
-      return { ...pool, items };
+      const regionalDex = resolveRegionalDexForLeague(
+        rulesConfig,
+        deps.pokemonVersions,
+        deps.regionalPokedexes,
+      );
+      const augmentedItems = augmentItemsWithAvailability(items, regionalDex);
+
+      return { ...pool, items: augmentedItems };
     },
 
     async getByLeagueId(userId: string, leagueId: string) {
@@ -237,7 +319,14 @@ export function createDraftPoolService(deps: {
 
       const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id);
 
-      return { ...pool, items };
+      const regionalDex = resolveRegionalDexForLeague(
+        league.rulesConfig as RulesConfig | null,
+        deps.pokemonVersions,
+        deps.regionalPokedexes,
+      );
+      const augmentedItems = augmentItemsWithAvailability(items, regionalDex);
+
+      return { ...pool, items: augmentedItems };
     },
   };
 }

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -1129,6 +1129,208 @@ Deno.test("draftPoolService.generate: throws BAD_REQUEST for invalid gameVersion
   assertEquals(error.code, "BAD_REQUEST");
 });
 
+// --- getByLeagueId availability derivation ---
+
+const nineEntryRegionalPokedexes: Record<string, RegionalPokedexEntry[]> = {
+  "firered-leafgreen": Array.from({ length: 9 }, (_, i) => ({
+    pokemonId: i + 1,
+    dexNumber: i + 1,
+  })),
+};
+
+function createFakeStoredPoolItem(
+  poolId: string,
+  pokemonId: number,
+): FakePoolItem {
+  return {
+    id: crypto.randomUUID(),
+    draftPoolId: poolId,
+    name: `pokemon-${pokemonId}`,
+    thumbnailUrl: null,
+    metadata: {
+      pokemonId,
+      types: ["normal"],
+      baseStats: {
+        hp: 50,
+        attack: 50,
+        defense: 50,
+        specialAttack: 50,
+        specialDefense: 50,
+        speed: 50,
+      },
+      generation: "generation-i",
+    },
+  };
+}
+
+Deno.test("draftPoolService.getByLeagueId: derives availability from regional dex thirds", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "leafgreen",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  // Dex size 9 → early [1-3], mid [4-6], late [7-9]
+  const storedItems = [
+    createFakeStoredPoolItem(fakePool.id, 1),
+    createFakeStoredPoolItem(fakePool.id, 3),
+    createFakeStoredPoolItem(fakePool.id, 4),
+    createFakeStoredPoolItem(fakePool.id, 6),
+    createFakeStoredPoolItem(fakePool.id, 7),
+    createFakeStoredPoolItem(fakePool.id, 9),
+  ];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: [],
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: nineEntryRegionalPokedexes,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  const byPokemonId = new Map(
+    result.items.map((item) => [item.metadata?.pokemonId, item.availability]),
+  );
+  assertEquals(byPokemonId.get(1), "early");
+  assertEquals(byPokemonId.get(3), "early");
+  assertEquals(byPokemonId.get(4), "mid");
+  assertEquals(byPokemonId.get(6), "mid");
+  assertEquals(byPokemonId.get(7), "late");
+  assertEquals(byPokemonId.get(9), "late");
+});
+
+Deno.test("draftPoolService.getByLeagueId: returns null availability when league has no gameVersion", async () => {
+  const fakeLeague = createFakeLeague();
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const storedItems = [createFakeStoredPoolItem(fakePool.id, 1)];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: [],
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: fakeRegionalPokedexes,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  assertEquals(result.items[0].availability, null);
+});
+
+Deno.test("draftPoolService.getByLeagueId: returns null availability for pool items not in the regional dex", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "leafgreen",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  // pokemonId 999 is not in any regional dex
+  const storedItems = [createFakeStoredPoolItem(fakePool.id, 999)];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: [],
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: nineEntryRegionalPokedexes,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  assertEquals(result.items[0].availability, null);
+});
+
+Deno.test("draftPoolService.generate: populates availability on returned items", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 1,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "leafgreen",
+    },
+  });
+  const pokemonData = createFakePokemonData(9);
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(2),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: nineEntryRegionalPokedexes,
+  });
+
+  const result = await service.generate("user-1", { leagueId: fakeLeague.id });
+  for (const item of result.items) {
+    const bucket = item.availability;
+    assertEquals(
+      bucket === "early" || bucket === "mid" || bucket === "late",
+      true,
+      `item ${item.name} should have an availability bucket, got ${bucket}`,
+    );
+  }
+});
+
 Deno.test("draftPoolService.generate: throws when all Pokemon are excluded by filters", async () => {
   const fakeLeague = createFakeLeague({
     rulesConfig: {


### PR DESCRIPTION
## Summary
- Derives an Early/Mid/Late availability bucket for each pool item from its position in the league version's regional Pokedex
- New \`Availability\` column on the draft pool page with sorting + multi-select filter
- No schema changes, no migrations — pure read-side augmentation using data already wired into the draft pool service

This is phase 1 of [docs/product/008-contextual-pool-research.md](https://github.com/Tiernebre/make-the-pick/blob/main/docs/product/008-contextual-pool-research.md). Follow-ups (routes/locations, effort/evolution) will come in separate PRs.

## Test plan
- [ ] \`deno task test:server\` passes (new service tests cover the thirds bucketing, missing game version, and species not in regional dex)
- [ ] \`deno task test:client\` passes (new DraftPoolPage test asserts the Availability header and per-row pill)
- [ ] Manual: open a league with a game version set, verify pills render and the filter/sort work
- [ ] Manual: open a league with no game version, verify items show em-dash instead of a pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)