### PR TITLE
feat(pool): route locations, effort score, and evolution data

### DIFF
--- a/client/src/features/draft/DraftPoolPage.test.tsx
+++ b/client/src/features/draft/DraftPoolPage.test.tsx
@@ -63,6 +63,38 @@ const mockPool = {
       name: "Pikachu",
       thumbnailUrl: "https://example.com/pikachu.png",
       availability: "early",
+      encounter: {
+        primary: { location: "Viridian Forest", method: "Walk" },
+        all: [
+          {
+            location: "Viridian Forest",
+            method: "Walk",
+            minLevel: 3,
+            maxLevel: 5,
+            chance: 10,
+          },
+        ],
+      },
+      effort: { score: 2, reasons: ["Rare encounter (10% best chance)"] },
+      evolution: {
+        pokemonId: 25,
+        chainId: 10,
+        evolvesFromId: 172,
+        triggers: [
+          {
+            trigger: "level-up",
+            minLevel: null,
+            item: null,
+            heldItem: null,
+            knownMove: null,
+            minHappiness: 220,
+            timeOfDay: null,
+            needsOverworldRain: false,
+            location: null,
+            tradeSpecies: null,
+          },
+        ],
+      },
       metadata: {
         pokemonId: 25,
         types: ["electric"],
@@ -83,6 +115,27 @@ const mockPool = {
       name: "Charizard",
       thumbnailUrl: "https://example.com/charizard.png",
       availability: "late",
+      encounter: null,
+      effort: { score: 4, reasons: ["No wild encounters in this version"] },
+      evolution: {
+        pokemonId: 6,
+        chainId: 2,
+        evolvesFromId: 5,
+        triggers: [
+          {
+            trigger: "level-up",
+            minLevel: 36,
+            item: null,
+            heldItem: null,
+            knownMove: null,
+            minHappiness: null,
+            timeOfDay: null,
+            needsOverworldRain: false,
+            location: null,
+            tradeSpecies: null,
+          },
+        ],
+      },
       metadata: {
         pokemonId: 6,
         types: ["fire", "flying"],
@@ -152,6 +205,9 @@ describe("DraftPoolPage", () => {
     expect(headerTexts).toContain("Name");
     expect(headerTexts).toContain("Type");
     expect(headerTexts).toContain("Availability");
+    expect(headerTexts).toContain("Found At");
+    expect(headerTexts).toContain("Effort");
+    expect(headerTexts).toContain("Evo");
     expect(headerTexts).toContain("HP");
     expect(headerTexts).toContain("Attack");
     expect(headerTexts).toContain("Defense");
@@ -199,6 +255,39 @@ describe("DraftPoolPage", () => {
     expect(charizardRow).toBeDefined();
     expect(within(pikachuRow!).getByText("Early")).toBeInTheDocument();
     expect(within(charizardRow!).getByText("Late")).toBeInTheDocument();
+  });
+
+  it("shows primary encounter location for species with data", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    const pikachuRow = within(table).getAllByRole("row").find((row) =>
+      within(row).queryByText("Pikachu")
+    );
+    expect(pikachuRow).toBeDefined();
+    expect(within(pikachuRow!).getByText("Viridian Forest"))
+      .toBeInTheDocument();
+  });
+
+  it("shows em dash for species with no encounter data", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    const charizardRow = within(table).getAllByRole("row").find((row) =>
+      within(row).queryByText("Charizard")
+    );
+    expect(charizardRow).toBeDefined();
+    // Charizard has encounter: null; location cell renders an em dash
+    expect(within(charizardRow!).getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("shows effort meters with aria-labels", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    expect(
+      within(table).getByLabelText("Effort 2 of 5"),
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByLabelText("Effort 4 of 5"),
+    ).toBeInTheDocument();
   });
 
   it("displays thumbnail images for each pokemon", () => {

--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -6,15 +6,25 @@ import {
   Container,
   Grid,
   Group,
+  HoverCard,
+  List,
   LoadingOverlay,
+  Popover,
+  Stack,
+  Table,
+  Text,
   Title,
+  UnstyledButton,
 } from "@mantine/core";
 import { WatchlistPanel } from "./WatchlistPanel";
 import { PoolItemNoteIcon } from "./PoolItemNoteIcon";
 import { IconStar, IconStarFilled } from "@tabler/icons-react";
 import type {
   DraftPoolItem,
+  PokemonEncounterSummary,
+  PokemonEvolution,
   PoolItemAvailability,
+  PoolItemEffort,
 } from "@make-the-pick/shared";
 import { Link, useParams } from "wouter";
 import { useLeague } from "../league/use-leagues";
@@ -83,6 +93,187 @@ const AVAILABILITY_FILTER_OPTIONS = (
   value,
   label: AVAILABILITY_META[value].label,
 }));
+
+function EffortMeter({ effort }: { effort: PoolItemEffort | null }) {
+  if (!effort) return <span style={{ color: "#999" }}>—</span>;
+  const score = effort.score;
+  const color = score <= 2 ? "teal" : score <= 3 ? "yellow" : "red";
+  return (
+    <HoverCard width={260} position="top" withArrow>
+      <HoverCard.Target>
+        <UnstyledButton aria-label={`Effort ${score} of 5`}>
+          <Group gap={3}>
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div
+                key={i}
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 2,
+                  backgroundColor: i <= score
+                    ? `var(--mantine-color-${color}-6)`
+                    : "var(--mantine-color-gray-3)",
+                }}
+              />
+            ))}
+          </Group>
+        </UnstyledButton>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Text size="sm" fw={600} mb="xs">
+          Effort to field: {score}/5
+        </Text>
+        <List size="xs" spacing={2}>
+          {effort.reasons.map((reason) => (
+            <List.Item key={reason}>{reason}</List.Item>
+          ))}
+        </List>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}
+
+function LocationCell(
+  { encounter }: {
+    encounter:
+      | {
+        primary: { location: string; method: string } | null;
+        all: PokemonEncounterSummary[];
+      }
+      | null;
+  },
+) {
+  if (!encounter || !encounter.primary || encounter.all.length === 0) {
+    return <span style={{ color: "#999" }}>—</span>;
+  }
+  const primary = encounter.primary;
+  return (
+    <Popover width={340} position="right" withArrow shadow="md">
+      <Popover.Target>
+        <UnstyledButton
+          style={{
+            fontSize: 13,
+            textAlign: "left",
+            cursor: "pointer",
+            color: "var(--mantine-color-blue-7)",
+          }}
+        >
+          <Text span size="sm" fw={500} lh={1.2}>
+            {primary.location}
+          </Text>
+          <br />
+          <Text span size="xs" c="dimmed">
+            {primary.method}
+          </Text>
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Text size="sm" fw={600} mb="xs">
+          All encounters
+        </Text>
+        <Table fz="xs" verticalSpacing={4} highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Location</Table.Th>
+              <Table.Th>Method</Table.Th>
+              <Table.Th>Level</Table.Th>
+              <Table.Th>%</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {encounter.all.map((e, i) => (
+              <Table.Tr key={`${e.location}-${e.method}-${i}`}>
+                <Table.Td>{e.location}</Table.Td>
+                <Table.Td>{e.method}</Table.Td>
+                <Table.Td>
+                  {e.minLevel === e.maxLevel
+                    ? e.minLevel
+                    : `${e.minLevel}-${e.maxLevel}`}
+                </Table.Td>
+                <Table.Td>{e.chance}%</Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+function formatEvolutionTrigger(
+  trigger: PokemonEvolution["triggers"][number],
+): string {
+  if (trigger.trigger === "level-up") {
+    const parts: string[] = [];
+    if (trigger.minLevel !== null) parts.push(`Level ${trigger.minLevel}`);
+    if (trigger.minHappiness !== null) {
+      parts.push(`happiness ≥ ${trigger.minHappiness}`);
+    }
+    if (trigger.timeOfDay) parts.push(`at ${trigger.timeOfDay}`);
+    if (trigger.knownMove) parts.push(`knowing ${trigger.knownMove}`);
+    if (trigger.location) parts.push(`at ${trigger.location}`);
+    if (trigger.heldItem) parts.push(`holding ${trigger.heldItem}`);
+    if (trigger.needsOverworldRain) parts.push("during rain");
+    return parts.length > 0 ? parts.join(", ") : "Level up";
+  }
+  if (trigger.trigger === "trade") {
+    if (trigger.heldItem) return `Trade holding ${trigger.heldItem}`;
+    if (trigger.tradeSpecies) {
+      return `Trade for ${trigger.tradeSpecies}`;
+    }
+    return "Trade";
+  }
+  if (trigger.trigger === "use-item" && trigger.item) {
+    return `Use ${trigger.item}`;
+  }
+  return trigger.trigger.replace(/-/g, " ");
+}
+
+function EvolutionCell({
+  evolution,
+}: {
+  evolution: PokemonEvolution | null;
+}) {
+  if (!evolution) return <span style={{ color: "#999" }}>—</span>;
+  const isStandalone = evolution.evolvesFromId === null &&
+    evolution.triggers.length === 0;
+  if (isStandalone) {
+    return <Text size="xs" c="dimmed">None</Text>;
+  }
+  return (
+    <HoverCard width={280} position="left" withArrow>
+      <HoverCard.Target>
+        <UnstyledButton
+          style={{
+            fontSize: 12,
+            color: "var(--mantine-color-blue-7)",
+          }}
+        >
+          {evolution.evolvesFromId ? "Evolves" : "Base form"}
+        </UnstyledButton>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Stack gap={6}>
+          <Text size="sm" fw={600}>Evolution</Text>
+          {evolution.evolvesFromId && (
+            <Text size="xs">Evolves from #{evolution.evolvesFromId}</Text>
+          )}
+          {evolution.triggers.length > 0
+            ? (
+              <List size="xs" spacing={2}>
+                {evolution.triggers.map((trigger, idx) => (
+                  <List.Item key={idx}>
+                    {formatEvolutionTrigger(trigger)}
+                  </List.Item>
+                ))}
+              </List>
+            )
+            : <Text size="xs" c="dimmed">Does not evolve further.</Text>}
+        </Stack>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}
 
 export function DraftPoolPage() {
   const { id } = useParams<{ id: string }>();
@@ -257,6 +448,34 @@ export function DraftPoolPage() {
             </Badge>
           );
         },
+      },
+      {
+        id: "location",
+        accessorFn: (row) => row.encounter?.primary?.location ?? null,
+        header: "Found At",
+        enableSorting: true,
+        enableColumnFilter: false,
+        size: 160,
+        Cell: ({ row }) => <LocationCell encounter={row.original.encounter} />,
+      },
+      {
+        id: "effort",
+        accessorFn: (row) => row.effort?.score ?? null,
+        header: "Effort",
+        grow: false,
+        size: 90,
+        filterVariant: "range",
+        Cell: ({ row }) => <EffortMeter effort={row.original.effort} />,
+      },
+      {
+        id: "evolution",
+        accessorFn: (row) => row.evolution?.evolvesFromId ?? null,
+        header: "Evo",
+        enableSorting: false,
+        enableColumnFilter: false,
+        grow: false,
+        size: 100,
+        Cell: ({ row }) => <EvolutionCell evolution={row.original.evolution} />,
       },
       {
         accessorFn: (row) => row.metadata?.baseStats?.hp ?? null,

--- a/deno.json
+++ b/deno.json
@@ -23,7 +23,9 @@
     "db:stop": "docker compose down",
     "db:generate": "cd server && deno run -A npm:drizzle-kit generate",
     "db:migrate": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env.example db/migrate.ts",
-    "sync:pokemon": "deno run --allow-net --allow-write --allow-read scripts/sync-pokemon.ts"
+    "sync:pokemon": "deno run --allow-net --allow-write --allow-read scripts/sync-pokemon.ts",
+    "sync:pokemon-encounters": "deno run --allow-net --allow-write --allow-read scripts/sync-pokemon-encounters.ts",
+    "sync:pokemon-evolutions": "deno run --allow-net --allow-write --allow-read scripts/sync-pokemon-evolutions.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1",

--- a/packages/shared/data/pokemon-evolutions.json
+++ b/packages/shared/data/pokemon-evolutions.json
@@ -1,0 +1,12772 @@
+{
+  "1": { "pokemonId": 1, "chainId": 1, "evolvesFromId": null, "triggers": [] },
+  "2": {
+    "pokemonId": 2,
+    "chainId": 1,
+    "evolvesFromId": 1,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "3": {
+    "pokemonId": 3,
+    "chainId": 1,
+    "evolvesFromId": 2,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "4": { "pokemonId": 4, "chainId": 2, "evolvesFromId": null, "triggers": [] },
+  "5": {
+    "pokemonId": 5,
+    "chainId": 2,
+    "evolvesFromId": 4,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "6": {
+    "pokemonId": 6,
+    "chainId": 2,
+    "evolvesFromId": 5,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "7": { "pokemonId": 7, "chainId": 3, "evolvesFromId": null, "triggers": [] },
+  "8": {
+    "pokemonId": 8,
+    "chainId": 3,
+    "evolvesFromId": 7,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "9": {
+    "pokemonId": 9,
+    "chainId": 3,
+    "evolvesFromId": 8,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "10": {
+    "pokemonId": 10,
+    "chainId": 4,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "11": {
+    "pokemonId": 11,
+    "chainId": 4,
+    "evolvesFromId": 10,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 7,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "12": {
+    "pokemonId": 12,
+    "chainId": 4,
+    "evolvesFromId": 11,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "13": {
+    "pokemonId": 13,
+    "chainId": 5,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "14": {
+    "pokemonId": 14,
+    "chainId": 5,
+    "evolvesFromId": 13,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 7,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "15": {
+    "pokemonId": 15,
+    "chainId": 5,
+    "evolvesFromId": 14,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "16": {
+    "pokemonId": 16,
+    "chainId": 6,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "17": {
+    "pokemonId": 17,
+    "chainId": 6,
+    "evolvesFromId": 16,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "18": {
+    "pokemonId": 18,
+    "chainId": 6,
+    "evolvesFromId": 17,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "19": {
+    "pokemonId": 19,
+    "chainId": 7,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "20": {
+    "pokemonId": 20,
+    "chainId": 7,
+    "evolvesFromId": 19,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "21": {
+    "pokemonId": 21,
+    "chainId": 8,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "22": {
+    "pokemonId": 22,
+    "chainId": 8,
+    "evolvesFromId": 21,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "23": {
+    "pokemonId": 23,
+    "chainId": 9,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "24": {
+    "pokemonId": 24,
+    "chainId": 9,
+    "evolvesFromId": 23,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "25": {
+    "pokemonId": 25,
+    "chainId": 10,
+    "evolvesFromId": 172,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 220,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "26": {
+    "pokemonId": 26,
+    "chainId": 10,
+    "evolvesFromId": 25,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "27": {
+    "pokemonId": 27,
+    "chainId": 11,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "28": {
+    "pokemonId": 28,
+    "chainId": 11,
+    "evolvesFromId": 27,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "29": {
+    "pokemonId": 29,
+    "chainId": 12,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "30": {
+    "pokemonId": 30,
+    "chainId": 12,
+    "evolvesFromId": 29,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "31": {
+    "pokemonId": 31,
+    "chainId": 12,
+    "evolvesFromId": 30,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "32": {
+    "pokemonId": 32,
+    "chainId": 13,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "33": {
+    "pokemonId": 33,
+    "chainId": 13,
+    "evolvesFromId": 32,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "34": {
+    "pokemonId": 34,
+    "chainId": 13,
+    "evolvesFromId": 33,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "35": {
+    "pokemonId": 35,
+    "chainId": 14,
+    "evolvesFromId": 173,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "36": {
+    "pokemonId": 36,
+    "chainId": 14,
+    "evolvesFromId": 35,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "37": {
+    "pokemonId": 37,
+    "chainId": 15,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "38": {
+    "pokemonId": 38,
+    "chainId": 15,
+    "evolvesFromId": 37,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "fire-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "39": {
+    "pokemonId": 39,
+    "chainId": 16,
+    "evolvesFromId": 174,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "40": {
+    "pokemonId": 40,
+    "chainId": 16,
+    "evolvesFromId": 39,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "41": {
+    "pokemonId": 41,
+    "chainId": 17,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "42": {
+    "pokemonId": 42,
+    "chainId": 17,
+    "evolvesFromId": 41,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "43": {
+    "pokemonId": 43,
+    "chainId": 18,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "44": {
+    "pokemonId": 44,
+    "chainId": 18,
+    "evolvesFromId": 43,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 21,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "45": {
+    "pokemonId": 45,
+    "chainId": 18,
+    "evolvesFromId": 44,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "46": {
+    "pokemonId": 46,
+    "chainId": 19,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "47": {
+    "pokemonId": 47,
+    "chainId": 19,
+    "evolvesFromId": 46,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "48": {
+    "pokemonId": 48,
+    "chainId": 20,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "49": {
+    "pokemonId": 49,
+    "chainId": 20,
+    "evolvesFromId": 48,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 31,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "50": {
+    "pokemonId": 50,
+    "chainId": 21,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "51": {
+    "pokemonId": 51,
+    "chainId": 21,
+    "evolvesFromId": 50,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "52": {
+    "pokemonId": 52,
+    "chainId": 22,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "53": {
+    "pokemonId": 53,
+    "chainId": 22,
+    "evolvesFromId": 52,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "54": {
+    "pokemonId": 54,
+    "chainId": 23,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "55": {
+    "pokemonId": 55,
+    "chainId": 23,
+    "evolvesFromId": 54,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "56": {
+    "pokemonId": 56,
+    "chainId": 24,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "57": {
+    "pokemonId": 57,
+    "chainId": 24,
+    "evolvesFromId": 56,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "58": {
+    "pokemonId": 58,
+    "chainId": 25,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "59": {
+    "pokemonId": 59,
+    "chainId": 25,
+    "evolvesFromId": 58,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "fire-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "60": {
+    "pokemonId": 60,
+    "chainId": 26,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "61": {
+    "pokemonId": 61,
+    "chainId": 26,
+    "evolvesFromId": 60,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "62": {
+    "pokemonId": 62,
+    "chainId": 26,
+    "evolvesFromId": 61,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "63": {
+    "pokemonId": 63,
+    "chainId": 27,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "64": {
+    "pokemonId": 64,
+    "chainId": 27,
+    "evolvesFromId": 63,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "65": {
+    "pokemonId": 65,
+    "chainId": 27,
+    "evolvesFromId": 64,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "66": {
+    "pokemonId": 66,
+    "chainId": 28,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "67": {
+    "pokemonId": 67,
+    "chainId": 28,
+    "evolvesFromId": 66,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "68": {
+    "pokemonId": 68,
+    "chainId": 28,
+    "evolvesFromId": 67,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "69": {
+    "pokemonId": 69,
+    "chainId": 29,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "70": {
+    "pokemonId": 70,
+    "chainId": 29,
+    "evolvesFromId": 69,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 21,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "71": {
+    "pokemonId": 71,
+    "chainId": 29,
+    "evolvesFromId": 70,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "72": {
+    "pokemonId": 72,
+    "chainId": 30,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "73": {
+    "pokemonId": 73,
+    "chainId": 30,
+    "evolvesFromId": 72,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "74": {
+    "pokemonId": 74,
+    "chainId": 31,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "75": {
+    "pokemonId": 75,
+    "chainId": 31,
+    "evolvesFromId": 74,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "76": {
+    "pokemonId": 76,
+    "chainId": 31,
+    "evolvesFromId": 75,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "77": {
+    "pokemonId": 77,
+    "chainId": 32,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "78": {
+    "pokemonId": 78,
+    "chainId": 32,
+    "evolvesFromId": 77,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "79": {
+    "pokemonId": 79,
+    "chainId": 33,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "80": {
+    "pokemonId": 80,
+    "chainId": 33,
+    "evolvesFromId": 79,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "galarica-cuff",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "81": {
+    "pokemonId": 81,
+    "chainId": 34,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "82": {
+    "pokemonId": 82,
+    "chainId": 34,
+    "evolvesFromId": 81,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "83": {
+    "pokemonId": 83,
+    "chainId": 35,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "84": {
+    "pokemonId": 84,
+    "chainId": 36,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "85": {
+    "pokemonId": 85,
+    "chainId": 36,
+    "evolvesFromId": 84,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 31,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "86": {
+    "pokemonId": 86,
+    "chainId": 37,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "87": {
+    "pokemonId": 87,
+    "chainId": 37,
+    "evolvesFromId": 86,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "88": {
+    "pokemonId": 88,
+    "chainId": 38,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "89": {
+    "pokemonId": 89,
+    "chainId": 38,
+    "evolvesFromId": 88,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "90": {
+    "pokemonId": 90,
+    "chainId": 39,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "91": {
+    "pokemonId": 91,
+    "chainId": 39,
+    "evolvesFromId": 90,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "92": {
+    "pokemonId": 92,
+    "chainId": 40,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "93": {
+    "pokemonId": 93,
+    "chainId": 40,
+    "evolvesFromId": 92,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "94": {
+    "pokemonId": 94,
+    "chainId": 40,
+    "evolvesFromId": 93,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "95": {
+    "pokemonId": 95,
+    "chainId": 41,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "96": {
+    "pokemonId": 96,
+    "chainId": 42,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "97": {
+    "pokemonId": 97,
+    "chainId": 42,
+    "evolvesFromId": 96,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "98": {
+    "pokemonId": 98,
+    "chainId": 43,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "99": {
+    "pokemonId": 99,
+    "chainId": 43,
+    "evolvesFromId": 98,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "100": {
+    "pokemonId": 100,
+    "chainId": 44,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "101": {
+    "pokemonId": 101,
+    "chainId": 44,
+    "evolvesFromId": 100,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "102": {
+    "pokemonId": 102,
+    "chainId": 45,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "103": {
+    "pokemonId": 103,
+    "chainId": 45,
+    "evolvesFromId": 102,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "104": {
+    "pokemonId": 104,
+    "chainId": 46,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "105": {
+    "pokemonId": 105,
+    "chainId": 46,
+    "evolvesFromId": 104,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "106": {
+    "pokemonId": 106,
+    "chainId": 47,
+    "evolvesFromId": 236,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "107": {
+    "pokemonId": 107,
+    "chainId": 47,
+    "evolvesFromId": 236,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "108": {
+    "pokemonId": 108,
+    "chainId": 48,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "109": {
+    "pokemonId": 109,
+    "chainId": 49,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "110": {
+    "pokemonId": 110,
+    "chainId": 49,
+    "evolvesFromId": 109,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "111": {
+    "pokemonId": 111,
+    "chainId": 50,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "112": {
+    "pokemonId": 112,
+    "chainId": 50,
+    "evolvesFromId": 111,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "113": {
+    "pokemonId": 113,
+    "chainId": 51,
+    "evolvesFromId": 440,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "oval-stone",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "114": {
+    "pokemonId": 114,
+    "chainId": 52,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "115": {
+    "pokemonId": 115,
+    "chainId": 53,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "116": {
+    "pokemonId": 116,
+    "chainId": 54,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "117": {
+    "pokemonId": 117,
+    "chainId": 54,
+    "evolvesFromId": 116,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "118": {
+    "pokemonId": 118,
+    "chainId": 55,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "119": {
+    "pokemonId": 119,
+    "chainId": 55,
+    "evolvesFromId": 118,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "120": {
+    "pokemonId": 120,
+    "chainId": 56,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "121": {
+    "pokemonId": 121,
+    "chainId": 56,
+    "evolvesFromId": 120,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "122": {
+    "pokemonId": 122,
+    "chainId": 57,
+    "evolvesFromId": 439,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "mimic",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "123": {
+    "pokemonId": 123,
+    "chainId": 58,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "124": {
+    "pokemonId": 124,
+    "chainId": 59,
+    "evolvesFromId": 238,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "125": {
+    "pokemonId": 125,
+    "chainId": 60,
+    "evolvesFromId": 239,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "126": {
+    "pokemonId": 126,
+    "chainId": 61,
+    "evolvesFromId": 240,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "127": {
+    "pokemonId": 127,
+    "chainId": 62,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "128": {
+    "pokemonId": 128,
+    "chainId": 63,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "129": {
+    "pokemonId": 129,
+    "chainId": 64,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "130": {
+    "pokemonId": 130,
+    "chainId": 64,
+    "evolvesFromId": 129,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "131": {
+    "pokemonId": 131,
+    "chainId": 65,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "132": {
+    "pokemonId": 132,
+    "chainId": 66,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "133": {
+    "pokemonId": 133,
+    "chainId": 67,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "134": {
+    "pokemonId": 134,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "135": {
+    "pokemonId": 135,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "136": {
+    "pokemonId": 136,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "fire-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "137": {
+    "pokemonId": 137,
+    "chainId": 68,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "138": {
+    "pokemonId": 138,
+    "chainId": 69,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "139": {
+    "pokemonId": 139,
+    "chainId": 69,
+    "evolvesFromId": 138,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "140": {
+    "pokemonId": 140,
+    "chainId": 70,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "141": {
+    "pokemonId": 141,
+    "chainId": 70,
+    "evolvesFromId": 140,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "142": {
+    "pokemonId": 142,
+    "chainId": 71,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "143": {
+    "pokemonId": 143,
+    "chainId": 72,
+    "evolvesFromId": 446,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "144": {
+    "pokemonId": 144,
+    "chainId": 73,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "145": {
+    "pokemonId": 145,
+    "chainId": 74,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "146": {
+    "pokemonId": 146,
+    "chainId": 75,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "147": {
+    "pokemonId": 147,
+    "chainId": 76,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "148": {
+    "pokemonId": 148,
+    "chainId": 76,
+    "evolvesFromId": 147,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "149": {
+    "pokemonId": 149,
+    "chainId": 76,
+    "evolvesFromId": 148,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 55,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "150": {
+    "pokemonId": 150,
+    "chainId": 77,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "151": {
+    "pokemonId": 151,
+    "chainId": 78,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "152": {
+    "pokemonId": 152,
+    "chainId": 79,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "153": {
+    "pokemonId": 153,
+    "chainId": 79,
+    "evolvesFromId": 152,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "154": {
+    "pokemonId": 154,
+    "chainId": 79,
+    "evolvesFromId": 153,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "155": {
+    "pokemonId": 155,
+    "chainId": 80,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "156": {
+    "pokemonId": 156,
+    "chainId": 80,
+    "evolvesFromId": 155,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "157": {
+    "pokemonId": 157,
+    "chainId": 80,
+    "evolvesFromId": 156,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "158": {
+    "pokemonId": 158,
+    "chainId": 81,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "159": {
+    "pokemonId": 159,
+    "chainId": 81,
+    "evolvesFromId": 158,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "160": {
+    "pokemonId": 160,
+    "chainId": 81,
+    "evolvesFromId": 159,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "161": {
+    "pokemonId": 161,
+    "chainId": 82,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "162": {
+    "pokemonId": 162,
+    "chainId": 82,
+    "evolvesFromId": 161,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "163": {
+    "pokemonId": 163,
+    "chainId": 83,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "164": {
+    "pokemonId": 164,
+    "chainId": 83,
+    "evolvesFromId": 163,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "165": {
+    "pokemonId": 165,
+    "chainId": 84,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "166": {
+    "pokemonId": 166,
+    "chainId": 84,
+    "evolvesFromId": 165,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "167": {
+    "pokemonId": 167,
+    "chainId": 85,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "168": {
+    "pokemonId": 168,
+    "chainId": 85,
+    "evolvesFromId": 167,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "169": {
+    "pokemonId": 169,
+    "chainId": 17,
+    "evolvesFromId": 42,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "170": {
+    "pokemonId": 170,
+    "chainId": 86,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "171": {
+    "pokemonId": 171,
+    "chainId": 86,
+    "evolvesFromId": 170,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 27,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "172": {
+    "pokemonId": 172,
+    "chainId": 10,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "173": {
+    "pokemonId": 173,
+    "chainId": 14,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "174": {
+    "pokemonId": 174,
+    "chainId": 16,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "175": {
+    "pokemonId": 175,
+    "chainId": 87,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "176": {
+    "pokemonId": 176,
+    "chainId": 87,
+    "evolvesFromId": 175,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "177": {
+    "pokemonId": 177,
+    "chainId": 88,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "178": {
+    "pokemonId": 178,
+    "chainId": 88,
+    "evolvesFromId": 177,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "179": {
+    "pokemonId": 179,
+    "chainId": 89,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "180": {
+    "pokemonId": 180,
+    "chainId": 89,
+    "evolvesFromId": 179,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "181": {
+    "pokemonId": 181,
+    "chainId": 89,
+    "evolvesFromId": 180,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "182": {
+    "pokemonId": 182,
+    "chainId": 18,
+    "evolvesFromId": 44,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sun-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "183": {
+    "pokemonId": 183,
+    "chainId": 90,
+    "evolvesFromId": 298,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "184": {
+    "pokemonId": 184,
+    "chainId": 90,
+    "evolvesFromId": 183,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "185": {
+    "pokemonId": 185,
+    "chainId": 91,
+    "evolvesFromId": 438,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "mimic",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "186": {
+    "pokemonId": 186,
+    "chainId": 26,
+    "evolvesFromId": 61,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "kings-rock",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "187": {
+    "pokemonId": 187,
+    "chainId": 92,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "188": {
+    "pokemonId": 188,
+    "chainId": 92,
+    "evolvesFromId": 187,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "189": {
+    "pokemonId": 189,
+    "chainId": 92,
+    "evolvesFromId": 188,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 27,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "190": {
+    "pokemonId": 190,
+    "chainId": 93,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "191": {
+    "pokemonId": 191,
+    "chainId": 94,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "192": {
+    "pokemonId": 192,
+    "chainId": 94,
+    "evolvesFromId": 191,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sun-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "193": {
+    "pokemonId": 193,
+    "chainId": 95,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "194": {
+    "pokemonId": 194,
+    "chainId": 96,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "195": {
+    "pokemonId": 195,
+    "chainId": 96,
+    "evolvesFromId": 194,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "196": {
+    "pokemonId": 196,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "197": {
+    "pokemonId": 197,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "198": {
+    "pokemonId": 198,
+    "chainId": 97,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "199": {
+    "pokemonId": 199,
+    "chainId": 33,
+    "evolvesFromId": 79,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "kings-rock",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "galarica-wreath",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "200": {
+    "pokemonId": 200,
+    "chainId": 98,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "201": {
+    "pokemonId": 201,
+    "chainId": 99,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "202": {
+    "pokemonId": 202,
+    "chainId": 100,
+    "evolvesFromId": 360,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "203": {
+    "pokemonId": 203,
+    "chainId": 101,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "204": {
+    "pokemonId": 204,
+    "chainId": 102,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "205": {
+    "pokemonId": 205,
+    "chainId": 102,
+    "evolvesFromId": 204,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 31,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "206": {
+    "pokemonId": 206,
+    "chainId": 103,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "207": {
+    "pokemonId": 207,
+    "chainId": 104,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "208": {
+    "pokemonId": 208,
+    "chainId": 41,
+    "evolvesFromId": 95,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "metal-coat",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "209": {
+    "pokemonId": 209,
+    "chainId": 105,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "210": {
+    "pokemonId": 210,
+    "chainId": 105,
+    "evolvesFromId": 209,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 23,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "211": {
+    "pokemonId": 211,
+    "chainId": 106,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "212": {
+    "pokemonId": 212,
+    "chainId": 58,
+    "evolvesFromId": 123,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "metal-coat",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "213": {
+    "pokemonId": 213,
+    "chainId": 107,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "214": {
+    "pokemonId": 214,
+    "chainId": 108,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "215": {
+    "pokemonId": 215,
+    "chainId": 109,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "216": {
+    "pokemonId": 216,
+    "chainId": 110,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "217": {
+    "pokemonId": 217,
+    "chainId": 110,
+    "evolvesFromId": 216,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "218": {
+    "pokemonId": 218,
+    "chainId": 111,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "219": {
+    "pokemonId": 219,
+    "chainId": 111,
+    "evolvesFromId": 218,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "220": {
+    "pokemonId": 220,
+    "chainId": 112,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "221": {
+    "pokemonId": 221,
+    "chainId": 112,
+    "evolvesFromId": 220,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "222": {
+    "pokemonId": 222,
+    "chainId": 113,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "223": {
+    "pokemonId": 223,
+    "chainId": 114,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "224": {
+    "pokemonId": 224,
+    "chainId": 114,
+    "evolvesFromId": 223,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "225": {
+    "pokemonId": 225,
+    "chainId": 115,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "226": {
+    "pokemonId": 226,
+    "chainId": 116,
+    "evolvesFromId": 458,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "227": {
+    "pokemonId": 227,
+    "chainId": 117,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "228": {
+    "pokemonId": 228,
+    "chainId": 118,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "229": {
+    "pokemonId": 229,
+    "chainId": 118,
+    "evolvesFromId": 228,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "230": {
+    "pokemonId": 230,
+    "chainId": 54,
+    "evolvesFromId": 117,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "dragon-scale",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "231": {
+    "pokemonId": 231,
+    "chainId": 119,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "232": {
+    "pokemonId": 232,
+    "chainId": 119,
+    "evolvesFromId": 231,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "233": {
+    "pokemonId": 233,
+    "chainId": 68,
+    "evolvesFromId": 137,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "up-grade",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "234": {
+    "pokemonId": 234,
+    "chainId": 120,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "235": {
+    "pokemonId": 235,
+    "chainId": 121,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "236": {
+    "pokemonId": 236,
+    "chainId": 47,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "237": {
+    "pokemonId": 237,
+    "chainId": 47,
+    "evolvesFromId": 236,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "238": {
+    "pokemonId": 238,
+    "chainId": 59,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "239": {
+    "pokemonId": 239,
+    "chainId": 60,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "240": {
+    "pokemonId": 240,
+    "chainId": 61,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "241": {
+    "pokemonId": 241,
+    "chainId": 122,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "242": {
+    "pokemonId": 242,
+    "chainId": 51,
+    "evolvesFromId": 113,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "243": {
+    "pokemonId": 243,
+    "chainId": 123,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "244": {
+    "pokemonId": 244,
+    "chainId": 124,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "245": {
+    "pokemonId": 245,
+    "chainId": 125,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "246": {
+    "pokemonId": 246,
+    "chainId": 126,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "247": {
+    "pokemonId": 247,
+    "chainId": 126,
+    "evolvesFromId": 246,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "248": {
+    "pokemonId": 248,
+    "chainId": 126,
+    "evolvesFromId": 247,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 55,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "249": {
+    "pokemonId": 249,
+    "chainId": 127,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "250": {
+    "pokemonId": 250,
+    "chainId": 128,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "251": {
+    "pokemonId": 251,
+    "chainId": 129,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "252": {
+    "pokemonId": 252,
+    "chainId": 130,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "253": {
+    "pokemonId": 253,
+    "chainId": 130,
+    "evolvesFromId": 252,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "254": {
+    "pokemonId": 254,
+    "chainId": 130,
+    "evolvesFromId": 253,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "255": {
+    "pokemonId": 255,
+    "chainId": 131,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "256": {
+    "pokemonId": 256,
+    "chainId": 131,
+    "evolvesFromId": 255,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "257": {
+    "pokemonId": 257,
+    "chainId": 131,
+    "evolvesFromId": 256,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "258": {
+    "pokemonId": 258,
+    "chainId": 132,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "259": {
+    "pokemonId": 259,
+    "chainId": 132,
+    "evolvesFromId": 258,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "260": {
+    "pokemonId": 260,
+    "chainId": 132,
+    "evolvesFromId": 259,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "261": {
+    "pokemonId": 261,
+    "chainId": 133,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "262": {
+    "pokemonId": 262,
+    "chainId": 133,
+    "evolvesFromId": 261,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "263": {
+    "pokemonId": 263,
+    "chainId": 134,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "264": {
+    "pokemonId": 264,
+    "chainId": 134,
+    "evolvesFromId": 263,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "265": {
+    "pokemonId": 265,
+    "chainId": 135,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "266": {
+    "pokemonId": 266,
+    "chainId": 135,
+    "evolvesFromId": 265,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 7,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "267": {
+    "pokemonId": 267,
+    "chainId": 135,
+    "evolvesFromId": 266,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "268": {
+    "pokemonId": 268,
+    "chainId": 135,
+    "evolvesFromId": 265,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 7,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "269": {
+    "pokemonId": 269,
+    "chainId": 135,
+    "evolvesFromId": 268,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "270": {
+    "pokemonId": 270,
+    "chainId": 136,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "271": {
+    "pokemonId": 271,
+    "chainId": 136,
+    "evolvesFromId": 270,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "272": {
+    "pokemonId": 272,
+    "chainId": 136,
+    "evolvesFromId": 271,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "273": {
+    "pokemonId": 273,
+    "chainId": 137,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "274": {
+    "pokemonId": 274,
+    "chainId": 137,
+    "evolvesFromId": 273,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "275": {
+    "pokemonId": 275,
+    "chainId": 137,
+    "evolvesFromId": 274,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "276": {
+    "pokemonId": 276,
+    "chainId": 138,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "277": {
+    "pokemonId": 277,
+    "chainId": 138,
+    "evolvesFromId": 276,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "278": {
+    "pokemonId": 278,
+    "chainId": 139,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "279": {
+    "pokemonId": 279,
+    "chainId": 139,
+    "evolvesFromId": 278,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "280": {
+    "pokemonId": 280,
+    "chainId": 140,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "281": {
+    "pokemonId": 281,
+    "chainId": 140,
+    "evolvesFromId": 280,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "282": {
+    "pokemonId": 282,
+    "chainId": 140,
+    "evolvesFromId": 281,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "283": {
+    "pokemonId": 283,
+    "chainId": 141,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "284": {
+    "pokemonId": 284,
+    "chainId": 141,
+    "evolvesFromId": 283,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "285": {
+    "pokemonId": 285,
+    "chainId": 142,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "286": {
+    "pokemonId": 286,
+    "chainId": 142,
+    "evolvesFromId": 285,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 23,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "287": {
+    "pokemonId": 287,
+    "chainId": 143,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "288": {
+    "pokemonId": 288,
+    "chainId": 143,
+    "evolvesFromId": 287,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "289": {
+    "pokemonId": 289,
+    "chainId": 143,
+    "evolvesFromId": 288,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "290": {
+    "pokemonId": 290,
+    "chainId": 144,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "291": {
+    "pokemonId": 291,
+    "chainId": 144,
+    "evolvesFromId": 290,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "292": {
+    "pokemonId": 292,
+    "chainId": 144,
+    "evolvesFromId": 290,
+    "triggers": [
+      {
+        "trigger": "shed",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "293": {
+    "pokemonId": 293,
+    "chainId": 145,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "294": {
+    "pokemonId": 294,
+    "chainId": 145,
+    "evolvesFromId": 293,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "295": {
+    "pokemonId": 295,
+    "chainId": 145,
+    "evolvesFromId": 294,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "296": {
+    "pokemonId": 296,
+    "chainId": 146,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "297": {
+    "pokemonId": 297,
+    "chainId": 146,
+    "evolvesFromId": 296,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "298": {
+    "pokemonId": 298,
+    "chainId": 90,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "299": {
+    "pokemonId": 299,
+    "chainId": 147,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "300": {
+    "pokemonId": 300,
+    "chainId": 148,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "301": {
+    "pokemonId": 301,
+    "chainId": 148,
+    "evolvesFromId": 300,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "302": {
+    "pokemonId": 302,
+    "chainId": 149,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "303": {
+    "pokemonId": 303,
+    "chainId": 150,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "304": {
+    "pokemonId": 304,
+    "chainId": 151,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "305": {
+    "pokemonId": 305,
+    "chainId": 151,
+    "evolvesFromId": 304,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "306": {
+    "pokemonId": 306,
+    "chainId": 151,
+    "evolvesFromId": 305,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "307": {
+    "pokemonId": 307,
+    "chainId": 152,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "308": {
+    "pokemonId": 308,
+    "chainId": 152,
+    "evolvesFromId": 307,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "309": {
+    "pokemonId": 309,
+    "chainId": 153,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "310": {
+    "pokemonId": 310,
+    "chainId": 153,
+    "evolvesFromId": 309,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "311": {
+    "pokemonId": 311,
+    "chainId": 154,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "312": {
+    "pokemonId": 312,
+    "chainId": 155,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "313": {
+    "pokemonId": 313,
+    "chainId": 156,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "314": {
+    "pokemonId": 314,
+    "chainId": 157,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "315": {
+    "pokemonId": 315,
+    "chainId": 158,
+    "evolvesFromId": 406,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "316": {
+    "pokemonId": 316,
+    "chainId": 159,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "317": {
+    "pokemonId": 317,
+    "chainId": 159,
+    "evolvesFromId": 316,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "318": {
+    "pokemonId": 318,
+    "chainId": 160,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "319": {
+    "pokemonId": 319,
+    "chainId": 160,
+    "evolvesFromId": 318,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "320": {
+    "pokemonId": 320,
+    "chainId": 161,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "321": {
+    "pokemonId": 321,
+    "chainId": 161,
+    "evolvesFromId": 320,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "322": {
+    "pokemonId": 322,
+    "chainId": 162,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "323": {
+    "pokemonId": 323,
+    "chainId": 162,
+    "evolvesFromId": 322,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "324": {
+    "pokemonId": 324,
+    "chainId": 163,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "325": {
+    "pokemonId": 325,
+    "chainId": 164,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "326": {
+    "pokemonId": 326,
+    "chainId": 164,
+    "evolvesFromId": 325,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "327": {
+    "pokemonId": 327,
+    "chainId": 165,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "328": {
+    "pokemonId": 328,
+    "chainId": 166,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "329": {
+    "pokemonId": 329,
+    "chainId": 166,
+    "evolvesFromId": 328,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "330": {
+    "pokemonId": 330,
+    "chainId": 166,
+    "evolvesFromId": 329,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 45,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "331": {
+    "pokemonId": 331,
+    "chainId": 167,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "332": {
+    "pokemonId": 332,
+    "chainId": 167,
+    "evolvesFromId": 331,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "333": {
+    "pokemonId": 333,
+    "chainId": 168,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "334": {
+    "pokemonId": 334,
+    "chainId": 168,
+    "evolvesFromId": 333,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "335": {
+    "pokemonId": 335,
+    "chainId": 169,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "336": {
+    "pokemonId": 336,
+    "chainId": 170,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "337": {
+    "pokemonId": 337,
+    "chainId": 171,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "338": {
+    "pokemonId": 338,
+    "chainId": 172,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "339": {
+    "pokemonId": 339,
+    "chainId": 173,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "340": {
+    "pokemonId": 340,
+    "chainId": 173,
+    "evolvesFromId": 339,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "341": {
+    "pokemonId": 341,
+    "chainId": 174,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "342": {
+    "pokemonId": 342,
+    "chainId": 174,
+    "evolvesFromId": 341,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "343": {
+    "pokemonId": 343,
+    "chainId": 175,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "344": {
+    "pokemonId": 344,
+    "chainId": 175,
+    "evolvesFromId": 343,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "345": {
+    "pokemonId": 345,
+    "chainId": 176,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "346": {
+    "pokemonId": 346,
+    "chainId": 176,
+    "evolvesFromId": 345,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "347": {
+    "pokemonId": 347,
+    "chainId": 177,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "348": {
+    "pokemonId": 348,
+    "chainId": 177,
+    "evolvesFromId": 347,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "349": {
+    "pokemonId": 349,
+    "chainId": 178,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "350": {
+    "pokemonId": 350,
+    "chainId": 178,
+    "evolvesFromId": 349,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "prism-scale",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "351": {
+    "pokemonId": 351,
+    "chainId": 179,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "352": {
+    "pokemonId": 352,
+    "chainId": 180,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "353": {
+    "pokemonId": 353,
+    "chainId": 181,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "354": {
+    "pokemonId": 354,
+    "chainId": 181,
+    "evolvesFromId": 353,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "355": {
+    "pokemonId": 355,
+    "chainId": 182,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "356": {
+    "pokemonId": 356,
+    "chainId": 182,
+    "evolvesFromId": 355,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "357": {
+    "pokemonId": 357,
+    "chainId": 183,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "358": {
+    "pokemonId": 358,
+    "chainId": 184,
+    "evolvesFromId": 433,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 220,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "359": {
+    "pokemonId": 359,
+    "chainId": 185,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "360": {
+    "pokemonId": 360,
+    "chainId": 100,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "361": {
+    "pokemonId": 361,
+    "chainId": 186,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "362": {
+    "pokemonId": 362,
+    "chainId": 186,
+    "evolvesFromId": 361,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "363": {
+    "pokemonId": 363,
+    "chainId": 187,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "364": {
+    "pokemonId": 364,
+    "chainId": 187,
+    "evolvesFromId": 363,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "365": {
+    "pokemonId": 365,
+    "chainId": 187,
+    "evolvesFromId": 364,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 44,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "366": {
+    "pokemonId": 366,
+    "chainId": 188,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "367": {
+    "pokemonId": 367,
+    "chainId": 188,
+    "evolvesFromId": 366,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "deep-sea-tooth",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "368": {
+    "pokemonId": 368,
+    "chainId": 188,
+    "evolvesFromId": 366,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "deep-sea-scale",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "369": {
+    "pokemonId": 369,
+    "chainId": 189,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "370": {
+    "pokemonId": 370,
+    "chainId": 190,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "371": {
+    "pokemonId": 371,
+    "chainId": 191,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "372": {
+    "pokemonId": 372,
+    "chainId": 191,
+    "evolvesFromId": 371,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "373": {
+    "pokemonId": 373,
+    "chainId": 191,
+    "evolvesFromId": 372,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 50,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "374": {
+    "pokemonId": 374,
+    "chainId": 192,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "375": {
+    "pokemonId": 375,
+    "chainId": 192,
+    "evolvesFromId": 374,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "376": {
+    "pokemonId": 376,
+    "chainId": 192,
+    "evolvesFromId": 375,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 45,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "377": {
+    "pokemonId": 377,
+    "chainId": 193,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "378": {
+    "pokemonId": 378,
+    "chainId": 194,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "379": {
+    "pokemonId": 379,
+    "chainId": 195,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "380": {
+    "pokemonId": 380,
+    "chainId": 196,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "381": {
+    "pokemonId": 381,
+    "chainId": 197,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "382": {
+    "pokemonId": 382,
+    "chainId": 198,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "383": {
+    "pokemonId": 383,
+    "chainId": 199,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "384": {
+    "pokemonId": 384,
+    "chainId": 200,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "385": {
+    "pokemonId": 385,
+    "chainId": 201,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "386": {
+    "pokemonId": 386,
+    "chainId": 202,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "387": {
+    "pokemonId": 387,
+    "chainId": 203,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "388": {
+    "pokemonId": 388,
+    "chainId": 203,
+    "evolvesFromId": 387,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "389": {
+    "pokemonId": 389,
+    "chainId": 203,
+    "evolvesFromId": 388,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "390": {
+    "pokemonId": 390,
+    "chainId": 204,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "391": {
+    "pokemonId": 391,
+    "chainId": 204,
+    "evolvesFromId": 390,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "392": {
+    "pokemonId": 392,
+    "chainId": 204,
+    "evolvesFromId": 391,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "393": {
+    "pokemonId": 393,
+    "chainId": 205,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "394": {
+    "pokemonId": 394,
+    "chainId": 205,
+    "evolvesFromId": 393,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "395": {
+    "pokemonId": 395,
+    "chainId": 205,
+    "evolvesFromId": 394,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "396": {
+    "pokemonId": 396,
+    "chainId": 206,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "397": {
+    "pokemonId": 397,
+    "chainId": 206,
+    "evolvesFromId": 396,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "398": {
+    "pokemonId": 398,
+    "chainId": 206,
+    "evolvesFromId": 397,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "399": {
+    "pokemonId": 399,
+    "chainId": 207,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "400": {
+    "pokemonId": 400,
+    "chainId": 207,
+    "evolvesFromId": 399,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "401": {
+    "pokemonId": 401,
+    "chainId": 208,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "402": {
+    "pokemonId": 402,
+    "chainId": 208,
+    "evolvesFromId": 401,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "403": {
+    "pokemonId": 403,
+    "chainId": 209,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "404": {
+    "pokemonId": 404,
+    "chainId": 209,
+    "evolvesFromId": 403,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "405": {
+    "pokemonId": 405,
+    "chainId": 209,
+    "evolvesFromId": 404,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "406": {
+    "pokemonId": 406,
+    "chainId": 158,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "407": {
+    "pokemonId": 407,
+    "chainId": 158,
+    "evolvesFromId": 315,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "shiny-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "408": {
+    "pokemonId": 408,
+    "chainId": 211,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "409": {
+    "pokemonId": 409,
+    "chainId": 211,
+    "evolvesFromId": 408,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "410": {
+    "pokemonId": 410,
+    "chainId": 212,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "411": {
+    "pokemonId": 411,
+    "chainId": 212,
+    "evolvesFromId": 410,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "412": {
+    "pokemonId": 412,
+    "chainId": 213,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "413": {
+    "pokemonId": 413,
+    "chainId": 213,
+    "evolvesFromId": 412,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "414": {
+    "pokemonId": 414,
+    "chainId": 213,
+    "evolvesFromId": 412,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "415": {
+    "pokemonId": 415,
+    "chainId": 214,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "416": {
+    "pokemonId": 416,
+    "chainId": 214,
+    "evolvesFromId": 415,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 21,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "417": {
+    "pokemonId": 417,
+    "chainId": 215,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "418": {
+    "pokemonId": 418,
+    "chainId": 216,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "419": {
+    "pokemonId": 419,
+    "chainId": 216,
+    "evolvesFromId": 418,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "420": {
+    "pokemonId": 420,
+    "chainId": 217,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "421": {
+    "pokemonId": 421,
+    "chainId": 217,
+    "evolvesFromId": 420,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "422": {
+    "pokemonId": 422,
+    "chainId": 218,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "423": {
+    "pokemonId": 423,
+    "chainId": 218,
+    "evolvesFromId": 422,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "424": {
+    "pokemonId": 424,
+    "chainId": 93,
+    "evolvesFromId": 190,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "double-hit",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "425": {
+    "pokemonId": 425,
+    "chainId": 219,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "426": {
+    "pokemonId": 426,
+    "chainId": 219,
+    "evolvesFromId": 425,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "427": {
+    "pokemonId": 427,
+    "chainId": 220,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "428": {
+    "pokemonId": 428,
+    "chainId": 220,
+    "evolvesFromId": 427,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "429": {
+    "pokemonId": 429,
+    "chainId": 98,
+    "evolvesFromId": 200,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dusk-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "430": {
+    "pokemonId": 430,
+    "chainId": 97,
+    "evolvesFromId": 198,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dusk-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "431": {
+    "pokemonId": 431,
+    "chainId": 221,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "432": {
+    "pokemonId": 432,
+    "chainId": 221,
+    "evolvesFromId": 431,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "433": {
+    "pokemonId": 433,
+    "chainId": 184,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "434": {
+    "pokemonId": 434,
+    "chainId": 223,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "435": {
+    "pokemonId": 435,
+    "chainId": 223,
+    "evolvesFromId": 434,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "436": {
+    "pokemonId": 436,
+    "chainId": 224,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "437": {
+    "pokemonId": 437,
+    "chainId": 224,
+    "evolvesFromId": 436,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "438": {
+    "pokemonId": 438,
+    "chainId": 91,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "439": {
+    "pokemonId": 439,
+    "chainId": 57,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "440": {
+    "pokemonId": 440,
+    "chainId": 51,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "441": {
+    "pokemonId": 441,
+    "chainId": 228,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "442": {
+    "pokemonId": 442,
+    "chainId": 229,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "443": {
+    "pokemonId": 443,
+    "chainId": 230,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "444": {
+    "pokemonId": 444,
+    "chainId": 230,
+    "evolvesFromId": 443,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "445": {
+    "pokemonId": 445,
+    "chainId": 230,
+    "evolvesFromId": 444,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 48,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "446": {
+    "pokemonId": 446,
+    "chainId": 72,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "447": {
+    "pokemonId": 447,
+    "chainId": 232,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "448": {
+    "pokemonId": 448,
+    "chainId": 232,
+    "evolvesFromId": 447,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "449": {
+    "pokemonId": 449,
+    "chainId": 233,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "450": {
+    "pokemonId": 450,
+    "chainId": 233,
+    "evolvesFromId": 449,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "451": {
+    "pokemonId": 451,
+    "chainId": 234,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "452": {
+    "pokemonId": 452,
+    "chainId": 234,
+    "evolvesFromId": 451,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "453": {
+    "pokemonId": 453,
+    "chainId": 235,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "454": {
+    "pokemonId": 454,
+    "chainId": 235,
+    "evolvesFromId": 453,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "455": {
+    "pokemonId": 455,
+    "chainId": 236,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "456": {
+    "pokemonId": 456,
+    "chainId": 237,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "457": {
+    "pokemonId": 457,
+    "chainId": 237,
+    "evolvesFromId": 456,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 31,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "458": {
+    "pokemonId": 458,
+    "chainId": 116,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "459": {
+    "pokemonId": 459,
+    "chainId": 239,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "460": {
+    "pokemonId": 460,
+    "chainId": 239,
+    "evolvesFromId": 459,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "461": {
+    "pokemonId": 461,
+    "chainId": 109,
+    "evolvesFromId": 215,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "razor-claw",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "462": {
+    "pokemonId": 462,
+    "chainId": 34,
+    "evolvesFromId": 82,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "mt-coronet",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "chargestone-cave",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "kalos-route-13",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "blush-mountain",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "vast-poni-canyon",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "463": {
+    "pokemonId": 463,
+    "chainId": 48,
+    "evolvesFromId": 108,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "rollout",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "464": {
+    "pokemonId": 464,
+    "chainId": 50,
+    "evolvesFromId": 112,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "protector",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "465": {
+    "pokemonId": 465,
+    "chainId": 52,
+    "evolvesFromId": 114,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "ancient-power",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "466": {
+    "pokemonId": 466,
+    "chainId": 60,
+    "evolvesFromId": 125,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "electirizer",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "467": {
+    "pokemonId": 467,
+    "chainId": 61,
+    "evolvesFromId": 126,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "magmarizer",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "468": {
+    "pokemonId": 468,
+    "chainId": 87,
+    "evolvesFromId": 176,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "shiny-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "469": {
+    "pokemonId": 469,
+    "chainId": 95,
+    "evolvesFromId": 193,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "ancient-power",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "470": {
+    "pokemonId": 470,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "eterna-forest",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "pinwheel-forest",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "kalos-route-20",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "471": {
+    "pokemonId": 471,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "sinnoh-route-217",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "twist-mountain",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "frost-cavern",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "472": {
+    "pokemonId": 472,
+    "chainId": 104,
+    "evolvesFromId": 207,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "razor-fang",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "473": {
+    "pokemonId": 473,
+    "chainId": 112,
+    "evolvesFromId": 221,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "ancient-power",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "474": {
+    "pokemonId": 474,
+    "chainId": 68,
+    "evolvesFromId": 233,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "dubious-disc",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "475": {
+    "pokemonId": 475,
+    "chainId": 140,
+    "evolvesFromId": 281,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dawn-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "476": {
+    "pokemonId": 476,
+    "chainId": 147,
+    "evolvesFromId": 299,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "mt-coronet",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "chargestone-cave",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "kalos-route-13",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "blush-mountain",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "vast-poni-canyon",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "477": {
+    "pokemonId": 477,
+    "chainId": 182,
+    "evolvesFromId": 356,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "reaper-cloth",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "478": {
+    "pokemonId": 478,
+    "chainId": 186,
+    "evolvesFromId": 361,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dawn-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "479": {
+    "pokemonId": 479,
+    "chainId": 240,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "480": {
+    "pokemonId": 480,
+    "chainId": 241,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "481": {
+    "pokemonId": 481,
+    "chainId": 242,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "482": {
+    "pokemonId": 482,
+    "chainId": 243,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "483": {
+    "pokemonId": 483,
+    "chainId": 244,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "484": {
+    "pokemonId": 484,
+    "chainId": 245,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "485": {
+    "pokemonId": 485,
+    "chainId": 246,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "486": {
+    "pokemonId": 486,
+    "chainId": 247,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "487": {
+    "pokemonId": 487,
+    "chainId": 248,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "488": {
+    "pokemonId": 488,
+    "chainId": 249,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "489": {
+    "pokemonId": 489,
+    "chainId": 250,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "490": {
+    "pokemonId": 490,
+    "chainId": 250,
+    "evolvesFromId": 489,
+    "triggers": []
+  },
+  "491": {
+    "pokemonId": 491,
+    "chainId": 252,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "492": {
+    "pokemonId": 492,
+    "chainId": 253,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "493": {
+    "pokemonId": 493,
+    "chainId": 254,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "494": {
+    "pokemonId": 494,
+    "chainId": 255,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "495": {
+    "pokemonId": 495,
+    "chainId": 256,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "496": {
+    "pokemonId": 496,
+    "chainId": 256,
+    "evolvesFromId": 495,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "497": {
+    "pokemonId": 497,
+    "chainId": 256,
+    "evolvesFromId": 496,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "498": {
+    "pokemonId": 498,
+    "chainId": 257,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "499": {
+    "pokemonId": 499,
+    "chainId": 257,
+    "evolvesFromId": 498,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "500": {
+    "pokemonId": 500,
+    "chainId": 257,
+    "evolvesFromId": 499,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "501": {
+    "pokemonId": 501,
+    "chainId": 258,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "502": {
+    "pokemonId": 502,
+    "chainId": 258,
+    "evolvesFromId": 501,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "503": {
+    "pokemonId": 503,
+    "chainId": 258,
+    "evolvesFromId": 502,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "504": {
+    "pokemonId": 504,
+    "chainId": 259,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "505": {
+    "pokemonId": 505,
+    "chainId": 259,
+    "evolvesFromId": 504,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "506": {
+    "pokemonId": 506,
+    "chainId": 260,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "507": {
+    "pokemonId": 507,
+    "chainId": 260,
+    "evolvesFromId": 506,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "508": {
+    "pokemonId": 508,
+    "chainId": 260,
+    "evolvesFromId": 507,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "509": {
+    "pokemonId": 509,
+    "chainId": 261,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "510": {
+    "pokemonId": 510,
+    "chainId": 261,
+    "evolvesFromId": 509,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "511": {
+    "pokemonId": 511,
+    "chainId": 262,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "512": {
+    "pokemonId": 512,
+    "chainId": 262,
+    "evolvesFromId": 511,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "leaf-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "513": {
+    "pokemonId": 513,
+    "chainId": 263,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "514": {
+    "pokemonId": 514,
+    "chainId": 263,
+    "evolvesFromId": 513,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "fire-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "515": {
+    "pokemonId": 515,
+    "chainId": 264,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "516": {
+    "pokemonId": 516,
+    "chainId": 264,
+    "evolvesFromId": 515,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "water-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "517": {
+    "pokemonId": 517,
+    "chainId": 265,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "518": {
+    "pokemonId": 518,
+    "chainId": 265,
+    "evolvesFromId": 517,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "moon-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "519": {
+    "pokemonId": 519,
+    "chainId": 266,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "520": {
+    "pokemonId": 520,
+    "chainId": 266,
+    "evolvesFromId": 519,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 21,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "521": {
+    "pokemonId": 521,
+    "chainId": 266,
+    "evolvesFromId": 520,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "522": {
+    "pokemonId": 522,
+    "chainId": 267,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "523": {
+    "pokemonId": 523,
+    "chainId": 267,
+    "evolvesFromId": 522,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 27,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "524": {
+    "pokemonId": 524,
+    "chainId": 268,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "525": {
+    "pokemonId": 525,
+    "chainId": 268,
+    "evolvesFromId": 524,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "526": {
+    "pokemonId": 526,
+    "chainId": 268,
+    "evolvesFromId": 525,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "527": {
+    "pokemonId": 527,
+    "chainId": 269,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "528": {
+    "pokemonId": 528,
+    "chainId": 269,
+    "evolvesFromId": 527,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "529": {
+    "pokemonId": 529,
+    "chainId": 270,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "530": {
+    "pokemonId": 530,
+    "chainId": 270,
+    "evolvesFromId": 529,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 31,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "531": {
+    "pokemonId": 531,
+    "chainId": 271,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "532": {
+    "pokemonId": 532,
+    "chainId": 272,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "533": {
+    "pokemonId": 533,
+    "chainId": 272,
+    "evolvesFromId": 532,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "534": {
+    "pokemonId": 534,
+    "chainId": 272,
+    "evolvesFromId": 533,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "535": {
+    "pokemonId": 535,
+    "chainId": 273,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "536": {
+    "pokemonId": 536,
+    "chainId": 273,
+    "evolvesFromId": 535,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "537": {
+    "pokemonId": 537,
+    "chainId": 273,
+    "evolvesFromId": 536,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "538": {
+    "pokemonId": 538,
+    "chainId": 274,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "539": {
+    "pokemonId": 539,
+    "chainId": 275,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "540": {
+    "pokemonId": 540,
+    "chainId": 276,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "541": {
+    "pokemonId": 541,
+    "chainId": 276,
+    "evolvesFromId": 540,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "542": {
+    "pokemonId": 542,
+    "chainId": 276,
+    "evolvesFromId": 541,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 220,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "543": {
+    "pokemonId": 543,
+    "chainId": 277,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "544": {
+    "pokemonId": 544,
+    "chainId": 277,
+    "evolvesFromId": 543,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "545": {
+    "pokemonId": 545,
+    "chainId": 277,
+    "evolvesFromId": 544,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "546": {
+    "pokemonId": 546,
+    "chainId": 278,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "547": {
+    "pokemonId": 547,
+    "chainId": 278,
+    "evolvesFromId": 546,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sun-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "548": {
+    "pokemonId": 548,
+    "chainId": 279,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "549": {
+    "pokemonId": 549,
+    "chainId": 279,
+    "evolvesFromId": 548,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sun-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "550": {
+    "pokemonId": 550,
+    "chainId": 280,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "551": {
+    "pokemonId": 551,
+    "chainId": 281,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "552": {
+    "pokemonId": 552,
+    "chainId": 281,
+    "evolvesFromId": 551,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 29,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "553": {
+    "pokemonId": 553,
+    "chainId": 281,
+    "evolvesFromId": 552,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "554": {
+    "pokemonId": 554,
+    "chainId": 282,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "555": {
+    "pokemonId": 555,
+    "chainId": 282,
+    "evolvesFromId": 554,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "556": {
+    "pokemonId": 556,
+    "chainId": 283,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "557": {
+    "pokemonId": 557,
+    "chainId": 284,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "558": {
+    "pokemonId": 558,
+    "chainId": 284,
+    "evolvesFromId": 557,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "559": {
+    "pokemonId": 559,
+    "chainId": 285,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "560": {
+    "pokemonId": 560,
+    "chainId": 285,
+    "evolvesFromId": 559,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "561": {
+    "pokemonId": 561,
+    "chainId": 286,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "562": {
+    "pokemonId": 562,
+    "chainId": 287,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "563": {
+    "pokemonId": 563,
+    "chainId": 287,
+    "evolvesFromId": 562,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "564": {
+    "pokemonId": 564,
+    "chainId": 288,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "565": {
+    "pokemonId": 565,
+    "chainId": 288,
+    "evolvesFromId": 564,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "566": {
+    "pokemonId": 566,
+    "chainId": 289,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "567": {
+    "pokemonId": 567,
+    "chainId": 289,
+    "evolvesFromId": 566,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "568": {
+    "pokemonId": 568,
+    "chainId": 290,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "569": {
+    "pokemonId": 569,
+    "chainId": 290,
+    "evolvesFromId": 568,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "570": {
+    "pokemonId": 570,
+    "chainId": 291,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "571": {
+    "pokemonId": 571,
+    "chainId": 291,
+    "evolvesFromId": 570,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "572": {
+    "pokemonId": 572,
+    "chainId": 292,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "573": {
+    "pokemonId": 573,
+    "chainId": 292,
+    "evolvesFromId": 572,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "shiny-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "574": {
+    "pokemonId": 574,
+    "chainId": 293,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "575": {
+    "pokemonId": 575,
+    "chainId": 293,
+    "evolvesFromId": 574,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "576": {
+    "pokemonId": 576,
+    "chainId": 293,
+    "evolvesFromId": 575,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 41,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "577": {
+    "pokemonId": 577,
+    "chainId": 294,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "578": {
+    "pokemonId": 578,
+    "chainId": 294,
+    "evolvesFromId": 577,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "579": {
+    "pokemonId": 579,
+    "chainId": 294,
+    "evolvesFromId": 578,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 41,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "580": {
+    "pokemonId": 580,
+    "chainId": 295,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "581": {
+    "pokemonId": 581,
+    "chainId": 295,
+    "evolvesFromId": 580,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "582": {
+    "pokemonId": 582,
+    "chainId": 296,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "583": {
+    "pokemonId": 583,
+    "chainId": 296,
+    "evolvesFromId": 582,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "584": {
+    "pokemonId": 584,
+    "chainId": 296,
+    "evolvesFromId": 583,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 47,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "585": {
+    "pokemonId": 585,
+    "chainId": 297,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "586": {
+    "pokemonId": 586,
+    "chainId": 297,
+    "evolvesFromId": 585,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "587": {
+    "pokemonId": 587,
+    "chainId": 298,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "588": {
+    "pokemonId": 588,
+    "chainId": 299,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "589": {
+    "pokemonId": 589,
+    "chainId": 299,
+    "evolvesFromId": 588,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": "shelmet"
+      }
+    ]
+  },
+  "590": {
+    "pokemonId": 590,
+    "chainId": 300,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "591": {
+    "pokemonId": 591,
+    "chainId": 300,
+    "evolvesFromId": 590,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "592": {
+    "pokemonId": 592,
+    "chainId": 301,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "593": {
+    "pokemonId": 593,
+    "chainId": 301,
+    "evolvesFromId": 592,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "594": {
+    "pokemonId": 594,
+    "chainId": 302,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "595": {
+    "pokemonId": 595,
+    "chainId": 303,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "596": {
+    "pokemonId": 596,
+    "chainId": 303,
+    "evolvesFromId": 595,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "597": {
+    "pokemonId": 597,
+    "chainId": 304,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "598": {
+    "pokemonId": 598,
+    "chainId": 304,
+    "evolvesFromId": 597,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "599": {
+    "pokemonId": 599,
+    "chainId": 305,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "600": {
+    "pokemonId": 600,
+    "chainId": 305,
+    "evolvesFromId": 599,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "601": {
+    "pokemonId": 601,
+    "chainId": 305,
+    "evolvesFromId": 600,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 49,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "602": {
+    "pokemonId": 602,
+    "chainId": 306,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "603": {
+    "pokemonId": 603,
+    "chainId": 306,
+    "evolvesFromId": 602,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "604": {
+    "pokemonId": 604,
+    "chainId": 306,
+    "evolvesFromId": 603,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "605": {
+    "pokemonId": 605,
+    "chainId": 307,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "606": {
+    "pokemonId": 606,
+    "chainId": 307,
+    "evolvesFromId": 605,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "607": {
+    "pokemonId": 607,
+    "chainId": 308,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "608": {
+    "pokemonId": 608,
+    "chainId": 308,
+    "evolvesFromId": 607,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 41,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "609": {
+    "pokemonId": 609,
+    "chainId": 308,
+    "evolvesFromId": 608,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dusk-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "610": {
+    "pokemonId": 610,
+    "chainId": 309,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "611": {
+    "pokemonId": 611,
+    "chainId": 309,
+    "evolvesFromId": 610,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "612": {
+    "pokemonId": 612,
+    "chainId": 309,
+    "evolvesFromId": 611,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 48,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "613": {
+    "pokemonId": 613,
+    "chainId": 310,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "614": {
+    "pokemonId": 614,
+    "chainId": 310,
+    "evolvesFromId": 613,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "615": {
+    "pokemonId": 615,
+    "chainId": 311,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "616": {
+    "pokemonId": 616,
+    "chainId": 312,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "617": {
+    "pokemonId": 617,
+    "chainId": 312,
+    "evolvesFromId": 616,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": "karrablast"
+      }
+    ]
+  },
+  "618": {
+    "pokemonId": 618,
+    "chainId": 313,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "619": {
+    "pokemonId": 619,
+    "chainId": 314,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "620": {
+    "pokemonId": 620,
+    "chainId": 314,
+    "evolvesFromId": 619,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 50,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "621": {
+    "pokemonId": 621,
+    "chainId": 315,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "622": {
+    "pokemonId": 622,
+    "chainId": 316,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "623": {
+    "pokemonId": 623,
+    "chainId": 316,
+    "evolvesFromId": 622,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 43,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "624": {
+    "pokemonId": 624,
+    "chainId": 317,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "625": {
+    "pokemonId": 625,
+    "chainId": 317,
+    "evolvesFromId": 624,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 52,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "626": {
+    "pokemonId": 626,
+    "chainId": 318,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "627": {
+    "pokemonId": 627,
+    "chainId": 319,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "628": {
+    "pokemonId": 628,
+    "chainId": 319,
+    "evolvesFromId": 627,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 54,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "629": {
+    "pokemonId": 629,
+    "chainId": 320,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "630": {
+    "pokemonId": 630,
+    "chainId": 320,
+    "evolvesFromId": 629,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 54,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "631": {
+    "pokemonId": 631,
+    "chainId": 321,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "632": {
+    "pokemonId": 632,
+    "chainId": 322,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "633": {
+    "pokemonId": 633,
+    "chainId": 323,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "634": {
+    "pokemonId": 634,
+    "chainId": 323,
+    "evolvesFromId": 633,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 50,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "635": {
+    "pokemonId": 635,
+    "chainId": 323,
+    "evolvesFromId": 634,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 64,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "636": {
+    "pokemonId": 636,
+    "chainId": 324,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "637": {
+    "pokemonId": 637,
+    "chainId": 324,
+    "evolvesFromId": 636,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 59,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "638": {
+    "pokemonId": 638,
+    "chainId": 325,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "639": {
+    "pokemonId": 639,
+    "chainId": 326,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "640": {
+    "pokemonId": 640,
+    "chainId": 327,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "641": {
+    "pokemonId": 641,
+    "chainId": 328,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "642": {
+    "pokemonId": 642,
+    "chainId": 329,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "643": {
+    "pokemonId": 643,
+    "chainId": 330,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "644": {
+    "pokemonId": 644,
+    "chainId": 331,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "645": {
+    "pokemonId": 645,
+    "chainId": 332,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "646": {
+    "pokemonId": 646,
+    "chainId": 333,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "647": {
+    "pokemonId": 647,
+    "chainId": 334,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "648": {
+    "pokemonId": 648,
+    "chainId": 335,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "649": {
+    "pokemonId": 649,
+    "chainId": 336,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "650": {
+    "pokemonId": 650,
+    "chainId": 337,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "651": {
+    "pokemonId": 651,
+    "chainId": 337,
+    "evolvesFromId": 650,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "652": {
+    "pokemonId": 652,
+    "chainId": 337,
+    "evolvesFromId": 651,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "653": {
+    "pokemonId": 653,
+    "chainId": 338,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "654": {
+    "pokemonId": 654,
+    "chainId": 338,
+    "evolvesFromId": 653,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "655": {
+    "pokemonId": 655,
+    "chainId": 338,
+    "evolvesFromId": 654,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "656": {
+    "pokemonId": 656,
+    "chainId": 339,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "657": {
+    "pokemonId": 657,
+    "chainId": 339,
+    "evolvesFromId": 656,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "658": {
+    "pokemonId": 658,
+    "chainId": 339,
+    "evolvesFromId": 657,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "659": {
+    "pokemonId": 659,
+    "chainId": 340,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "660": {
+    "pokemonId": 660,
+    "chainId": 340,
+    "evolvesFromId": 659,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "661": {
+    "pokemonId": 661,
+    "chainId": 341,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "662": {
+    "pokemonId": 662,
+    "chainId": 341,
+    "evolvesFromId": 661,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "663": {
+    "pokemonId": 663,
+    "chainId": 341,
+    "evolvesFromId": 662,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "664": {
+    "pokemonId": 664,
+    "chainId": 342,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "665": {
+    "pokemonId": 665,
+    "chainId": 342,
+    "evolvesFromId": 664,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 9,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "666": {
+    "pokemonId": 666,
+    "chainId": 342,
+    "evolvesFromId": 665,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 12,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "667": {
+    "pokemonId": 667,
+    "chainId": 343,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "668": {
+    "pokemonId": 668,
+    "chainId": 343,
+    "evolvesFromId": 667,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "669": {
+    "pokemonId": 669,
+    "chainId": 344,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "670": {
+    "pokemonId": 670,
+    "chainId": 344,
+    "evolvesFromId": 669,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 19,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "671": {
+    "pokemonId": 671,
+    "chainId": 344,
+    "evolvesFromId": 670,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "shiny-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "672": {
+    "pokemonId": 672,
+    "chainId": 345,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "673": {
+    "pokemonId": 673,
+    "chainId": 345,
+    "evolvesFromId": 672,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "674": {
+    "pokemonId": 674,
+    "chainId": 346,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "675": {
+    "pokemonId": 675,
+    "chainId": 346,
+    "evolvesFromId": 674,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "676": {
+    "pokemonId": 676,
+    "chainId": 347,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "677": {
+    "pokemonId": 677,
+    "chainId": 348,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "678": {
+    "pokemonId": 678,
+    "chainId": 348,
+    "evolvesFromId": 677,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "679": {
+    "pokemonId": 679,
+    "chainId": 349,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "680": {
+    "pokemonId": 680,
+    "chainId": 349,
+    "evolvesFromId": 679,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "681": {
+    "pokemonId": 681,
+    "chainId": 349,
+    "evolvesFromId": 680,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "dusk-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "682": {
+    "pokemonId": 682,
+    "chainId": 350,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "683": {
+    "pokemonId": 683,
+    "chainId": 350,
+    "evolvesFromId": 682,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "sachet",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "684": {
+    "pokemonId": 684,
+    "chainId": 351,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "685": {
+    "pokemonId": 685,
+    "chainId": 351,
+    "evolvesFromId": 684,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "whipped-dream",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "686": {
+    "pokemonId": 686,
+    "chainId": 352,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "687": {
+    "pokemonId": 687,
+    "chainId": 352,
+    "evolvesFromId": 686,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "688": {
+    "pokemonId": 688,
+    "chainId": 353,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "689": {
+    "pokemonId": 689,
+    "chainId": 353,
+    "evolvesFromId": 688,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "690": {
+    "pokemonId": 690,
+    "chainId": 354,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "691": {
+    "pokemonId": 691,
+    "chainId": 354,
+    "evolvesFromId": 690,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 48,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "692": {
+    "pokemonId": 692,
+    "chainId": 355,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "693": {
+    "pokemonId": 693,
+    "chainId": 355,
+    "evolvesFromId": 692,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "694": {
+    "pokemonId": 694,
+    "chainId": 356,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "695": {
+    "pokemonId": 695,
+    "chainId": 356,
+    "evolvesFromId": 694,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sun-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "696": {
+    "pokemonId": 696,
+    "chainId": 357,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "697": {
+    "pokemonId": 697,
+    "chainId": 357,
+    "evolvesFromId": 696,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "698": {
+    "pokemonId": 698,
+    "chainId": 358,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "699": {
+    "pokemonId": 699,
+    "chainId": 358,
+    "evolvesFromId": 698,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 39,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "700": {
+    "pokemonId": 700,
+    "chainId": 67,
+    "evolvesFromId": 133,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "701": {
+    "pokemonId": 701,
+    "chainId": 359,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "702": {
+    "pokemonId": 702,
+    "chainId": 360,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "703": {
+    "pokemonId": 703,
+    "chainId": 361,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "704": {
+    "pokemonId": 704,
+    "chainId": 362,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "705": {
+    "pokemonId": 705,
+    "chainId": 362,
+    "evolvesFromId": 704,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "706": {
+    "pokemonId": 706,
+    "chainId": 362,
+    "evolvesFromId": 705,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 50,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": true,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "707": {
+    "pokemonId": 707,
+    "chainId": 363,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "708": {
+    "pokemonId": 708,
+    "chainId": 364,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "709": {
+    "pokemonId": 709,
+    "chainId": 364,
+    "evolvesFromId": 708,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "710": {
+    "pokemonId": 710,
+    "chainId": 365,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "711": {
+    "pokemonId": 711,
+    "chainId": 365,
+    "evolvesFromId": 710,
+    "triggers": [
+      {
+        "trigger": "trade",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "712": {
+    "pokemonId": 712,
+    "chainId": 366,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "713": {
+    "pokemonId": 713,
+    "chainId": 366,
+    "evolvesFromId": 712,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 37,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "714": {
+    "pokemonId": 714,
+    "chainId": 367,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "715": {
+    "pokemonId": 715,
+    "chainId": 367,
+    "evolvesFromId": 714,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 48,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "716": {
+    "pokemonId": 716,
+    "chainId": 368,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "717": {
+    "pokemonId": 717,
+    "chainId": 369,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "718": {
+    "pokemonId": 718,
+    "chainId": 370,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "719": {
+    "pokemonId": 719,
+    "chainId": 371,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "720": {
+    "pokemonId": 720,
+    "chainId": 372,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "721": {
+    "pokemonId": 721,
+    "chainId": 373,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "722": {
+    "pokemonId": 722,
+    "chainId": 374,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "723": {
+    "pokemonId": 723,
+    "chainId": 374,
+    "evolvesFromId": 722,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "724": {
+    "pokemonId": 724,
+    "chainId": 374,
+    "evolvesFromId": 723,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "725": {
+    "pokemonId": 725,
+    "chainId": 375,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "726": {
+    "pokemonId": 726,
+    "chainId": 375,
+    "evolvesFromId": 725,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "727": {
+    "pokemonId": 727,
+    "chainId": 375,
+    "evolvesFromId": 726,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "728": {
+    "pokemonId": 728,
+    "chainId": 376,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "729": {
+    "pokemonId": 729,
+    "chainId": 376,
+    "evolvesFromId": 728,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 17,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "730": {
+    "pokemonId": 730,
+    "chainId": 376,
+    "evolvesFromId": 729,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "731": {
+    "pokemonId": 731,
+    "chainId": 377,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "732": {
+    "pokemonId": 732,
+    "chainId": 377,
+    "evolvesFromId": 731,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 14,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "733": {
+    "pokemonId": 733,
+    "chainId": 377,
+    "evolvesFromId": 732,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "734": {
+    "pokemonId": 734,
+    "chainId": 378,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "735": {
+    "pokemonId": 735,
+    "chainId": 378,
+    "evolvesFromId": 734,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "736": {
+    "pokemonId": 736,
+    "chainId": 379,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "737": {
+    "pokemonId": 737,
+    "chainId": 379,
+    "evolvesFromId": 736,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "738": {
+    "pokemonId": 738,
+    "chainId": 379,
+    "evolvesFromId": 737,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "vast-poni-canyon",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "blush-mountain",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "739": {
+    "pokemonId": 739,
+    "chainId": 380,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "740": {
+    "pokemonId": 740,
+    "chainId": 380,
+    "evolvesFromId": 739,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": "mount-lanakila",
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "741": {
+    "pokemonId": 741,
+    "chainId": 381,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "742": {
+    "pokemonId": 742,
+    "chainId": 382,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "743": {
+    "pokemonId": 743,
+    "chainId": 382,
+    "evolvesFromId": 742,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "744": {
+    "pokemonId": 744,
+    "chainId": 383,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "745": {
+    "pokemonId": 745,
+    "chainId": 383,
+    "evolvesFromId": 744,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "dusk",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "746": {
+    "pokemonId": 746,
+    "chainId": 384,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "747": {
+    "pokemonId": 747,
+    "chainId": 385,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "748": {
+    "pokemonId": 748,
+    "chainId": 385,
+    "evolvesFromId": 747,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "749": {
+    "pokemonId": 749,
+    "chainId": 386,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "750": {
+    "pokemonId": 750,
+    "chainId": 386,
+    "evolvesFromId": 749,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "751": {
+    "pokemonId": 751,
+    "chainId": 387,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "752": {
+    "pokemonId": 752,
+    "chainId": 387,
+    "evolvesFromId": 751,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "753": {
+    "pokemonId": 753,
+    "chainId": 388,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "754": {
+    "pokemonId": 754,
+    "chainId": 388,
+    "evolvesFromId": 753,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "755": {
+    "pokemonId": 755,
+    "chainId": 389,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "756": {
+    "pokemonId": 756,
+    "chainId": 389,
+    "evolvesFromId": 755,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "757": {
+    "pokemonId": 757,
+    "chainId": 390,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "758": {
+    "pokemonId": 758,
+    "chainId": 390,
+    "evolvesFromId": 757,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 33,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "759": {
+    "pokemonId": 759,
+    "chainId": 391,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "760": {
+    "pokemonId": 760,
+    "chainId": 391,
+    "evolvesFromId": 759,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 27,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "761": {
+    "pokemonId": 761,
+    "chainId": 392,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "762": {
+    "pokemonId": 762,
+    "chainId": 392,
+    "evolvesFromId": 761,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "763": {
+    "pokemonId": 763,
+    "chainId": 392,
+    "evolvesFromId": 762,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "stomp",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "764": {
+    "pokemonId": 764,
+    "chainId": 393,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "765": {
+    "pokemonId": 765,
+    "chainId": 394,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "766": {
+    "pokemonId": 766,
+    "chainId": 395,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "767": {
+    "pokemonId": 767,
+    "chainId": 396,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "768": {
+    "pokemonId": 768,
+    "chainId": 396,
+    "evolvesFromId": 767,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "769": {
+    "pokemonId": 769,
+    "chainId": 397,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "770": {
+    "pokemonId": 770,
+    "chainId": 397,
+    "evolvesFromId": 769,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "771": {
+    "pokemonId": 771,
+    "chainId": 398,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "772": {
+    "pokemonId": 772,
+    "chainId": 399,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "773": {
+    "pokemonId": 773,
+    "chainId": 399,
+    "evolvesFromId": 772,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "774": {
+    "pokemonId": 774,
+    "chainId": 400,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "775": {
+    "pokemonId": 775,
+    "chainId": 401,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "776": {
+    "pokemonId": 776,
+    "chainId": 402,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "777": {
+    "pokemonId": 777,
+    "chainId": 403,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "778": {
+    "pokemonId": 778,
+    "chainId": 404,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "779": {
+    "pokemonId": 779,
+    "chainId": 405,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "780": {
+    "pokemonId": 780,
+    "chainId": 406,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "781": {
+    "pokemonId": 781,
+    "chainId": 407,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "782": {
+    "pokemonId": 782,
+    "chainId": 408,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "783": {
+    "pokemonId": 783,
+    "chainId": 408,
+    "evolvesFromId": 782,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "784": {
+    "pokemonId": 784,
+    "chainId": 408,
+    "evolvesFromId": 783,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 45,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "785": {
+    "pokemonId": 785,
+    "chainId": 409,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "786": {
+    "pokemonId": 786,
+    "chainId": 410,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "787": {
+    "pokemonId": 787,
+    "chainId": 411,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "788": {
+    "pokemonId": 788,
+    "chainId": 412,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "789": {
+    "pokemonId": 789,
+    "chainId": 413,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "790": {
+    "pokemonId": 790,
+    "chainId": 413,
+    "evolvesFromId": 789,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 43,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "791": {
+    "pokemonId": 791,
+    "chainId": 413,
+    "evolvesFromId": 790,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 53,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "792": {
+    "pokemonId": 792,
+    "chainId": 413,
+    "evolvesFromId": 790,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 53,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "793": {
+    "pokemonId": 793,
+    "chainId": 414,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "794": {
+    "pokemonId": 794,
+    "chainId": 415,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "795": {
+    "pokemonId": 795,
+    "chainId": 416,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "796": {
+    "pokemonId": 796,
+    "chainId": 417,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "797": {
+    "pokemonId": 797,
+    "chainId": 418,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "798": {
+    "pokemonId": 798,
+    "chainId": 419,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "799": {
+    "pokemonId": 799,
+    "chainId": 420,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "800": {
+    "pokemonId": 800,
+    "chainId": 421,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "801": {
+    "pokemonId": 801,
+    "chainId": 422,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "802": {
+    "pokemonId": 802,
+    "chainId": 423,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "803": {
+    "pokemonId": 803,
+    "chainId": 424,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "804": {
+    "pokemonId": 804,
+    "chainId": 424,
+    "evolvesFromId": 803,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "dragon-pulse",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "805": {
+    "pokemonId": 805,
+    "chainId": 425,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "806": {
+    "pokemonId": 806,
+    "chainId": 426,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "807": {
+    "pokemonId": 807,
+    "chainId": 427,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "808": {
+    "pokemonId": 808,
+    "chainId": 428,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "809": {
+    "pokemonId": 809,
+    "chainId": 429,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "810": {
+    "pokemonId": 810,
+    "chainId": 430,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "811": {
+    "pokemonId": 811,
+    "chainId": 430,
+    "evolvesFromId": 810,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "812": {
+    "pokemonId": 812,
+    "chainId": 430,
+    "evolvesFromId": 811,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "813": {
+    "pokemonId": 813,
+    "chainId": 431,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "814": {
+    "pokemonId": 814,
+    "chainId": 431,
+    "evolvesFromId": 813,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "815": {
+    "pokemonId": 815,
+    "chainId": 431,
+    "evolvesFromId": 814,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "816": {
+    "pokemonId": 816,
+    "chainId": 432,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "817": {
+    "pokemonId": 817,
+    "chainId": 432,
+    "evolvesFromId": 816,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "818": {
+    "pokemonId": 818,
+    "chainId": 432,
+    "evolvesFromId": 817,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "819": {
+    "pokemonId": 819,
+    "chainId": 433,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "820": {
+    "pokemonId": 820,
+    "chainId": 433,
+    "evolvesFromId": 819,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "821": {
+    "pokemonId": 821,
+    "chainId": 434,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "822": {
+    "pokemonId": 822,
+    "chainId": 434,
+    "evolvesFromId": 821,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "823": {
+    "pokemonId": 823,
+    "chainId": 434,
+    "evolvesFromId": 822,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "824": {
+    "pokemonId": 824,
+    "chainId": 435,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "825": {
+    "pokemonId": 825,
+    "chainId": 435,
+    "evolvesFromId": 824,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 10,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "826": {
+    "pokemonId": 826,
+    "chainId": 435,
+    "evolvesFromId": 825,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "827": {
+    "pokemonId": 827,
+    "chainId": 436,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "828": {
+    "pokemonId": 828,
+    "chainId": 436,
+    "evolvesFromId": 827,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "829": {
+    "pokemonId": 829,
+    "chainId": 437,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "830": {
+    "pokemonId": 830,
+    "chainId": 437,
+    "evolvesFromId": 829,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "831": {
+    "pokemonId": 831,
+    "chainId": 438,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "832": {
+    "pokemonId": 832,
+    "chainId": 438,
+    "evolvesFromId": 831,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "833": {
+    "pokemonId": 833,
+    "chainId": 439,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "834": {
+    "pokemonId": 834,
+    "chainId": 439,
+    "evolvesFromId": 833,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 22,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "835": {
+    "pokemonId": 835,
+    "chainId": 440,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "836": {
+    "pokemonId": 836,
+    "chainId": 440,
+    "evolvesFromId": 835,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "837": {
+    "pokemonId": 837,
+    "chainId": 441,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "838": {
+    "pokemonId": 838,
+    "chainId": 441,
+    "evolvesFromId": 837,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "839": {
+    "pokemonId": 839,
+    "chainId": 441,
+    "evolvesFromId": 838,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "840": {
+    "pokemonId": 840,
+    "chainId": 442,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "841": {
+    "pokemonId": 841,
+    "chainId": 442,
+    "evolvesFromId": 840,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "tart-apple",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "842": {
+    "pokemonId": 842,
+    "chainId": 442,
+    "evolvesFromId": 840,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "sweet-apple",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "843": {
+    "pokemonId": 843,
+    "chainId": 443,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "844": {
+    "pokemonId": 844,
+    "chainId": 443,
+    "evolvesFromId": 843,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "845": {
+    "pokemonId": 845,
+    "chainId": 444,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "846": {
+    "pokemonId": 846,
+    "chainId": 445,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "847": {
+    "pokemonId": 847,
+    "chainId": 445,
+    "evolvesFromId": 846,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "848": {
+    "pokemonId": 848,
+    "chainId": 446,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "849": {
+    "pokemonId": 849,
+    "chainId": 446,
+    "evolvesFromId": 848,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "850": {
+    "pokemonId": 850,
+    "chainId": 447,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "851": {
+    "pokemonId": 851,
+    "chainId": 447,
+    "evolvesFromId": 850,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "852": {
+    "pokemonId": 852,
+    "chainId": 448,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "853": {
+    "pokemonId": 853,
+    "chainId": 448,
+    "evolvesFromId": 852,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "taunt",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "854": {
+    "pokemonId": 854,
+    "chainId": 449,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "855": {
+    "pokemonId": 855,
+    "chainId": 449,
+    "evolvesFromId": 854,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "cracked-pot",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "856": {
+    "pokemonId": 856,
+    "chainId": 450,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "857": {
+    "pokemonId": 857,
+    "chainId": 450,
+    "evolvesFromId": 856,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "858": {
+    "pokemonId": 858,
+    "chainId": 450,
+    "evolvesFromId": 857,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "859": {
+    "pokemonId": 859,
+    "chainId": 451,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "860": {
+    "pokemonId": 860,
+    "chainId": 451,
+    "evolvesFromId": 859,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 32,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "861": {
+    "pokemonId": 861,
+    "chainId": 451,
+    "evolvesFromId": 860,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "862": {
+    "pokemonId": 862,
+    "chainId": 134,
+    "evolvesFromId": 264,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "863": {
+    "pokemonId": 863,
+    "chainId": 22,
+    "evolvesFromId": 52,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "864": {
+    "pokemonId": 864,
+    "chainId": 113,
+    "evolvesFromId": 222,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "865": {
+    "pokemonId": 865,
+    "chainId": 35,
+    "evolvesFromId": 83,
+    "triggers": [
+      {
+        "trigger": "three-critical-hits",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "866": {
+    "pokemonId": 866,
+    "chainId": 57,
+    "evolvesFromId": 122,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 42,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "867": {
+    "pokemonId": 867,
+    "chainId": 287,
+    "evolvesFromId": 562,
+    "triggers": [
+      {
+        "trigger": "take-damage",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "868": {
+    "pokemonId": 868,
+    "chainId": 452,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "869": {
+    "pokemonId": 869,
+    "chainId": 452,
+    "evolvesFromId": 868,
+    "triggers": [
+      {
+        "trigger": "spin",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "870": {
+    "pokemonId": 870,
+    "chainId": 453,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "871": {
+    "pokemonId": 871,
+    "chainId": 454,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "872": {
+    "pokemonId": 872,
+    "chainId": 455,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "873": {
+    "pokemonId": 873,
+    "chainId": 455,
+    "evolvesFromId": 872,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": 160,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "874": {
+    "pokemonId": 874,
+    "chainId": 456,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "875": {
+    "pokemonId": 875,
+    "chainId": 457,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "876": {
+    "pokemonId": 876,
+    "chainId": 458,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "877": {
+    "pokemonId": 877,
+    "chainId": 459,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "878": {
+    "pokemonId": 878,
+    "chainId": 460,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "879": {
+    "pokemonId": 879,
+    "chainId": 460,
+    "evolvesFromId": 878,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 34,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "880": {
+    "pokemonId": 880,
+    "chainId": 461,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "881": {
+    "pokemonId": 881,
+    "chainId": 462,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "882": {
+    "pokemonId": 882,
+    "chainId": 463,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "883": {
+    "pokemonId": 883,
+    "chainId": 464,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "884": {
+    "pokemonId": 884,
+    "chainId": 465,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "885": {
+    "pokemonId": 885,
+    "chainId": 466,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "886": {
+    "pokemonId": 886,
+    "chainId": 466,
+    "evolvesFromId": 885,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 50,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "887": {
+    "pokemonId": 887,
+    "chainId": 466,
+    "evolvesFromId": 886,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 60,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "888": {
+    "pokemonId": 888,
+    "chainId": 467,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "889": {
+    "pokemonId": 889,
+    "chainId": 468,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "890": {
+    "pokemonId": 890,
+    "chainId": 469,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "891": {
+    "pokemonId": 891,
+    "chainId": 470,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "892": {
+    "pokemonId": 892,
+    "chainId": 470,
+    "evolvesFromId": 891,
+    "triggers": [
+      {
+        "trigger": "tower-of-darkness",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "tower-of-waters",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "893": {
+    "pokemonId": 893,
+    "chainId": 471,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "894": {
+    "pokemonId": 894,
+    "chainId": 472,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "895": {
+    "pokemonId": 895,
+    "chainId": 473,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "896": {
+    "pokemonId": 896,
+    "chainId": 474,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "897": {
+    "pokemonId": 897,
+    "chainId": 475,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "898": {
+    "pokemonId": 898,
+    "chainId": 476,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "899": {
+    "pokemonId": 899,
+    "chainId": 120,
+    "evolvesFromId": 234,
+    "triggers": [
+      {
+        "trigger": "agile-style-move",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "900": {
+    "pokemonId": 900,
+    "chainId": 58,
+    "evolvesFromId": 123,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "black-augurite",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "901": {
+    "pokemonId": 901,
+    "chainId": 110,
+    "evolvesFromId": 217,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "peat-block",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "full-moon",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "902": {
+    "pokemonId": 902,
+    "chainId": 280,
+    "evolvesFromId": 550,
+    "triggers": [
+      {
+        "trigger": "recoil-damage",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "903": {
+    "pokemonId": 903,
+    "chainId": 109,
+    "evolvesFromId": 215,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": "razor-claw",
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "day",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "904": {
+    "pokemonId": 904,
+    "chainId": 106,
+    "evolvesFromId": 211,
+    "triggers": [
+      {
+        "trigger": "strong-style-move",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "barb-barrage",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      },
+      {
+        "trigger": "use-move",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "905": {
+    "pokemonId": 905,
+    "chainId": 477,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "906": {
+    "pokemonId": 906,
+    "chainId": 478,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "907": {
+    "pokemonId": 907,
+    "chainId": 478,
+    "evolvesFromId": 906,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "908": {
+    "pokemonId": 908,
+    "chainId": 478,
+    "evolvesFromId": 907,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "909": {
+    "pokemonId": 909,
+    "chainId": 479,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "910": {
+    "pokemonId": 910,
+    "chainId": 479,
+    "evolvesFromId": 909,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "911": {
+    "pokemonId": 911,
+    "chainId": 479,
+    "evolvesFromId": 910,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "912": {
+    "pokemonId": 912,
+    "chainId": 480,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "913": {
+    "pokemonId": 913,
+    "chainId": 480,
+    "evolvesFromId": 912,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 16,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "914": {
+    "pokemonId": 914,
+    "chainId": 480,
+    "evolvesFromId": 913,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 36,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "915": {
+    "pokemonId": 915,
+    "chainId": 481,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "916": {
+    "pokemonId": 916,
+    "chainId": 481,
+    "evolvesFromId": 915,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "917": {
+    "pokemonId": 917,
+    "chainId": 482,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "918": {
+    "pokemonId": 918,
+    "chainId": 482,
+    "evolvesFromId": 917,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 15,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "919": {
+    "pokemonId": 919,
+    "chainId": 483,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "920": {
+    "pokemonId": 920,
+    "chainId": 483,
+    "evolvesFromId": 919,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "921": {
+    "pokemonId": 921,
+    "chainId": 484,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "922": {
+    "pokemonId": 922,
+    "chainId": 484,
+    "evolvesFromId": 921,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 18,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "923": {
+    "pokemonId": 923,
+    "chainId": 484,
+    "evolvesFromId": 922,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "924": {
+    "pokemonId": 924,
+    "chainId": 485,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "925": {
+    "pokemonId": 925,
+    "chainId": 485,
+    "evolvesFromId": 924,
+    "triggers": [
+      {
+        "trigger": "other",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "926": {
+    "pokemonId": 926,
+    "chainId": 486,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "927": {
+    "pokemonId": 927,
+    "chainId": 486,
+    "evolvesFromId": 926,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "928": {
+    "pokemonId": 928,
+    "chainId": 487,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "929": {
+    "pokemonId": 929,
+    "chainId": 487,
+    "evolvesFromId": 928,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "930": {
+    "pokemonId": 930,
+    "chainId": 487,
+    "evolvesFromId": 929,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "931": {
+    "pokemonId": 931,
+    "chainId": 488,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "932": {
+    "pokemonId": 932,
+    "chainId": 489,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "933": {
+    "pokemonId": 933,
+    "chainId": 489,
+    "evolvesFromId": 932,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "934": {
+    "pokemonId": 934,
+    "chainId": 489,
+    "evolvesFromId": 933,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "935": {
+    "pokemonId": 935,
+    "chainId": 490,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "936": {
+    "pokemonId": 936,
+    "chainId": 490,
+    "evolvesFromId": 935,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "auspicious-armor",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "937": {
+    "pokemonId": 937,
+    "chainId": 490,
+    "evolvesFromId": 935,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "malicious-armor",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "938": {
+    "pokemonId": 938,
+    "chainId": 491,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "939": {
+    "pokemonId": 939,
+    "chainId": 491,
+    "evolvesFromId": 938,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "thunder-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "940": {
+    "pokemonId": 940,
+    "chainId": 492,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "941": {
+    "pokemonId": 941,
+    "chainId": 492,
+    "evolvesFromId": 940,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 25,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "942": {
+    "pokemonId": 942,
+    "chainId": 493,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "943": {
+    "pokemonId": 943,
+    "chainId": 493,
+    "evolvesFromId": 942,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "944": {
+    "pokemonId": 944,
+    "chainId": 494,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "945": {
+    "pokemonId": 945,
+    "chainId": 494,
+    "evolvesFromId": 944,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 28,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "946": {
+    "pokemonId": 946,
+    "chainId": 495,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "947": {
+    "pokemonId": 947,
+    "chainId": 495,
+    "evolvesFromId": 946,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "948": {
+    "pokemonId": 948,
+    "chainId": 496,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "949": {
+    "pokemonId": 949,
+    "chainId": 496,
+    "evolvesFromId": 948,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "950": {
+    "pokemonId": 950,
+    "chainId": 497,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "951": {
+    "pokemonId": 951,
+    "chainId": 498,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "952": {
+    "pokemonId": 952,
+    "chainId": 498,
+    "evolvesFromId": 951,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "fire-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "953": {
+    "pokemonId": 953,
+    "chainId": 499,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "954": {
+    "pokemonId": 954,
+    "chainId": 499,
+    "evolvesFromId": 953,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "955": {
+    "pokemonId": 955,
+    "chainId": 500,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "956": {
+    "pokemonId": 956,
+    "chainId": 500,
+    "evolvesFromId": 955,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "957": {
+    "pokemonId": 957,
+    "chainId": 501,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "958": {
+    "pokemonId": 958,
+    "chainId": 501,
+    "evolvesFromId": 957,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 24,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "959": {
+    "pokemonId": 959,
+    "chainId": 501,
+    "evolvesFromId": 958,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "960": {
+    "pokemonId": 960,
+    "chainId": 502,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "961": {
+    "pokemonId": 961,
+    "chainId": 502,
+    "evolvesFromId": 960,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 26,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "962": {
+    "pokemonId": 962,
+    "chainId": 503,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "963": {
+    "pokemonId": 963,
+    "chainId": 504,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "964": {
+    "pokemonId": 964,
+    "chainId": 504,
+    "evolvesFromId": 963,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 38,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "965": {
+    "pokemonId": 965,
+    "chainId": 505,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "966": {
+    "pokemonId": 966,
+    "chainId": 505,
+    "evolvesFromId": 965,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 40,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "967": {
+    "pokemonId": 967,
+    "chainId": 506,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "968": {
+    "pokemonId": 968,
+    "chainId": 507,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "969": {
+    "pokemonId": 969,
+    "chainId": 508,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "970": {
+    "pokemonId": 970,
+    "chainId": 508,
+    "evolvesFromId": 969,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "971": {
+    "pokemonId": 971,
+    "chainId": 509,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "972": {
+    "pokemonId": 972,
+    "chainId": 509,
+    "evolvesFromId": 971,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 30,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": "night",
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "973": {
+    "pokemonId": 973,
+    "chainId": 510,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "974": {
+    "pokemonId": 974,
+    "chainId": 511,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "975": {
+    "pokemonId": 975,
+    "chainId": 511,
+    "evolvesFromId": 974,
+    "triggers": [
+      {
+        "trigger": "use-item",
+        "minLevel": null,
+        "item": "ice-stone",
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "976": {
+    "pokemonId": 976,
+    "chainId": 512,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "977": {
+    "pokemonId": 977,
+    "chainId": 513,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "978": {
+    "pokemonId": 978,
+    "chainId": 514,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "979": {
+    "pokemonId": 979,
+    "chainId": 24,
+    "evolvesFromId": 57,
+    "triggers": [
+      {
+        "trigger": "use-move",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "980": {
+    "pokemonId": 980,
+    "chainId": 96,
+    "evolvesFromId": 194,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 20,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "981": {
+    "pokemonId": 981,
+    "chainId": 101,
+    "evolvesFromId": 203,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "twin-beam",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "982": {
+    "pokemonId": 982,
+    "chainId": 103,
+    "evolvesFromId": 206,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": "hyper-drill",
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "983": {
+    "pokemonId": 983,
+    "chainId": 317,
+    "evolvesFromId": 625,
+    "triggers": [
+      {
+        "trigger": "three-defeated-bisharp",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "984": {
+    "pokemonId": 984,
+    "chainId": 515,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "985": {
+    "pokemonId": 985,
+    "chainId": 516,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "986": {
+    "pokemonId": 986,
+    "chainId": 517,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "987": {
+    "pokemonId": 987,
+    "chainId": 518,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "988": {
+    "pokemonId": 988,
+    "chainId": 519,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "989": {
+    "pokemonId": 989,
+    "chainId": 520,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "990": {
+    "pokemonId": 990,
+    "chainId": 521,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "991": {
+    "pokemonId": 991,
+    "chainId": 522,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "992": {
+    "pokemonId": 992,
+    "chainId": 523,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "993": {
+    "pokemonId": 993,
+    "chainId": 524,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "994": {
+    "pokemonId": 994,
+    "chainId": 525,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "995": {
+    "pokemonId": 995,
+    "chainId": 526,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "996": {
+    "pokemonId": 996,
+    "chainId": 527,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "997": {
+    "pokemonId": 997,
+    "chainId": 527,
+    "evolvesFromId": 996,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 35,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "998": {
+    "pokemonId": 998,
+    "chainId": 527,
+    "evolvesFromId": 997,
+    "triggers": [
+      {
+        "trigger": "level-up",
+        "minLevel": 54,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "999": {
+    "pokemonId": 999,
+    "chainId": 528,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1000": {
+    "pokemonId": 1000,
+    "chainId": 528,
+    "evolvesFromId": 999,
+    "triggers": [
+      {
+        "trigger": "gimmmighoul-coins",
+        "minLevel": null,
+        "item": null,
+        "heldItem": null,
+        "knownMove": null,
+        "minHappiness": null,
+        "timeOfDay": null,
+        "needsOverworldRain": false,
+        "location": null,
+        "tradeSpecies": null
+      }
+    ]
+  },
+  "1001": {
+    "pokemonId": 1001,
+    "chainId": 529,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1002": {
+    "pokemonId": 1002,
+    "chainId": 530,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1003": {
+    "pokemonId": 1003,
+    "chainId": 531,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1004": {
+    "pokemonId": 1004,
+    "chainId": 532,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1005": {
+    "pokemonId": 1005,
+    "chainId": 533,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1006": {
+    "pokemonId": 1006,
+    "chainId": 534,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1007": {
+    "pokemonId": 1007,
+    "chainId": 535,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1008": {
+    "pokemonId": 1008,
+    "chainId": 536,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1009": {
+    "pokemonId": 1009,
+    "chainId": 537,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1010": {
+    "pokemonId": 1010,
+    "chainId": 538,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1011": {
+    "pokemonId": 1011,
+    "chainId": 442,
+    "evolvesFromId": 840,
+    "triggers": []
+  },
+  "1012": {
+    "pokemonId": 1012,
+    "chainId": 539,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1013": {
+    "pokemonId": 1013,
+    "chainId": 539,
+    "evolvesFromId": 1012,
+    "triggers": []
+  },
+  "1014": {
+    "pokemonId": 1014,
+    "chainId": 540,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1015": {
+    "pokemonId": 1015,
+    "chainId": 541,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1016": {
+    "pokemonId": 1016,
+    "chainId": 542,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1017": {
+    "pokemonId": 1017,
+    "chainId": 543,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1018": {
+    "pokemonId": 1018,
+    "chainId": 465,
+    "evolvesFromId": 884,
+    "triggers": []
+  },
+  "1019": {
+    "pokemonId": 1019,
+    "chainId": 442,
+    "evolvesFromId": 1011,
+    "triggers": []
+  },
+  "1020": {
+    "pokemonId": 1020,
+    "chainId": 544,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1021": {
+    "pokemonId": 1021,
+    "chainId": 545,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1022": {
+    "pokemonId": 1022,
+    "chainId": 547,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1023": {
+    "pokemonId": 1023,
+    "chainId": 546,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1024": {
+    "pokemonId": 1024,
+    "chainId": 548,
+    "evolvesFromId": null,
+    "triggers": []
+  },
+  "1025": {
+    "pokemonId": 1025,
+    "chainId": 549,
+    "evolvesFromId": null,
+    "triggers": []
+  }
+}

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -72,6 +72,26 @@ export {
   regionalPokedexEntrySchema,
 } from "./schemas/mod.ts";
 export {
+  type EvolutionTrigger,
+  evolutionTriggerSchema,
+  type PokemonEncounterPrimary,
+  pokemonEncounterPrimarySchema,
+  type PokemonEncountersData,
+  pokemonEncountersDataSchema,
+  type PokemonEncountersEntry,
+  pokemonEncountersEntrySchema,
+  type PokemonEncounterSummary,
+  pokemonEncounterSummarySchema,
+  type PokemonEvolution,
+  pokemonEvolutionSchema,
+  type PokemonEvolutionsData,
+  pokemonEvolutionsDataSchema,
+  type PoolItemEffort,
+  poolItemEffortSchema,
+  type PoolItemEncounter,
+  poolItemEncounterSchema,
+} from "./schemas/mod.ts";
+export {
   type PokemonMovesEntry,
   pokemonMovesEntrySchema,
 } from "./schemas/mod.ts";

--- a/packages/shared/schemas/draft-pool.ts
+++ b/packages/shared/schemas/draft-pool.ts
@@ -1,5 +1,10 @@
 import type { z } from "zod";
 import { array, enum as enum_, nullable, number, object, string } from "zod";
+import {
+  poolItemEffortSchema,
+  poolItemEncounterSchema,
+} from "./pokemon-encounters.ts";
+import { pokemonEvolutionSchema } from "./pokemon-evolutions.ts";
 
 export const poolItemAvailabilitySchema: z.ZodEnum<["early", "mid", "late"]> =
   enum_(["early", "mid", "late"]);
@@ -41,6 +46,9 @@ export const draftPoolItemSchema: z.ZodObject<{
   thumbnailUrl: z.ZodNullable<z.ZodString>;
   metadata: z.ZodNullable<typeof draftPoolItemMetadataSchema>;
   availability: z.ZodNullable<typeof poolItemAvailabilitySchema>;
+  encounter: z.ZodNullable<typeof poolItemEncounterSchema>;
+  effort: z.ZodNullable<typeof poolItemEffortSchema>;
+  evolution: z.ZodNullable<typeof pokemonEvolutionSchema>;
 }> = object({
   id: string().uuid(),
   draftPoolId: string().uuid(),
@@ -48,6 +56,9 @@ export const draftPoolItemSchema: z.ZodObject<{
   thumbnailUrl: nullable(string()),
   metadata: draftPoolItemMetadataSchema.nullable(),
   availability: poolItemAvailabilitySchema.nullable(),
+  encounter: poolItemEncounterSchema.nullable(),
+  effort: poolItemEffortSchema.nullable(),
+  evolution: pokemonEvolutionSchema.nullable(),
 });
 
 export type DraftPoolItem = z.infer<typeof draftPoolItemSchema>;

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -41,6 +41,7 @@ export {
   type PoolItemAvailability,
   poolItemAvailabilitySchema,
 } from "./draft-pool.ts";
+
 export { type HealthResponse, healthResponseSchema } from "./health.ts";
 export {
   type AdvanceLeagueStatusInput,
@@ -71,6 +72,28 @@ export {
   type RegionalPokedexEntry,
   regionalPokedexEntrySchema,
 } from "./pokemon.ts";
+export {
+  type PokemonEncounterPrimary,
+  pokemonEncounterPrimarySchema,
+  type PokemonEncountersData,
+  pokemonEncountersDataSchema,
+  type PokemonEncountersEntry,
+  pokemonEncountersEntrySchema,
+  type PokemonEncounterSummary,
+  pokemonEncounterSummarySchema,
+  type PoolItemEffort,
+  poolItemEffortSchema,
+  type PoolItemEncounter,
+  poolItemEncounterSchema,
+} from "./pokemon-encounters.ts";
+export {
+  type EvolutionTrigger,
+  evolutionTriggerSchema,
+  type PokemonEvolution,
+  pokemonEvolutionSchema,
+  type PokemonEvolutionsData,
+  pokemonEvolutionsDataSchema,
+} from "./pokemon-evolutions.ts";
 export {
   type PokemonMovesEntry,
   pokemonMovesEntrySchema,

--- a/packages/shared/schemas/pokemon-encounters.ts
+++ b/packages/shared/schemas/pokemon-encounters.ts
@@ -1,0 +1,73 @@
+import type { z } from "zod";
+import { array, number, object, record, string } from "zod";
+
+export const pokemonEncounterSummarySchema: z.ZodObject<{
+  location: z.ZodString;
+  method: z.ZodString;
+  minLevel: z.ZodNumber;
+  maxLevel: z.ZodNumber;
+  chance: z.ZodNumber;
+}> = object({
+  location: string(),
+  method: string(),
+  minLevel: number(),
+  maxLevel: number(),
+  chance: number(),
+});
+
+export type PokemonEncounterSummary = z.infer<
+  typeof pokemonEncounterSummarySchema
+>;
+
+export const pokemonEncounterPrimarySchema: z.ZodObject<{
+  location: z.ZodString;
+  method: z.ZodString;
+}> = object({
+  location: string(),
+  method: string(),
+});
+
+export type PokemonEncounterPrimary = z.infer<
+  typeof pokemonEncounterPrimarySchema
+>;
+
+export const pokemonEncountersEntrySchema: z.ZodObject<{
+  primary: z.ZodNullable<typeof pokemonEncounterPrimarySchema>;
+  encounters: z.ZodArray<typeof pokemonEncounterSummarySchema>;
+}> = object({
+  primary: pokemonEncounterPrimarySchema.nullable(),
+  encounters: array(pokemonEncounterSummarySchema),
+});
+
+export type PokemonEncountersEntry = z.infer<
+  typeof pokemonEncountersEntrySchema
+>;
+
+export const pokemonEncountersDataSchema: z.ZodRecord<
+  z.ZodString,
+  z.ZodRecord<z.ZodString, typeof pokemonEncountersEntrySchema>
+> = record(string(), record(string(), pokemonEncountersEntrySchema));
+
+export type PokemonEncountersData = z.infer<
+  typeof pokemonEncountersDataSchema
+>;
+
+export const poolItemEncounterSchema: z.ZodObject<{
+  primary: z.ZodNullable<typeof pokemonEncounterPrimarySchema>;
+  all: z.ZodArray<typeof pokemonEncounterSummarySchema>;
+}> = object({
+  primary: pokemonEncounterPrimarySchema.nullable(),
+  all: array(pokemonEncounterSummarySchema),
+});
+
+export type PoolItemEncounter = z.infer<typeof poolItemEncounterSchema>;
+
+export const poolItemEffortSchema: z.ZodObject<{
+  score: z.ZodNumber;
+  reasons: z.ZodArray<z.ZodString>;
+}> = object({
+  score: number().int().min(1).max(5),
+  reasons: array(string()),
+});
+
+export type PoolItemEffort = z.infer<typeof poolItemEffortSchema>;

--- a/packages/shared/schemas/pokemon-evolutions.ts
+++ b/packages/shared/schemas/pokemon-evolutions.ts
@@ -1,0 +1,49 @@
+import type { z } from "zod";
+import { array, boolean, nullable, number, object, record, string } from "zod";
+
+export const evolutionTriggerSchema: z.ZodObject<{
+  trigger: z.ZodString;
+  minLevel: z.ZodNullable<z.ZodNumber>;
+  item: z.ZodNullable<z.ZodString>;
+  heldItem: z.ZodNullable<z.ZodString>;
+  knownMove: z.ZodNullable<z.ZodString>;
+  minHappiness: z.ZodNullable<z.ZodNumber>;
+  timeOfDay: z.ZodNullable<z.ZodString>;
+  needsOverworldRain: z.ZodBoolean;
+  location: z.ZodNullable<z.ZodString>;
+  tradeSpecies: z.ZodNullable<z.ZodString>;
+}> = object({
+  trigger: string(),
+  minLevel: nullable(number()),
+  item: nullable(string()),
+  heldItem: nullable(string()),
+  knownMove: nullable(string()),
+  minHappiness: nullable(number()),
+  timeOfDay: nullable(string()),
+  needsOverworldRain: boolean(),
+  location: nullable(string()),
+  tradeSpecies: nullable(string()),
+});
+
+export type EvolutionTrigger = z.infer<typeof evolutionTriggerSchema>;
+
+export const pokemonEvolutionSchema: z.ZodObject<{
+  pokemonId: z.ZodNumber;
+  chainId: z.ZodNumber;
+  evolvesFromId: z.ZodNullable<z.ZodNumber>;
+  triggers: z.ZodArray<typeof evolutionTriggerSchema>;
+}> = object({
+  pokemonId: number(),
+  chainId: number(),
+  evolvesFromId: nullable(number()),
+  triggers: array(evolutionTriggerSchema),
+});
+
+export type PokemonEvolution = z.infer<typeof pokemonEvolutionSchema>;
+
+export const pokemonEvolutionsDataSchema: z.ZodRecord<
+  z.ZodString,
+  typeof pokemonEvolutionSchema
+> = record(string(), pokemonEvolutionSchema);
+
+export type PokemonEvolutionsData = z.infer<typeof pokemonEvolutionsDataSchema>;

--- a/scripts/sync-pokemon-encounters.ts
+++ b/scripts/sync-pokemon-encounters.ts
@@ -1,0 +1,208 @@
+import pokemonJson from "../packages/shared/data/pokemon.json" with {
+  type: "json",
+};
+import pokemonVersionsJson from "../packages/shared/data/pokemon-versions.json" with {
+  type: "json",
+};
+
+const POKEAPI_BASE = "https://pokeapi.co/api/v2";
+const BATCH_SIZE = 25;
+const MAX_ENCOUNTERS_PER_ENTRY = 10;
+
+interface RawEncounterEntry {
+  location_area: { name: string; url: string };
+  version_details: Array<{
+    max_chance: number;
+    version: { name: string };
+    encounter_details: Array<{
+      chance: number;
+      min_level: number;
+      max_level: number;
+      method: { name: string };
+    }>;
+  }>;
+}
+
+interface PokemonVersionJson {
+  id: string;
+  name: string;
+  versionGroup: string;
+  region: string;
+  generation: number;
+}
+
+interface EncounterSummary {
+  location: string;
+  method: string;
+  minLevel: number;
+  maxLevel: number;
+  chance: number;
+}
+
+interface PokemonEncounters {
+  primary: { location: string; method: string } | null;
+  encounters: EncounterSummary[];
+}
+
+type EncounterData = Record<
+  string,
+  Record<string, PokemonEncounters>
+>;
+
+function humanizeLocation(name: string): string {
+  return name
+    .replace(/-area$/, "")
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function humanizeMethod(name: string): string {
+  return name
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+async function fetchWithRetry(url: string): Promise<Response> {
+  const response = await fetch(url);
+  if (response.ok) return response;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  const retry = await fetch(url);
+  if (retry.ok) return retry;
+  throw new Error(
+    `Failed to fetch ${url}: ${retry.status} ${retry.statusText}`,
+  );
+}
+
+async function fetchEncounters(
+  pokemonId: number,
+): Promise<RawEncounterEntry[]> {
+  const response = await fetchWithRetry(
+    `${POKEAPI_BASE}/pokemon/${pokemonId}/encounters`,
+  );
+  return response.json();
+}
+
+function summarize(
+  raw: RawEncounterEntry[],
+  supportedVersions: Set<string>,
+): Record<string, PokemonEncounters> {
+  const byVersion = new Map<string, EncounterSummary[]>();
+
+  for (const area of raw) {
+    const locationName = humanizeLocation(area.location_area.name);
+    for (const vd of area.version_details) {
+      const versionName = vd.version.name;
+      if (!supportedVersions.has(versionName)) continue;
+
+      const list = byVersion.get(versionName) ?? [];
+
+      // Dedup by (location, method) inside this area, take max level range + chance
+      const methodBuckets = new Map<string, EncounterSummary>();
+      for (const ed of vd.encounter_details) {
+        const method = ed.method.name;
+        const existing = methodBuckets.get(method);
+        if (!existing) {
+          methodBuckets.set(method, {
+            location: locationName,
+            method: humanizeMethod(method),
+            minLevel: ed.min_level,
+            maxLevel: ed.max_level,
+            chance: ed.chance,
+          });
+        } else {
+          existing.minLevel = Math.min(existing.minLevel, ed.min_level);
+          existing.maxLevel = Math.max(existing.maxLevel, ed.max_level);
+          existing.chance = Math.max(existing.chance, ed.chance);
+        }
+      }
+      for (const summary of methodBuckets.values()) {
+        list.push(summary);
+      }
+      byVersion.set(versionName, list);
+    }
+  }
+
+  const result: Record<string, PokemonEncounters> = {};
+  for (const [versionName, encounters] of byVersion) {
+    // Sort: highest chance first, stable by location/method for determinism
+    encounters.sort((a, b) =>
+      b.chance - a.chance ||
+      a.location.localeCompare(b.location) ||
+      a.method.localeCompare(b.method)
+    );
+    const first = encounters[0];
+    result[versionName] = {
+      primary: first
+        ? { location: first.location, method: first.method }
+        : null,
+      encounters: encounters.slice(0, MAX_ENCOUNTERS_PER_ENTRY),
+    };
+  }
+  return result;
+}
+
+async function main() {
+  const pokemon = pokemonJson as Array<{ id: number; name: string }>;
+  const versions = pokemonVersionsJson as PokemonVersionJson[];
+  const supportedVersions = new Set(versions.map((v) => v.id));
+
+  console.log(
+    `Fetching encounters for ${pokemon.length} Pokemon across ${supportedVersions.size} versions...`,
+  );
+
+  // versionName -> pokemonId -> PokemonEncounters
+  const data: EncounterData = {};
+  for (const v of supportedVersions) data[v] = {};
+
+  let processed = 0;
+  for (let i = 0; i < pokemon.length; i += BATCH_SIZE) {
+    const batch = pokemon.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (p) => {
+        try {
+          const raw = await fetchEncounters(p.id);
+          return {
+            id: p.id,
+            name: p.name,
+            summary: summarize(raw, supportedVersions),
+          };
+        } catch (err) {
+          console.warn(
+            `  skipping ${p.name} (${p.id}): ${(err as Error).message}`,
+          );
+          return { id: p.id, name: p.name, summary: {} };
+        }
+      }),
+    );
+    for (const { id, summary } of results) {
+      for (const [versionName, pokemonEnc] of Object.entries(summary)) {
+        if (pokemonEnc.encounters.length > 0) {
+          data[versionName][String(id)] = pokemonEnc;
+        }
+      }
+    }
+    processed += batch.length;
+    console.log(`  processed ${processed}/${pokemon.length}`);
+  }
+
+  const outputPath = new URL(
+    "../packages/shared/data/pokemon-encounters.json",
+    import.meta.url,
+  );
+  await Deno.writeTextFile(
+    outputPath,
+    JSON.stringify(data, null, 2) + "\n",
+  );
+
+  const totalEntries = Object.values(data).reduce(
+    (sum, v) => sum + Object.keys(v).length,
+    0,
+  );
+  console.log(
+    `\nDone. ${totalEntries} (version, pokemon) encounter entries written to packages/shared/data/pokemon-encounters.json`,
+  );
+}
+
+main();

--- a/scripts/sync-pokemon-evolutions.ts
+++ b/scripts/sync-pokemon-evolutions.ts
@@ -1,0 +1,211 @@
+import pokemonJson from "../packages/shared/data/pokemon.json" with {
+  type: "json",
+};
+
+const POKEAPI_BASE = "https://pokeapi.co/api/v2";
+const BATCH_SIZE = 25;
+
+interface RawSpecies {
+  id: number;
+  name: string;
+  evolution_chain: { url: string } | null;
+  evolves_from_species: { name: string; url: string } | null;
+}
+
+interface RawEvolutionDetail {
+  trigger: { name: string };
+  min_level: number | null;
+  item: { name: string } | null;
+  held_item: { name: string } | null;
+  known_move: { name: string } | null;
+  min_happiness: number | null;
+  min_affection: number | null;
+  time_of_day: string;
+  needs_overworld_rain: boolean;
+  location: { name: string } | null;
+  gender: number | null;
+  trade_species: { name: string } | null;
+}
+
+interface RawEvolutionChainNode {
+  species: { name: string; url: string };
+  evolution_details: RawEvolutionDetail[];
+  evolves_to: RawEvolutionChainNode[];
+}
+
+interface RawEvolutionChain {
+  id: number;
+  chain: RawEvolutionChainNode;
+}
+
+interface EvolutionTrigger {
+  trigger: string;
+  minLevel: number | null;
+  item: string | null;
+  heldItem: string | null;
+  knownMove: string | null;
+  minHappiness: number | null;
+  timeOfDay: string | null;
+  needsOverworldRain: boolean;
+  location: string | null;
+  tradeSpecies: string | null;
+}
+
+interface PokemonEvolution {
+  pokemonId: number;
+  chainId: number;
+  evolvesFromId: number | null;
+  triggers: EvolutionTrigger[];
+}
+
+function extractIdFromUrl(url: string): number {
+  const parts = url.replace(/\/$/, "").split("/");
+  return Number(parts[parts.length - 1]);
+}
+
+async function fetchWithRetry(url: string): Promise<Response> {
+  const response = await fetch(url);
+  if (response.ok) return response;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  const retry = await fetch(url);
+  if (retry.ok) return retry;
+  throw new Error(
+    `Failed to fetch ${url}: ${retry.status} ${retry.statusText}`,
+  );
+}
+
+async function fetchSpecies(id: number): Promise<RawSpecies> {
+  const response = await fetchWithRetry(
+    `${POKEAPI_BASE}/pokemon-species/${id}`,
+  );
+  return response.json();
+}
+
+async function fetchEvolutionChain(url: string): Promise<RawEvolutionChain> {
+  const response = await fetchWithRetry(url);
+  return response.json();
+}
+
+function mapDetail(raw: RawEvolutionDetail): EvolutionTrigger {
+  return {
+    trigger: raw.trigger.name,
+    minLevel: raw.min_level,
+    item: raw.item?.name ?? null,
+    heldItem: raw.held_item?.name ?? null,
+    knownMove: raw.known_move?.name ?? null,
+    minHappiness: raw.min_happiness,
+    timeOfDay: raw.time_of_day && raw.time_of_day.length > 0
+      ? raw.time_of_day
+      : null,
+    needsOverworldRain: raw.needs_overworld_rain,
+    location: raw.location?.name ?? null,
+    tradeSpecies: raw.trade_species?.name ?? null,
+  };
+}
+
+function walkChain(
+  chain: RawEvolutionChainNode,
+  chainId: number,
+  parentId: number | null,
+  out: Map<number, PokemonEvolution>,
+) {
+  const speciesId = extractIdFromUrl(chain.species.url);
+  const existing = out.get(speciesId);
+  if (!existing) {
+    out.set(speciesId, {
+      pokemonId: speciesId,
+      chainId,
+      evolvesFromId: parentId,
+      triggers: chain.evolution_details.map(mapDetail),
+    });
+  }
+  for (const next of chain.evolves_to) {
+    walkChain(next, chainId, speciesId, out);
+  }
+}
+
+async function main() {
+  const pokemon = pokemonJson as Array<{ id: number; name: string }>;
+  const seenChainIds = new Set<number>();
+  const result = new Map<number, PokemonEvolution>();
+
+  console.log(
+    `Fetching species metadata for ${pokemon.length} Pokemon to discover evolution chains...`,
+  );
+
+  // First: fetch species for every pokemon to find evolution_chain URLs.
+  const chainUrls = new Map<number, string>();
+  let processed = 0;
+  for (let i = 0; i < pokemon.length; i += BATCH_SIZE) {
+    const batch = pokemon.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (p) => {
+        try {
+          const species = await fetchSpecies(p.id);
+          return { id: p.id, url: species.evolution_chain?.url ?? null };
+        } catch (err) {
+          console.warn(
+            `  species ${p.name} (${p.id}): ${(err as Error).message}`,
+          );
+          return { id: p.id, url: null };
+        }
+      }),
+    );
+    for (const r of results) {
+      if (r.url) {
+        const chainId = extractIdFromUrl(r.url);
+        chainUrls.set(chainId, r.url);
+      }
+    }
+    processed += batch.length;
+    console.log(`  species ${processed}/${pokemon.length}`);
+  }
+
+  console.log(
+    `\nFetching ${chainUrls.size} unique evolution chains...`,
+  );
+  const chainList = [...chainUrls.entries()];
+  processed = 0;
+  for (let i = 0; i < chainList.length; i += BATCH_SIZE) {
+    const batch = chainList.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async ([chainId, url]) => {
+        try {
+          const chain = await fetchEvolutionChain(url);
+          return { chainId, chain };
+        } catch (err) {
+          console.warn(`  chain ${chainId}: ${(err as Error).message}`);
+          return null;
+        }
+      }),
+    );
+    for (const entry of results) {
+      if (!entry) continue;
+      if (seenChainIds.has(entry.chainId)) continue;
+      seenChainIds.add(entry.chainId);
+      walkChain(entry.chain.chain, entry.chainId, null, result);
+    }
+    processed += batch.length;
+    console.log(`  chains ${processed}/${chainList.length}`);
+  }
+
+  // Stable output keyed by pokemon id.
+  const record: Record<string, PokemonEvolution> = {};
+  for (const [id, evo] of [...result.entries()].sort(([a], [b]) => a - b)) {
+    record[String(id)] = evo;
+  }
+
+  const outputPath = new URL(
+    "../packages/shared/data/pokemon-evolutions.json",
+    import.meta.url,
+  );
+  await Deno.writeTextFile(
+    outputPath,
+    JSON.stringify(record, null, 2) + "\n",
+  );
+  console.log(
+    `\nDone. ${result.size} Pokemon evolution entries written to packages/shared/data/pokemon-evolutions.json`,
+  );
+}
+
+main();

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -1,8 +1,13 @@
 import type {
   DraftPoolItemMetadata,
   Pokemon,
+  PokemonEncountersData,
+  PokemonEvolution,
+  PokemonEvolutionsData,
   PokemonVersion,
   PoolItemAvailability,
+  PoolItemEffort,
+  PoolItemEncounter,
   RegionalPokedexEntry,
 } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
@@ -38,6 +43,101 @@ interface AugmentedPoolItem {
   thumbnailUrl: string | null;
   metadata: DraftPoolItemMetadata | null;
   availability: PoolItemAvailability | null;
+  encounter: PoolItemEncounter | null;
+  effort: PoolItemEffort | null;
+  evolution: PokemonEvolution | null;
+}
+
+interface AugmentContext {
+  regionalDex: RegionalPokedexEntry[] | undefined;
+  gameVersionId: string | undefined;
+  encountersForVersion:
+    | Record<
+      string,
+      {
+        primary: { location: string; method: string } | null;
+        encounters: Array<
+          {
+            location: string;
+            method: string;
+            minLevel: number;
+            maxLevel: number;
+            chance: number;
+          }
+        >;
+      }
+    >
+    | undefined;
+  evolutions: PokemonEvolutionsData | undefined;
+  tradeEvolutionIds: Set<number>;
+}
+
+function isSimpleLevelUpTrigger(
+  t: PokemonEvolution["triggers"][number],
+): boolean {
+  return t.trigger === "level-up" &&
+    t.minLevel !== null &&
+    t.item === null &&
+    t.heldItem === null &&
+    t.knownMove === null &&
+    t.minHappiness === null &&
+    t.timeOfDay === null &&
+    !t.needsOverworldRain &&
+    t.location === null &&
+    t.tradeSpecies === null;
+}
+
+export function computeEffort(deps: {
+  captureRate: number | null;
+  encounter: PoolItemEncounter | null;
+  evolution: PokemonEvolution | null;
+  isTradeEvolution: boolean;
+}): PoolItemEffort {
+  const reasons: string[] = [];
+  let score = 1;
+
+  const bestChance = deps.encounter?.all.length
+    ? Math.max(...deps.encounter.all.map((e) => e.chance))
+    : null;
+  if (bestChance !== null && bestChance > 0 && bestChance < 10) {
+    reasons.push(`Rare encounter (${bestChance}% best chance)`);
+    score += 1;
+  }
+
+  if (!deps.encounter || deps.encounter.all.length === 0) {
+    reasons.push("No wild encounters in this version");
+    score += 1;
+  }
+
+  if (deps.isTradeEvolution) {
+    reasons.push("Trade evolution required");
+    score += 1;
+  }
+
+  if (deps.evolution && deps.evolution.triggers.length > 0) {
+    const hasComplex = deps.evolution.triggers.some(
+      (t) => !isSimpleLevelUpTrigger(t),
+    );
+    if (hasComplex) {
+      reasons.push("Complex evolution requirement");
+      score += 1;
+    } else {
+      const highestLevel = Math.max(
+        ...deps.evolution.triggers.map((t) => t.minLevel ?? 0),
+        0,
+      );
+      if (highestLevel >= 36) {
+        reasons.push(`Evolves at level ${highestLevel}`);
+        score += 1;
+      }
+    }
+  }
+
+  if (reasons.length === 0) {
+    reasons.push("Easy to obtain and field");
+  }
+
+  return { score: Math.min(score, 5), reasons };
 }
 
 export function computeAvailabilityBucket(
@@ -51,20 +151,22 @@ export function computeAvailabilityBucket(
   return "late";
 }
 
-function augmentItemsWithAvailability(
+function augmentItems(
   items: StoredPoolItem[],
-  regionalDex: RegionalPokedexEntry[] | undefined,
+  ctx: AugmentContext,
+  pokemonById: Map<number, Pokemon>,
 ): AugmentedPoolItem[] {
   const dexByPokemonId = new Map<number, number>();
-  const dexSize = regionalDex?.length ?? 0;
-  if (regionalDex) {
-    for (const entry of regionalDex) {
+  const dexSize = ctx.regionalDex?.length ?? 0;
+  if (ctx.regionalDex) {
+    for (const entry of ctx.regionalDex) {
       dexByPokemonId.set(entry.pokemonId, entry.dexNumber);
     }
   }
 
   return items.map((item) => {
     const metadata = item.metadata as DraftPoolItemMetadata | null;
+
     let availability: PoolItemAvailability | null = null;
     if (metadata && dexSize > 0) {
       const dexNumber = dexByPokemonId.get(metadata.pokemonId);
@@ -72,6 +174,31 @@ function augmentItemsWithAvailability(
         availability = computeAvailabilityBucket(dexNumber, dexSize);
       }
     }
+
+    let encounter: PoolItemEncounter | null = null;
+    if (metadata && ctx.encountersForVersion) {
+      const entry = ctx.encountersForVersion[String(metadata.pokemonId)];
+      if (entry) {
+        encounter = { primary: entry.primary, all: entry.encounters };
+      }
+    }
+
+    let evolution: PokemonEvolution | null = null;
+    if (metadata && ctx.evolutions) {
+      evolution = ctx.evolutions[String(metadata.pokemonId)] ?? null;
+    }
+
+    let effort: PoolItemEffort | null = null;
+    if (metadata) {
+      const pokemon = pokemonById.get(metadata.pokemonId);
+      effort = computeEffort({
+        captureRate: pokemon?.captureRate ?? null,
+        encounter,
+        evolution,
+        isTradeEvolution: ctx.tradeEvolutionIds.has(metadata.pokemonId),
+      });
+    }
+
     return {
       id: item.id,
       draftPoolId: item.draftPoolId,
@@ -79,6 +206,9 @@ function augmentItemsWithAvailability(
       thumbnailUrl: item.thumbnailUrl,
       metadata,
       availability,
+      encounter,
+      effort,
+      evolution,
     };
   });
 }
@@ -117,7 +247,37 @@ export function createDraftPoolService(deps: {
   legendaryPokemonIds?: number[];
   starterPokemonIds?: number[];
   tradeEvolutionPokemonIds?: number[];
+  pokemonEncounters?: PokemonEncountersData;
+  pokemonEvolutions?: PokemonEvolutionsData;
 }) {
+  const pokemonById = new Map<number, Pokemon>(
+    deps.pokemonData.map((p) => [p.id, p]),
+  );
+  const tradeEvolutionIdSet = new Set<number>(
+    deps.tradeEvolutionPokemonIds ?? [],
+  );
+
+  function buildAugmentContext(
+    rulesConfig: RulesConfig | null,
+  ): AugmentContext {
+    const regionalDex = resolveRegionalDexForLeague(
+      rulesConfig,
+      deps.pokemonVersions,
+      deps.regionalPokedexes,
+    );
+    const gameVersionId = rulesConfig?.gameVersion;
+    const encountersForVersion = gameVersionId
+      ? deps.pokemonEncounters?.[gameVersionId]
+      : undefined;
+    return {
+      regionalDex,
+      gameVersionId,
+      encountersForVersion,
+      evolutions: deps.pokemonEvolutions,
+      tradeEvolutionIds: tradeEvolutionIdSet,
+    };
+  }
+
   return {
     async generate(userId: string, input: { leagueId: string }) {
       log.debug(
@@ -283,12 +443,11 @@ export function createDraftPoolService(deps: {
         "draft pool generated",
       );
 
-      const regionalDex = resolveRegionalDexForLeague(
-        rulesConfig,
-        deps.pokemonVersions,
-        deps.regionalPokedexes,
+      const augmentedItems = augmentItems(
+        items,
+        buildAugmentContext(rulesConfig),
+        pokemonById,
       );
-      const augmentedItems = augmentItemsWithAvailability(items, regionalDex);
 
       return { ...pool, items: augmentedItems };
     },
@@ -319,12 +478,11 @@ export function createDraftPoolService(deps: {
 
       const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id);
 
-      const regionalDex = resolveRegionalDexForLeague(
-        league.rulesConfig as RulesConfig | null,
-        deps.pokemonVersions,
-        deps.regionalPokedexes,
+      const augmentedItems = augmentItems(
+        items,
+        buildAugmentContext(league.rulesConfig as RulesConfig | null),
+        pokemonById,
       );
-      const augmentedItems = augmentItemsWithAvailability(items, regionalDex);
 
       return { ...pool, items: augmentedItems };
     },

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -2,12 +2,14 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { TRPCError } from "@trpc/server";
 import type {
   Pokemon,
+  PokemonEncountersData,
+  PokemonEvolutionsData,
   PokemonVersion,
   RegionalPokedexEntry,
 } from "@make-the-pick/shared";
 import type { LeagueRepository } from "../league/league.repository.ts";
 import type { DraftPoolRepository } from "./draft-pool.repository.ts";
-import { createDraftPoolService } from "./draft-pool.service.ts";
+import { computeEffort, createDraftPoolService } from "./draft-pool.service.ts";
 
 type FakeLeague = Awaited<ReturnType<LeagueRepository["findById"]>>;
 type FakePlayer = Awaited<ReturnType<LeagueRepository["findPlayer"]>>;
@@ -1329,6 +1331,269 @@ Deno.test("draftPoolService.generate: populates availability on returned items",
       `item ${item.name} should have an availability bucket, got ${bucket}`,
     );
   }
+});
+
+// --- encounter, effort, evolution derivation ---
+
+const fakeEncounters: PokemonEncountersData = {
+  emerald: {
+    "1": {
+      primary: { location: "Route 101", method: "Walk" },
+      encounters: [
+        {
+          location: "Route 101",
+          method: "Walk",
+          minLevel: 3,
+          maxLevel: 5,
+          chance: 30,
+        },
+      ],
+    },
+    "2": {
+      primary: { location: "Rare Cave", method: "Walk" },
+      encounters: [
+        {
+          location: "Rare Cave",
+          method: "Walk",
+          minLevel: 25,
+          maxLevel: 30,
+          chance: 5,
+        },
+      ],
+    },
+  },
+};
+
+const fakeEvolutions: PokemonEvolutionsData = {
+  "1": {
+    pokemonId: 1,
+    chainId: 1,
+    evolvesFromId: null,
+    triggers: [],
+  },
+  "2": {
+    pokemonId: 2,
+    chainId: 1,
+    evolvesFromId: 1,
+    triggers: [
+      {
+        trigger: "level-up",
+        minLevel: 45,
+        item: null,
+        heldItem: null,
+        knownMove: null,
+        minHappiness: null,
+        timeOfDay: null,
+        needsOverworldRain: false,
+        location: null,
+        tradeSpecies: null,
+      },
+    ],
+  },
+};
+
+Deno.test("computeEffort: low score when the Pokemon is easy to obtain", () => {
+  const result = computeEffort({
+    captureRate: 190,
+    encounter: {
+      primary: { location: "Route 101", method: "Walk" },
+      all: [
+        {
+          location: "Route 101",
+          method: "Walk",
+          minLevel: 3,
+          maxLevel: 5,
+          chance: 30,
+        },
+      ],
+    },
+    evolution: null,
+    isTradeEvolution: false,
+  });
+  assertEquals(result.score, 1);
+});
+
+Deno.test("computeEffort: high score when the Pokemon is rare, trade-evo, and late-level", () => {
+  const result = computeEffort({
+    captureRate: 25,
+    encounter: {
+      primary: { location: "Secret Cave", method: "Walk" },
+      all: [
+        {
+          location: "Secret Cave",
+          method: "Walk",
+          minLevel: 40,
+          maxLevel: 45,
+          chance: 3,
+        },
+      ],
+    },
+    evolution: {
+      pokemonId: 68,
+      chainId: 36,
+      evolvesFromId: 67,
+      triggers: [
+        {
+          trigger: "trade",
+          minLevel: null,
+          item: null,
+          heldItem: null,
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+    isTradeEvolution: true,
+  });
+  assertEquals(result.score, 4);
+});
+
+Deno.test("computeEffort: flags held-item trade evolutions as complex", () => {
+  const result = computeEffort({
+    captureRate: 190,
+    encounter: {
+      primary: { location: "Route 1", method: "Walk" },
+      all: [
+        {
+          location: "Route 1",
+          method: "Walk",
+          minLevel: 3,
+          maxLevel: 5,
+          chance: 30,
+        },
+      ],
+    },
+    evolution: {
+      pokemonId: 199,
+      chainId: 41,
+      evolvesFromId: 79,
+      triggers: [
+        {
+          trigger: "trade",
+          minLevel: null,
+          item: null,
+          heldItem: "kings-rock",
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+    isTradeEvolution: false,
+  });
+  assertEquals(result.score, 2);
+  assertEquals(
+    result.reasons.some((r) => r.toLowerCase().includes("complex")),
+    true,
+  );
+});
+
+Deno.test("draftPoolService.getByLeagueId: attaches encounter, effort, and evolution", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "emerald",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const storedItems = [
+    createFakeStoredPoolItem(fakePool.id, 1),
+    createFakeStoredPoolItem(fakePool.id, 2),
+  ];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(5),
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: fakeRegionalPokedexes,
+    pokemonEncounters: fakeEncounters,
+    pokemonEvolutions: fakeEvolutions,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  const byId = new Map(
+    result.items.map((item) => [item.metadata?.pokemonId, item]),
+  );
+
+  const commonMon = byId.get(1)!;
+  assertEquals(commonMon.encounter?.primary?.location, "Route 101");
+  assertEquals(commonMon.encounter?.all.length, 1);
+  assertEquals(commonMon.effort?.score, 1);
+  assertEquals(commonMon.evolution?.pokemonId, 1);
+
+  const rareMon = byId.get(2)!;
+  assertEquals(rareMon.encounter?.primary?.location, "Rare Cave");
+  assertEquals(rareMon.effort !== null && rareMon.effort.score > 1, true);
+  assertEquals(rareMon.evolution?.evolvesFromId, 1);
+});
+
+Deno.test("draftPoolService.getByLeagueId: returns null encounter when species has no data in this version", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "emerald",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const storedItems = [createFakeStoredPoolItem(fakePool.id, 999)];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(5),
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: fakeRegionalPokedexes,
+    pokemonEncounters: fakeEncounters,
+    pokemonEvolutions: fakeEvolutions,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  assertEquals(result.items[0].encounter, null);
+  assertEquals(result.items[0].evolution, null);
 });
 
 Deno.test("draftPoolService.generate: throws when all Pokemon are excluded by filters", async () => {

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -1,5 +1,7 @@
 import type {
   Pokemon,
+  PokemonEncountersData,
+  PokemonEvolutionsData,
   PokemonVersion,
   RegionalPokedexEntry,
 } from "@make-the-pick/shared";
@@ -19,6 +21,12 @@ import starterPokemonJson from "../../packages/shared/data/starter-pokemon.json"
   type: "json",
 };
 import tradeEvolutionPokemonJson from "../../packages/shared/data/trade-evolution-pokemon.json" with {
+  type: "json",
+};
+import pokemonEncountersJson from "../../packages/shared/data/pokemon-encounters.json" with {
+  type: "json",
+};
+import pokemonEvolutionsJson from "../../packages/shared/data/pokemon-evolutions.json" with {
   type: "json",
 };
 import type { Hono } from "hono";
@@ -78,6 +86,8 @@ export function createFeatureRouters(db: Database) {
     legendaryPokemonIds: legendaryPokemonJson as number[],
     starterPokemonIds: starterPokemonJson as number[],
     tradeEvolutionPokemonIds: tradeEvolutionPokemonJson as number[],
+    pokemonEncounters: pokemonEncountersJson as PokemonEncountersData,
+    pokemonEvolutions: pokemonEvolutionsJson as PokemonEvolutionsData,
   });
   const draftPoolRouter = createDraftPoolRouter(draftPoolService);
 


### PR DESCRIPTION
## Summary
Phases 2 and 3 of [docs/product/008-contextual-pool-research.md](https://github.com/Tiernebre/make-the-pick/blob/main/docs/product/008-contextual-pool-research.md), bundled into one PR per request. Builds on top of #34 (availability pill, already merged).

### New on the draft pool page
- **Found At** — primary encounter location + method inline, click opens a popover with every location/method/level-range/rarity for that Pokemon in the league's specific game version.
- **Effort** — 1–5 meter scored from encounter rarity, no-wild-encounters, trade-evolution requirement, and complex/late-level evolution triggers. Hover card lists the reasons.
- **Evo** — hover card describing the evolution lineage and trigger (level, item, trade, happiness, time of day, held item, etc.).

### Data pipeline
- `scripts/sync-pokemon-encounters.ts` — fetches every Pokemon's `/pokemon/{id}/encounters` from PokeAPI, filters to versions we support, keys by *version* (not version group) so ruby vs sapphire exclusives render correctly, caps at top 10 most-likely encounters per (version, species) to keep the file manageable.
- `scripts/sync-pokemon-evolutions.ts` — walks every distinct evolution chain, dedupes by chain id, captures each species' parent + trigger details.
- Outputs checked in at `packages/shared/data/pokemon-encounters.json` (~2.3 MB) and `pokemon-evolutions.json` (~164 KB).
- New `sync:pokemon-encounters` and `sync:pokemon-evolutions` deno tasks for repeatable refreshes.

### Server
- `createDraftPoolService` takes optional `pokemonEncounters` and `pokemonEvolutions` deps, wired in `server/features/mod.ts`.
- `augmentItems` attaches `encounter`, `effort`, and `evolution` to each pool item alongside the existing `availability`.
- `computeEffort` exported for unit testing.

### Tests
- Server: new unit tests for \`computeEffort\` (easy, rare + trade + late-level, held-item trade evo flagged as complex) and integration tests asserting \`getByLeagueId\` attaches the new fields correctly + falls back to null when a species has no data in the chosen version. **211 → 216 tests.**
- Client: new fixture covers a common Pokemon with encounters and one without; assertions cover the new headers, primary location rendering, em-dash fallback, and effort-meter aria-labels. **182 → 185 tests.**

## Test plan
- [ ] \`deno task test:server\` (216 tests)
- [ ] \`deno task test:client\` (185 tests)
- [ ] \`deno lint\`
- [ ] Manual: open a league with \`gameVersion: emerald\`, verify Found At inline + popover, Effort meter + hover card, Evo hover card.
- [ ] Manual: verify Pokemon with no encounters in the version (legendaries, post-game) still render a sensible Effort score and em-dash in Found At.

🤖 Generated with [Claude Code](https://claude.com/claude-code)