### PR TITLE
feat(draft): dev-only NPC players to fill draft pool

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -10,6 +10,8 @@ const {
   mockDeleteMutate,
   mockUseAdvanceLeagueStatus,
   mockAdvanceMutate,
+  mockUseAddNpcPlayer,
+  mockAddNpcMutate,
 } = vi.hoisted(
   () => ({
     mockUseLeague: vi.fn(),
@@ -18,6 +20,8 @@ const {
     mockDeleteMutate: vi.fn(),
     mockUseAdvanceLeagueStatus: vi.fn(),
     mockAdvanceMutate: vi.fn(),
+    mockUseAddNpcPlayer: vi.fn(),
+    mockAddNpcMutate: vi.fn(),
   }),
 );
 
@@ -26,6 +30,7 @@ vi.mock("./use-leagues", () => ({
   useLeaguePlayers: mockUseLeaguePlayers,
   useDeleteLeague: mockUseDeleteLeague,
   useAdvanceLeagueStatus: mockUseAdvanceLeagueStatus,
+  useAddNpcPlayer: mockUseAddNpcPlayer,
 }));
 
 vi.mock("../../auth", () => ({
@@ -69,6 +74,10 @@ describe("LeagueDetailPage", () => {
     });
     mockUseAdvanceLeagueStatus.mockReturnValue({
       mutate: mockAdvanceMutate,
+      isPending: false,
+    });
+    mockUseAddNpcPlayer.mockReturnValue({
+      mutate: mockAddNpcMutate,
       isPending: false,
     });
   });

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -26,11 +26,14 @@ import { useSession } from "../../auth";
 import { LifecycleStepper } from "./LifecycleStepper";
 import { TrainerCard } from "./TrainerCard";
 import {
+  useAddNpcPlayer,
   useAdvanceLeagueStatus,
   useDeleteLeague,
   useLeague,
   useLeaguePlayers,
 } from "./use-leagues";
+
+const IS_DEV = import.meta.env.DEV;
 
 const NEXT_STATUS: Record<string, string | null> = {
   setup: "drafting",
@@ -50,6 +53,7 @@ export function LeagueDetailPage() {
   const { data: session } = useSession();
   const deleteLeague = useDeleteLeague();
   const advanceStatus = useAdvanceLeagueStatus();
+  const addNpcPlayer = useAddNpcPlayer();
   const [, navigate] = useLocation();
 
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
@@ -233,6 +237,11 @@ export function LeagueDetailPage() {
                               .slice(0, 2)}
                           </Avatar>
                           <Text size="sm">{player.name}</Text>
+                          {player.isNpc && (
+                            <Badge variant="light" color="grape" size="xs">
+                              NPC
+                            </Badge>
+                          )}
                         </Group>
                         <Badge variant="light" size="sm" tt="capitalize">
                           {player.role}
@@ -243,6 +252,17 @@ export function LeagueDetailPage() {
                       <Text c="dimmed" size="sm">
                         No players yet.
                       </Text>
+                    )}
+                    {IS_DEV && isCommissioner &&
+                      league.data.status === "setup" && (
+                      <Button
+                        variant="light"
+                        size="xs"
+                        loading={addNpcPlayer.isPending}
+                        onClick={() => addNpcPlayer.mutate({ leagueId: id! })}
+                      >
+                        + Add NPC (dev)
+                      </Button>
                     )}
                   </Stack>
                 </Card>

--- a/client/src/features/league/use-leagues.ts
+++ b/client/src/features/league/use-leagues.ts
@@ -49,6 +49,15 @@ export function useAdvanceLeagueStatus() {
   });
 }
 
+export function useAddNpcPlayer() {
+  const utils = trpc.useUtils();
+  return trpc.league.addNpcPlayer.useMutation({
+    onSuccess: (_data, variables) => {
+      utils.league.listPlayers.invalidate({ leagueId: variables.leagueId });
+    },
+  });
+}
+
 export function useDeleteLeague() {
   const utils = trpc.useUtils();
   return trpc.league.delete.useMutation({

--- a/docs/domain/league.md
+++ b/docs/domain/league.md
@@ -98,6 +98,17 @@ The `rules_config` field stores draft-related settings as a JSON object:
 | numberOfRounds       | integer (≥ 1)           | Number of draft rounds            |
 | pickTimeLimitSeconds | integer (≥ 1) \| null   | Seconds per pick, null = no limit |
 
+## NPC Players (dev only)
+
+Users carry an `isNpc` boolean flag (default `false`). NPC users are seeded by
+`deno task seed:dev` as a reusable pool and are added to leagues via the
+dev-only `league.addNpcPlayer` tRPC procedure, which is blocked in production.
+
+When an NPC is on the clock during a draft, the server schedules an auto-pick
+after a short random "thinking" delay (300–1500 ms) that picks a random
+available pool item. This lets a single developer exercise full draft flows
+without needing other humans to fill the remaining seats.
+
 ## Max Players Enforcement
 
 When `max_players` is set, the server rejects join attempts (via invite code)

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -129,6 +129,7 @@ export const leaguePlayerSchema: z.ZodObject<{
   userId: z.ZodString;
   name: z.ZodString;
   image: z.ZodNullable<z.ZodString>;
+  isNpc: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>;
   role: typeof leaguePlayerRoleSchema;
   joinedAt: z.ZodString;
 }> = object({
@@ -136,6 +137,7 @@ export const leaguePlayerSchema: z.ZodObject<{
   userId: string(),
   name: string(),
   image: string().nullable(),
+  isNpc: boolean().optional().default(false),
   role: leaguePlayerRoleSchema,
   joinedAt: string(),
 });

--- a/server/cli/seed/seed-dev.ts
+++ b/server/cli/seed/seed-dev.ts
@@ -11,6 +11,17 @@ const log = logger.child({ module: "cli.seed.dev" });
 const DEV_USER_ID = "dev-tiernebre";
 const DEV_USER_EMAIL = "tiernebre@gmail.com";
 
+const NPC_NAMES = [
+  "Professor Oak",
+  "Professor Elm",
+  "Professor Birch",
+  "Professor Rowan",
+  "Professor Juniper",
+  "Professor Sycamore",
+  "Professor Kukui",
+  "Professor Magnolia",
+];
+
 const LEAGUE_STATUSES = ["setup", "drafting", "competing", "complete"] as const;
 
 interface DevLeagueSpec {
@@ -85,6 +96,25 @@ async function ensureDevUser(db: Db) {
 
   log.info({ email: DEV_USER_EMAIL }, "dev user created");
   return user;
+}
+
+async function ensureNpcUsers(db: Db) {
+  const now = new Date();
+  for (const name of NPC_NAMES) {
+    const id = `npc-${name.toLowerCase().replace(/\s+/g, "-")}`;
+    const email = `${id}@npc.local`;
+    await db.insert(schema.user).values({
+      id,
+      name,
+      email,
+      emailVerified: true,
+      image: null,
+      isNpc: true,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoNothing();
+  }
+  log.info({ count: NPC_NAMES.length }, "NPC users ensured");
 }
 
 async function ensureFakePlayers(db: Db, count: number) {
@@ -347,6 +377,7 @@ export async function seedDev() {
 
   try {
     const devUser = await ensureDevUser(db);
+    await ensureNpcUsers(db);
 
     const existingDevLeagues = await db.select().from(schema.league).where(
       eq(schema.league.createdBy, devUser.id),

--- a/server/db/migrations/0015_dry_stick.sql
+++ b/server/db/migrations/0015_dry_stick.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "is_npc" boolean DEFAULT false NOT NULL;

--- a/server/db/migrations/meta/0015_snapshot.json
+++ b/server/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1118 @@
+{
+  "id": "95770117-8244-4b16-9686-ac7a7190c2f5",
+  "prevId": "1e2557e6-c8c8-4cf9-b95d-5e743deff19b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft": {
+      "name": "draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "draft_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'snake'"
+        },
+        "status": {
+          "name": "status",
+          "type": "draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "pick_order": {
+          "name": "pick_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_pick": {
+          "name": "current_pick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_turn_deadline": {
+          "name": "current_turn_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_league_id_league_id_fk": {
+          "name": "draft_league_id_league_id_fk",
+          "tableFrom": "draft",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "draft_pool_id_draft_pool_id_fk": {
+          "name": "draft_pool_id_draft_pool_id_fk",
+          "tableFrom": "draft",
+          "tableTo": "draft_pool",
+          "columnsFrom": [
+            "pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_league_id_unique": {
+          "name": "draft_league_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pick": {
+      "name": "draft_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_item_id": {
+          "name": "pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_at": {
+          "name": "picked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pick_draft_id_draft_id_fk": {
+          "name": "draft_pick_draft_id_draft_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "draft",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "draft_pick_league_player_id_league_player_id_fk": {
+          "name": "draft_pick_league_player_id_league_player_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_pick_pool_item_id_draft_pool_item_id_fk": {
+          "name": "draft_pick_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pick_position_unique": {
+          "name": "draft_pick_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "pick_number"
+          ]
+        },
+        "draft_pick_item_unique": {
+          "name": "draft_pick_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pool": {
+      "name": "draft_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pool_league_id_league_id_fk": {
+          "name": "draft_pool_league_id_league_id_fk",
+          "tableFrom": "draft_pool",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pool_league_id_unique": {
+          "name": "draft_pool_league_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pool_item": {
+      "name": "draft_pool_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_pool_id": {
+          "name": "draft_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pool_item_draft_pool_id_draft_pool_id_fk": {
+          "name": "draft_pool_item_draft_pool_id_draft_pool_id_fk",
+          "tableFrom": "draft_pool_item",
+          "tableTo": "draft_pool",
+          "columnsFrom": [
+            "draft_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pool_item_unique": {
+          "name": "draft_pool_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_pool_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league": {
+      "name": "league",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "league_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "sport_type": {
+          "name": "sport_type",
+          "type": "sport_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules_config": {
+          "name": "rules_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_created_by_user_id_fk": {
+          "name": "league_created_by_user_id_fk",
+          "tableFrom": "league",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_invite_code_unique": {
+          "name": "league_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_player": {
+      "name": "league_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "league_player_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_player_league_id_league_id_fk": {
+          "name": "league_player_league_id_league_id_fk",
+          "tableFrom": "league_player",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_player_user_id_user_id_fk": {
+          "name": "league_player_user_id_user_id_fk",
+          "tableFrom": "league_player",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_player_unique": {
+          "name": "league_player_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pool_item_note": {
+      "name": "pool_item_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_pool_item_id": {
+          "name": "draft_pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pool_item_note_league_player_id_league_player_id_fk": {
+          "name": "pool_item_note_league_player_id_league_player_id_fk",
+          "tableFrom": "pool_item_note",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pool_item_note_draft_pool_item_id_draft_pool_item_id_fk": {
+          "name": "pool_item_note_draft_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "pool_item_note",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "draft_pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pool_item_note_unique": {
+          "name": "pool_item_note_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_player_id",
+            "draft_pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_npc": {
+          "name": "is_npc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchlist_item": {
+      "name": "watchlist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_pool_item_id": {
+          "name": "draft_pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watchlist_item_league_player_id_league_player_id_fk": {
+          "name": "watchlist_item_league_player_id_league_player_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "watchlist_item_draft_pool_item_id_draft_pool_item_id_fk": {
+          "name": "watchlist_item_draft_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "draft_pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "watchlist_item_unique": {
+          "name": "watchlist_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_player_id",
+            "draft_pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.draft_format": {
+      "name": "draft_format",
+      "schema": "public",
+      "values": [
+        "snake"
+      ]
+    },
+    "public.draft_status": {
+      "name": "draft_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "paused",
+        "complete"
+      ]
+    },
+    "public.league_player_role": {
+      "name": "league_player_role",
+      "schema": "public",
+      "values": [
+        "commissioner",
+        "member"
+      ]
+    },
+    "public.league_status": {
+      "name": "league_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "drafting",
+        "competing",
+        "complete"
+      ]
+    },
+    "public.sport_type": {
+      "name": "sport_type",
+      "schema": "public",
+      "values": [
+        "pokemon"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775812137206,
       "tag": "0014_draft_paused_status",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775851375195,
+      "tag": "0015_dry_stick",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -23,6 +23,7 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").notNull(),
   image: text("image"),
+  isNpc: boolean("is_npc").notNull().default(false),
   createdAt: timestamp("created_at").notNull(),
   updatedAt: timestamp("updated_at").notNull(),
 });

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -105,6 +105,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),

--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -10,6 +10,7 @@ import {
 import { computeTurnDeadline, resolveSnakeTurn } from "./draft-utils.ts";
 import type { DraftEventPublisher } from "./draft.events.ts";
 import type { Clock, DraftTimerScheduler } from "./draft.timers.ts";
+import { type NpcScheduler, randomNpcPickDelayMs } from "./npc-scheduler.ts";
 
 const noopPublisher: DraftEventPublisher = {
   subscribe: () => () => {},
@@ -80,6 +81,19 @@ interface PoolItemWithMetadata {
  * the strongest-on-paper option so auto-picks never hand out obviously bad
  * Pokémon to absent drafters.
  */
+/**
+ * Random pool-item selector used by NPC auto-picks. Dev-only: real auto-picks
+ * on deadline expiry use the deterministic `selectAutoPickItem` above.
+ */
+export function selectRandomPoolItem<T>(
+  availableItems: T[],
+  randomFn: () => number = Math.random,
+): T | null {
+  if (availableItems.length === 0) return null;
+  const index = Math.floor(randomFn() * availableItems.length);
+  return availableItems[index];
+}
+
 export function selectAutoPickItem<T extends PoolItemWithMetadata>(
   availableItems: T[],
 ): T | null {
@@ -167,6 +181,7 @@ function toStateShape(args: {
       userId: player.userId,
       name: player.name,
       image: player.image,
+      isNpc: (player as { isNpc?: boolean }).isNpc ?? false,
       role: player.role,
       joinedAt: player.joinedAt instanceof Date
         ? player.joinedAt.toISOString()
@@ -190,10 +205,14 @@ export function createDraftService(deps: {
   draftEventPublisher?: DraftEventPublisher;
   clock?: Clock;
   timerScheduler?: DraftTimerScheduler;
+  npcScheduler?: NpcScheduler;
+  randomFn?: () => number;
 }) {
   const publisher = deps.draftEventPublisher ?? noopPublisher;
   const clock: Clock = deps.clock ?? { now: () => new Date() };
   const scheduler = deps.timerScheduler;
+  const npcScheduler = deps.npcScheduler;
+  const randomFn = deps.randomFn ?? Math.random;
 
   function publishTurnChange(
     leagueId: string,
@@ -212,6 +231,33 @@ export function createDraftService(deps: {
       },
     };
     publisher.publish(leagueId, event);
+  }
+
+  /**
+   * If the player whose turn it currently is happens to be an NPC, schedule
+   * an auto-pick after a short random "thinking" delay. No-op when no NPC
+   * scheduler is wired (production) or the current player is human.
+   */
+  function maybeScheduleNpcPick(args: {
+    draftId: string;
+    leagueId: string;
+    pickOrder: string[];
+    currentPick: number;
+    players: LeaguePlayerRow[];
+  }) {
+    if (!npcScheduler) return;
+    const turn = resolveSnakeTurn(args.pickOrder, args.currentPick);
+    const player = args.players.find((p) => p.id === turn.leaguePlayerId);
+    const isNpc = (player as { isNpc?: boolean } | undefined)?.isNpc ?? false;
+    if (!isNpc) {
+      npcScheduler.cancel(args.draftId);
+      return;
+    }
+    npcScheduler.schedule(
+      args.draftId,
+      args.leagueId,
+      randomNpcPickDelayMs(randomFn),
+    );
   }
 
   async function loadDraftContext(leagueId: string) {
@@ -322,6 +368,13 @@ export function createDraftService(deps: {
       );
 
       scheduler?.schedule(updated.id, leagueId, deadline);
+      maybeScheduleNpcPick({
+        draftId: updated.id,
+        leagueId,
+        pickOrder: state.draft.pickOrder,
+        currentPick: state.draft.currentPick,
+        players,
+      });
 
       return state;
     },
@@ -501,9 +554,17 @@ export function createDraftService(deps: {
           },
         });
         scheduler?.cancel(draftRow.id);
+        npcScheduler?.cancel(draftRow.id);
       } else {
         publishTurnChange(leagueId, pickOrder, nextPick, nextDeadline);
         scheduler?.schedule(draftRow.id, leagueId, nextDeadline);
+        maybeScheduleNpcPick({
+          draftId: draftRow.id,
+          leagueId,
+          pickOrder,
+          currentPick: nextPick,
+          players,
+        });
       }
 
       return state;
@@ -610,9 +671,122 @@ export function createDraftService(deps: {
           data: { completedAt: now.toISOString() },
         });
         scheduler?.cancel(draftRow.id);
+        npcScheduler?.cancel(draftRow.id);
       } else {
         publishTurnChange(leagueId, pickOrder, nextPick, nextDeadline);
         scheduler?.schedule(draftRow.id, leagueId, nextDeadline);
+        maybeScheduleNpcPick({
+          draftId: draftRow.id,
+          leagueId,
+          pickOrder,
+          currentPick: nextPick,
+          players,
+        });
+      }
+    },
+
+    /**
+     * Dev-only: auto-pick driven by the NPC scheduler when an NPC player is
+     * on the clock. Unlike `runAutoPick`, this does NOT check the turn
+     * deadline — it fires after a short "thinking" delay regardless of the
+     * configured pick time limit. Picks a random pool item so a single
+     * developer can exercise full draft flows without recruiting humans.
+     */
+    async runNpcPick(
+      { leagueId }: { leagueId: string },
+    ) {
+      log.debug({ leagueId }, "running NPC auto-pick");
+      if (!npcScheduler) return;
+      const { league, players, poolItems } = await loadDraftContext(leagueId);
+
+      const draftRow = await deps.draftRepo.findByLeagueId(leagueId);
+      if (!draftRow) return;
+      if (draftRow.status !== "in_progress") return;
+
+      const pickOrder = draftRow.pickOrder as string[];
+      const turn = resolveSnakeTurn(pickOrder, draftRow.currentPick);
+      const currentPlayer = players.find((p) => p.id === turn.leaguePlayerId);
+      if (!currentPlayer) return;
+      const isNpc = (currentPlayer as { isNpc?: boolean }).isNpc ?? false;
+      if (!isNpc) return;
+
+      const picks = await deps.draftRepo.listPicks(draftRow.id);
+      const pickedItemIds = new Set(picks.map((p) => p.poolItemId));
+      const available = poolItems.filter((item) => !pickedItemIds.has(item.id));
+      const chosen = selectRandomPoolItem(available, randomFn);
+      if (!chosen) return;
+
+      let createdPickRow: Awaited<
+        ReturnType<DraftRepository["createPick"]>
+      >;
+      try {
+        createdPickRow = await deps.draftRepo.createPick({
+          draftId: draftRow.id,
+          leaguePlayerId: currentPlayer.id,
+          poolItemId: chosen.id,
+          pickNumber: draftRow.currentPick,
+          autoPicked: true,
+        });
+      } catch (err) {
+        if (err instanceof DraftPickConflictError) return;
+        throw err;
+      }
+
+      const nextPick = await deps.draftRepo.incrementCurrentPick(draftRow.id);
+      const numberOfRounds = getNumberOfRounds(league);
+      const totalPicks = numberOfRounds * pickOrder.length;
+      const isFinalPick = nextPick >= totalPicks;
+
+      const now = clock.now();
+      let nextDeadline: Date | null = null;
+      if (isFinalPick) {
+        await deps.draftRepo.updateStatus(draftRow.id, "complete", {
+          completedAt: now,
+        });
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, null);
+      } else {
+        const pickTimeLimitSeconds = getPickTimeLimitSeconds(league);
+        nextDeadline = computeTurnDeadline(now, pickTimeLimitSeconds);
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, nextDeadline);
+      }
+
+      const pickRound =
+        resolveSnakeTurn(pickOrder, createdPickRow.pickNumber).round;
+      publisher.publish(leagueId, {
+        type: "draft:pick_made",
+        data: {
+          id: createdPickRow.id,
+          draftId: createdPickRow.draftId,
+          leaguePlayerId: createdPickRow.leaguePlayerId,
+          poolItemId: createdPickRow.poolItemId,
+          pickNumber: createdPickRow.pickNumber,
+          pickedAt: createdPickRow.pickedAt instanceof Date
+            ? createdPickRow.pickedAt.toISOString()
+            : String(createdPickRow.pickedAt),
+          autoPicked: true,
+          playerName: currentPlayer.name,
+          itemName: chosen.name,
+          round: pickRound,
+        },
+      });
+
+      if (isFinalPick) {
+        publisher.publish(leagueId, {
+          type: "draft:completed",
+          data: { completedAt: now.toISOString() },
+        });
+        scheduler?.cancel(draftRow.id);
+        npcScheduler.cancel(draftRow.id);
+      } else {
+        publishTurnChange(leagueId, pickOrder, nextPick, nextDeadline);
+        scheduler?.schedule(draftRow.id, leagueId, nextDeadline);
+        maybeScheduleNpcPick({
+          draftId: draftRow.id,
+          leagueId,
+          pickOrder,
+          currentPick: nextPick,
+          players,
+        });
       }
     },
 
@@ -648,6 +822,7 @@ export function createDraftService(deps: {
       const pausedAt = clock.now();
       const updated = await deps.draftRepo.pauseDraft(draftRow.id, pausedAt);
       scheduler?.cancel(draftRow.id);
+      npcScheduler?.cancel(draftRow.id);
 
       const [players, pool] = await Promise.all([
         deps.leagueRepo.findPlayersByLeagueId(leagueId),
@@ -723,6 +898,13 @@ export function createDraftService(deps: {
         updated.currentPick,
         deadline,
       );
+      maybeScheduleNpcPick({
+        draftId: updated.id,
+        leagueId,
+        pickOrder: updated.pickOrder as string[],
+        currentPick: updated.currentPick,
+        players,
+      });
 
       return state;
     },
@@ -846,6 +1028,15 @@ export function createDraftService(deps: {
           updatedDraft.currentPick,
           newDeadline,
         );
+        maybeScheduleNpcPick({
+          draftId: updatedDraft.id,
+          leagueId,
+          pickOrder,
+          currentPick: updatedDraft.currentPick,
+          players,
+        });
+      } else {
+        npcScheduler?.cancel(draftRow.id);
       }
 
       return state;

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -5,6 +5,7 @@ import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts
 import type { LeagueRepository } from "../league/league.repository.ts";
 import {
   type CreateDraftInput,
+  type CreatePickInput,
   DraftPickConflictError,
   type DraftRepository,
 } from "./draft.repository.ts";
@@ -117,12 +118,14 @@ function createLeaguePlayerRow(
   _leagueId: string,
   userId: string,
   role: "commissioner" | "member" = "member",
+  isNpc = false,
 ) {
   return {
     id: crypto.randomUUID(),
     userId,
     name: userId,
     image: null,
+    isNpc,
     role,
     joinedAt: new Date(),
   };
@@ -152,6 +155,7 @@ function createFakeLeagueRepo(
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     ...overrides,
   };
 }
@@ -2322,4 +2326,226 @@ Deno.test("draftService.undoLastPick: pending draft → BAD_REQUEST", async () =
     TRPCError,
   );
   assertEquals(error.code, "BAD_REQUEST");
+});
+
+// --- NPC auto-pick --------------------------------------------------------
+
+interface RecordingNpcScheduler {
+  scheduled: Array<{ draftId: string; leagueId: string; delayMs: number }>;
+  cancelled: string[];
+  schedule(draftId: string, leagueId: string, delayMs: number): void;
+  cancel(draftId: string): void;
+  triggerNowForTest(draftId: string): Promise<void>;
+  setHandler(): void;
+  activeTimerCount(): number;
+}
+
+function createRecordingNpcScheduler(): RecordingNpcScheduler {
+  return {
+    scheduled: [],
+    cancelled: [],
+    schedule(draftId, leagueId, delayMs) {
+      this.scheduled.push({ draftId, leagueId, delayMs });
+    },
+    cancel(draftId) {
+      this.cancelled.push(draftId);
+    },
+    triggerNowForTest: () => Promise.resolve(),
+    setHandler: () => {},
+    activeTimerCount: () => 0,
+  };
+}
+
+Deno.test("draftService.makePick: schedules NPC pick when next player is an NPC", async () => {
+  // Human picks first, NPC is next on the clock after this human pick lands.
+  const league = createFakeLeague({
+    status: "drafting",
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 2,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+    },
+  });
+  const pool = createFakePool(league.id);
+  const human = createLeaguePlayerRow(league.id, "user-1", "commissioner");
+  const npc = createLeaguePlayerRow(league.id, "npc-oak", "member", true);
+  const poolItems = [
+    createFakePoolItem(pool.id, { name: "pikachu" }),
+    createFakePoolItem(pool.id, { name: "charmander" }),
+    createFakePoolItem(pool.id, { name: "bulbasaur" }),
+    createFakePoolItem(pool.id, { name: "squirtle" }),
+  ];
+  const draft = createFakeDraft({
+    leagueId: league.id,
+    poolId: pool.id,
+    status: "in_progress",
+    pickOrder: [human.id, npc.id],
+    currentPick: 0,
+    startedAt: new Date(),
+  });
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+    incrementCurrentPick: () => Promise.resolve(1),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: () => Promise.resolve({ ...human, leagueId: league.id }),
+    findPlayersByLeagueId: () => Promise.resolve([human, npc]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+  const npcScheduler = createRecordingNpcScheduler();
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    npcScheduler,
+    randomFn: () => 0.5,
+  });
+
+  await service.makePick({
+    userId: "user-1",
+    leagueId: league.id,
+    poolItemId: poolItems[0].id,
+  });
+
+  assertEquals(npcScheduler.scheduled.length, 1);
+  assertEquals(npcScheduler.scheduled[0].draftId, draft.id);
+  assertEquals(npcScheduler.scheduled[0].leagueId, league.id);
+  const delay = npcScheduler.scheduled[0].delayMs;
+  assertEquals(delay >= 300 && delay <= 1500, true);
+});
+
+Deno.test("draftService.runNpcPick: creates random autoPicked pick and emits pick_made", async () => {
+  const league = createFakeLeague({
+    status: "drafting",
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 2,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+    },
+  });
+  const pool = createFakePool(league.id);
+  const human = createLeaguePlayerRow(league.id, "user-1", "commissioner");
+  const npc = createLeaguePlayerRow(league.id, "npc-oak", "member", true);
+  const poolItems = [
+    createFakePoolItem(pool.id, { name: "pikachu" }),
+    createFakePoolItem(pool.id, { name: "charmander" }),
+    createFakePoolItem(pool.id, { name: "bulbasaur" }),
+    createFakePoolItem(pool.id, { name: "squirtle" }),
+  ];
+  // NPC is on the clock (currentPick=1).
+  const draft = createFakeDraft({
+    leagueId: league.id,
+    poolId: pool.id,
+    status: "in_progress",
+    pickOrder: [human.id, npc.id],
+    currentPick: 1,
+    startedAt: new Date(),
+  });
+  let createdPick: CreatePickInput | null = null;
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+    incrementCurrentPick: () => Promise.resolve(2),
+    createPick: (input) => {
+      createdPick = input;
+      return Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: input.autoPicked ?? false,
+      });
+    },
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayersByLeagueId: () => Promise.resolve([human, npc]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+  const publisher = createRecordingPublisher();
+  const npcScheduler = createRecordingNpcScheduler();
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+    npcScheduler,
+    // Deterministic randomFn: picks index 0 of the 4-item available pool.
+    randomFn: () => 0,
+  });
+
+  await service.runNpcPick({ leagueId: league.id });
+
+  assertEquals(createdPick !== null, true);
+  assertEquals(createdPick!.leaguePlayerId, npc.id);
+  assertEquals(createdPick!.autoPicked, true);
+  assertEquals(createdPick!.poolItemId, poolItems[0].id);
+  const pickEvent = publisher.published.find((p) =>
+    p.event.type === "draft:pick_made"
+  );
+  assertEquals(pickEvent !== undefined, true);
+});
+
+Deno.test("draftService.runNpcPick: no-op when current player is not an NPC", async () => {
+  const league = createFakeLeague({ status: "drafting" });
+  const pool = createFakePool(league.id);
+  const human = createLeaguePlayerRow(league.id, "user-1", "commissioner");
+  const poolItems = [createFakePoolItem(pool.id)];
+  const draft = createFakeDraft({
+    leagueId: league.id,
+    poolId: pool.id,
+    status: "in_progress",
+    pickOrder: [human.id],
+    currentPick: 0,
+    startedAt: new Date(),
+  });
+  let createPickCalled = false;
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+    createPick: (input) => {
+      createPickCalled = true;
+      return Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: false,
+      });
+    },
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayersByLeagueId: () => Promise.resolve([human]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    npcScheduler: createRecordingNpcScheduler(),
+  });
+
+  await service.runNpcPick({ leagueId: league.id });
+
+  assertEquals(createPickCalled, false);
 });

--- a/server/features/draft/mod.ts
+++ b/server/features/draft/mod.ts
@@ -28,3 +28,5 @@ export type {
   Clock,
   DraftTimerScheduler,
 } from "./draft.timers.ts";
+export { createNpcScheduler } from "./npc-scheduler.ts";
+export type { NpcScheduler } from "./npc-scheduler.ts";

--- a/server/features/draft/npc-scheduler.ts
+++ b/server/features/draft/npc-scheduler.ts
@@ -1,0 +1,94 @@
+import { logger } from "../../logger.ts";
+
+const log = logger.child({ module: "draft.npc-scheduler" });
+
+export type NpcPickHandler = (
+  args: { leagueId: string },
+) => Promise<void>;
+
+/**
+ * Lightweight in-process scheduler for NPC auto-picks. Mirrors the draft
+ * timer scheduler's shape so tests can fire timers deterministically.
+ * Dev-only: NPC players only exist in non-production environments.
+ */
+export interface NpcScheduler {
+  schedule(draftId: string, leagueId: string, delayMs: number): void;
+  cancel(draftId: string): void;
+  triggerNowForTest(draftId: string): Promise<void>;
+  setHandler(handler: NpcPickHandler): void;
+  activeTimerCount(): number;
+}
+
+interface Entry {
+  leagueId: string;
+  timer: number;
+}
+
+export function createNpcScheduler(): NpcScheduler {
+  const timers = new Map<string, Entry>();
+  let handler: NpcPickHandler | null = null;
+
+  function clearExisting(draftId: string): void {
+    const existing = timers.get(draftId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      timers.delete(draftId);
+    }
+  }
+
+  async function fire(draftId: string, leagueId: string): Promise<void> {
+    timers.delete(draftId);
+    if (!handler) {
+      log.warn({ draftId }, "NPC timer fired with no handler wired");
+      return;
+    }
+    try {
+      await handler({ leagueId });
+    } catch (err) {
+      log.error({ err, draftId, leagueId }, "NPC pick handler threw");
+    }
+  }
+
+  return {
+    schedule(draftId, leagueId, delayMs) {
+      clearExisting(draftId);
+      const timer = setTimeout(() => {
+        void fire(draftId, leagueId);
+      }, Math.max(0, delayMs));
+      timers.set(draftId, { leagueId, timer });
+    },
+
+    cancel(draftId) {
+      clearExisting(draftId);
+    },
+
+    async triggerNowForTest(draftId) {
+      const entry = timers.get(draftId);
+      if (!entry) return;
+      clearTimeout(entry.timer);
+      await fire(draftId, entry.leagueId);
+    },
+
+    setHandler(next) {
+      handler = next;
+    },
+
+    activeTimerCount() {
+      return timers.size;
+    },
+  };
+}
+
+/**
+ * Minimum random delay floor (ms) — kept low so dev testing feels snappy
+ * while still simulating a brief "thinking" beat before the NPC picks.
+ */
+export const NPC_PICK_DELAY_MIN_MS = 300;
+export const NPC_PICK_DELAY_MAX_MS = 1500;
+
+export function randomNpcPickDelayMs(
+  randomFn: () => number = Math.random,
+): number {
+  const range = NPC_PICK_DELAY_MAX_MS - NPC_PICK_DELAY_MIN_MS;
+  return NPC_PICK_DELAY_MIN_MS + Math.floor(randomFn() * (range + 1));
+}

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, sql } from "drizzle-orm";
+import { and, count, eq, notInArray, sql } from "drizzle-orm";
 import type { db } from "../../db/mod.ts";
 import { league, leaguePlayer, user } from "../../db/mod.ts";
 import { logger } from "../../logger.ts";
@@ -123,6 +123,7 @@ export function createLeagueRepository(db: Database) {
           userId: leaguePlayer.userId,
           name: user.name,
           image: user.image,
+          isNpc: user.isNpc,
           role: leaguePlayer.role,
           joinedAt: leaguePlayer.joinedAt,
         })
@@ -132,6 +133,25 @@ export function createLeagueRepository(db: Database) {
       log.debug(
         { leagueId, count: rows.length },
         "findPlayersByLeagueId result",
+      );
+      return rows;
+    },
+
+    async findAvailableNpcUsers(leagueId: string) {
+      log.debug({ leagueId }, "finding available NPC users");
+      const existing = await db
+        .select({ userId: leaguePlayer.userId })
+        .from(leaguePlayer)
+        .where(eq(leaguePlayer.leagueId, leagueId));
+      const existingIds = existing.map((r) => r.userId);
+      const rows = await db.select().from(user).where(
+        existingIds.length > 0
+          ? and(eq(user.isNpc, true), notInArray(user.id, existingIds))
+          : eq(user.isNpc, true),
+      );
+      log.debug(
+        { leagueId, count: rows.length },
+        "findAvailableNpcUsers result",
       );
       return rows;
     },

--- a/server/features/league/league.router.ts
+++ b/server/features/league/league.router.ts
@@ -3,9 +3,19 @@ import {
   createLeagueSchema,
   updateLeagueSettingsSchema,
 } from "@make-the-pick/shared";
+import { TRPCError } from "@trpc/server";
 import { object, string } from "zod";
 import { protectedProcedure, router } from "../../trpc/trpc.ts";
 import type { LeagueService } from "./league.service.ts";
+
+function assertDevMode() {
+  if (Deno.env.get("DENO_ENV") === "production") {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Not available in production",
+    });
+  }
+}
 
 export function createLeagueRouter(leagueService: LeagueService) {
   return router({
@@ -54,6 +64,13 @@ export function createLeagueRouter(leagueService: LeagueService) {
       .input(object({ leagueId: string().uuid(), playerUserId: string() }))
       .mutation(({ ctx, input }) => {
         return leagueService.removePlayer(ctx.user.id, input);
+      }),
+
+    addNpcPlayer: protectedProcedure
+      .input(object({ leagueId: string().uuid() }))
+      .mutation(({ ctx, input }) => {
+        assertDevMode();
+        return leagueService.addNpcPlayer(ctx.user.id, input);
       }),
 
     delete: protectedProcedure

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -258,6 +258,56 @@ export function createLeagueService(
       return league;
     },
 
+    async addNpcPlayer(
+      userId: string,
+      input: { leagueId: string },
+    ) {
+      log.debug({ userId, leagueId: input.leagueId }, "adding NPC to league");
+      const league = await deps.leagueRepo.findById(input.leagueId);
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+      const caller = await deps.leagueRepo.findPlayer(input.leagueId, userId);
+      if (caller?.role !== "commissioner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the league commissioner can add NPC players",
+        });
+      }
+      if (league.status !== "setup") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "NPCs can only be added while the league is in setup",
+        });
+      }
+      if (league.maxPlayers !== null) {
+        const playerCount = await deps.leagueRepo.countPlayers(input.leagueId);
+        if (playerCount >= league.maxPlayers) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "League is full",
+          });
+        }
+      }
+      const available = await deps.leagueRepo.findAvailableNpcUsers(
+        input.leagueId,
+      );
+      if (available.length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "No NPC users available — run `deno task seed:dev` to seed the NPC pool",
+        });
+      }
+      const npc = available[0];
+      await deps.leagueRepo.addPlayer(input.leagueId, npc.id);
+      log.debug(
+        { leagueId: input.leagueId, npcId: npc.id, npcName: npc.name },
+        "NPC added to league",
+      );
+      return { userId: npc.id, name: npc.name };
+    },
+
     async removePlayer(
       userId: string,
       input: { leagueId: string; playerUserId: string },

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -71,6 +71,7 @@ function createFakeRepo(
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     ...overrides,
   };
 }
@@ -336,7 +337,8 @@ Deno.test("leagueService.listPlayers: returns players for a league", async () =>
       id: crypto.randomUUID(),
       userId: "user-1",
       name: "Commissioner",
-      image: "https://example.com/avatar1.png",
+      image: "https://example.com/avatar1.png" as string | null,
+      isNpc: false,
       role: "commissioner" as const,
       joinedAt: new Date(),
     },
@@ -344,7 +346,8 @@ Deno.test("leagueService.listPlayers: returns players for a league", async () =>
       id: crypto.randomUUID(),
       userId: "user-2",
       name: "Member",
-      image: null,
+      image: null as string | null,
+      isNpc: false,
       role: "member" as const,
       joinedAt: new Date(),
     },

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -28,6 +28,7 @@ import {
   createDraftRouter,
   createDraftService,
   createDraftTimerScheduler,
+  createNpcScheduler,
   type DraftEventPublisher,
   type DraftService,
   type DraftTimerScheduler,
@@ -87,15 +88,25 @@ export function createFeatureRouters(db: Database) {
   // exists. This breaks the scheduler <-> service circular dependency
   // without resorting to `any` casts or module-level globals.
   const draftTimerScheduler = createDraftTimerScheduler({ draftRepo });
+  // Dev-only NPC scheduler — only wired outside production. When null, the
+  // draft service treats every player as human and skips the NPC auto-pick
+  // code path entirely.
+  const npcScheduler = Deno.env.get("DENO_ENV") !== "production"
+    ? createNpcScheduler()
+    : undefined;
   const draftService = createDraftService({
     draftRepo,
     leagueRepo,
     draftPoolRepo,
     draftEventPublisher,
     timerScheduler: draftTimerScheduler,
+    npcScheduler,
   });
   draftTimerScheduler.setAutoPickHandler(({ leagueId }) =>
     draftService.runAutoPick({ leagueId })
+  );
+  npcScheduler?.setHandler(({ leagueId }) =>
+    draftService.runNpcPick({ leagueId })
   );
   const draftRouter = createDraftRouter(draftService);
 

--- a/server/features/pool-item-note/pool-item-note.service_test.ts
+++ b/server/features/pool-item-note/pool-item-note.service_test.ts
@@ -76,6 +76,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),

--- a/server/features/watchlist/watchlist.service_test.ts
+++ b/server/features/watchlist/watchlist.service_test.ts
@@ -75,6 +75,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),


### PR DESCRIPTION
## Summary
- NPC "bot" players for local draft testing: a developer can fill remaining league seats with NPCs and exercise the full draft flow end-to-end without needing other humans at the keyboard.
- Ships ADR-005's Option B (dev-only tRPC + UI button) directly since it's the variant that's usable during interactive testing.
- Existing `runAutoPick` path (deadline-expiry, deterministic) is untouched — NPC picks use a parallel `runNpcPick` method with a random selector.

## How it works
- `user.is_npc` boolean flag (migration 0015) + a reusable pool of 8 Professor-themed NPC users seeded by `deno task seed:dev`.
- `league.addNpcPlayer` tRPC mutation, guarded by `DENO_ENV !== "production"` at the router layer. UI surfaces a dev-only "+ Add NPC (dev)" button under the players list on the league detail page during `setup`.
- After every turn transition (startDraft / makePick / runAutoPick / resumeDraft / undoLastPick / NPC picks themselves), the draft service checks if the current player is an NPC. If yes, it schedules `runNpcPick` after a random 300–1500 ms "thinking" delay via a new `NpcScheduler` (mirrors the existing `DraftTimerScheduler` shape for testability).
- `runNpcPick` writes an `autoPicked: true` pick using a new `selectRandomPoolItem` selector (random, not best-stats, so repeat runs surface different states).
- `NpcScheduler` is only constructed outside production (gated in `features/mod.ts`), so the NPC code path is inert when `DENO_ENV === "production"`.

## Test plan
- [x] `deno test server/` — 205 passed (3 new NPC tests covering hook scheduling, runNpcPick happy path, and no-op-for-human guard).
- [x] `deno task test:client` — 181 passed (LeagueDetailPage mock updated with `useAddNpcPlayer`).
- [x] `deno lint server/ client/src/features/league/ packages/shared` — clean.
- [x] `deno task seed:dev` — NPC users backfill successfully on re-run.
- [ ] Manual smoke: create a league, click "+ Add NPC" to fill seats, advance to drafting, verify NPCs pick on their turn with a short delay and the draft completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)