### PR TITLE
feat(league): surface Pokemon settings in Rules card

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -425,6 +425,51 @@ describe("LeagueDetailPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows Pokemon settings in the Rules card when present", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          numberOfRounds: 10,
+          pickTimeLimitSeconds: 90,
+          poolSizeMultiplier: 2.5,
+          gameVersion: "scarlet-violet",
+          excludeLegendaries: true,
+          excludeStarters: false,
+          excludeTradeEvolutions: true,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText(/game version/i)).toBeInTheDocument();
+    expect(screen.getByText(/scarlet-violet/i)).toBeInTheDocument();
+    expect(screen.getByText(/pool multiplier/i)).toBeInTheDocument();
+    expect(screen.getByText(/2\.5x/)).toBeInTheDocument();
+    expect(screen.getByText(/pick timer/i)).toBeInTheDocument();
+    expect(screen.getByText(/90s/)).toBeInTheDocument();
+    expect(screen.getByText(/exclusions/i)).toBeInTheDocument();
+    expect(screen.getByText(/legendaries/i)).toBeInTheDocument();
+    expect(screen.getByText(/trade evolutions/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^starters$/i)).not.toBeInTheDocument();
+  });
+
   it("does not render a Save Settings button", () => {
     mockUseLeague.mockReturnValue({
       data: {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -302,25 +302,43 @@ export function LeagueDetailPage() {
                         : "View"}
                     </Button>
                   </Group>
-                  {league.data.rulesConfig &&
-                      typeof league.data.rulesConfig === "object"
-                    ? (
+                  {(() => {
+                    if (
+                      !league.data.rulesConfig ||
+                      typeof league.data.rulesConfig !== "object"
+                    ) {
+                      return (
+                        <Text size="sm" c="dimmed">
+                          Not configured yet.
+                        </Text>
+                      );
+                    }
+                    const rules = league.data.rulesConfig as {
+                      draftFormat?: string;
+                      numberOfRounds?: number;
+                      pickTimeLimitSeconds?: number | null;
+                      poolSizeMultiplier?: number;
+                      gameVersion?: string;
+                      excludeLegendaries?: boolean;
+                      excludeStarters?: boolean;
+                      excludeTradeEvolutions?: boolean;
+                    };
+                    const exclusions = [
+                      rules.excludeLegendaries && "Legendaries",
+                      rules.excludeStarters && "Starters",
+                      rules.excludeTradeEvolutions && "Trade evolutions",
+                    ].filter((v): v is string => typeof v === "string");
+                    return (
                       <Stack gap="xs">
                         <Group justify="space-between">
                           <Text size="sm" c="dimmed">Format</Text>
                           <Text size="sm" tt="capitalize">
-                            {(league.data.rulesConfig as {
-                              draftFormat?: string;
-                            }).draftFormat ?? "—"}
+                            {rules.draftFormat ?? "—"}
                           </Text>
                         </Group>
                         <Group justify="space-between">
                           <Text size="sm" c="dimmed">Rounds</Text>
-                          <Text size="sm">
-                            {(league.data.rulesConfig as {
-                              numberOfRounds?: number;
-                            }).numberOfRounds ?? "—"}
-                          </Text>
+                          <Text size="sm">{rules.numberOfRounds ?? "—"}</Text>
                         </Group>
                         {league.data.maxPlayers && (
                           <Group justify="space-between">
@@ -328,13 +346,45 @@ export function LeagueDetailPage() {
                             <Text size="sm">{league.data.maxPlayers}</Text>
                           </Group>
                         )}
+                        <Group justify="space-between">
+                          <Text size="sm" c="dimmed">Pick timer</Text>
+                          <Text size="sm">
+                            {rules.pickTimeLimitSeconds
+                              ? `${rules.pickTimeLimitSeconds}s`
+                              : "No limit"}
+                          </Text>
+                        </Group>
+                        {league.data.sportType === "pokemon" && (
+                          <>
+                            <Group justify="space-between">
+                              <Text size="sm" c="dimmed">Game version</Text>
+                              <Text size="sm">
+                                {rules.gameVersion ?? "All Pokemon"}
+                              </Text>
+                            </Group>
+                            <Group justify="space-between">
+                              <Text size="sm" c="dimmed">Pool multiplier</Text>
+                              <Text size="sm">
+                                {rules.poolSizeMultiplier ?? 2}x
+                              </Text>
+                            </Group>
+                            <Group
+                              justify="space-between"
+                              align="flex-start"
+                              wrap="nowrap"
+                            >
+                              <Text size="sm" c="dimmed">Exclusions</Text>
+                              <Text size="sm" ta="right">
+                                {exclusions.length > 0
+                                  ? exclusions.join(", ")
+                                  : "None"}
+                              </Text>
+                            </Group>
+                          </>
+                        )}
                       </Stack>
-                    )
-                    : (
-                      <Text size="sm" c="dimmed">
-                        Not configured yet.
-                      </Text>
-                    )}
+                    );
+                  })()}
                 </Card>
               </Stack>
             </Grid.Col>


### PR DESCRIPTION
## Summary
- Rules card on the league detail page now shows game version, pool multiplier, pick timer, and exclusions for Pokemon leagues, so non-commissioners can see what shape the draft pool is in before the draft begins
- Format / rounds / max players still render first; Pokemon-specific fields only show when `sportType === "pokemon"`

## Test plan
- [x] `deno task test:client -- --run LeagueDetailPage` (new test: "shows Pokemon settings in the Rules card when present")
- [ ] Manual: open a Pokemon league as a non-commissioner and confirm all rules fields render on the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)