### PR TITLE
feat(league): add shareable invite link to league info

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -106,6 +106,15 @@ describe("LeagueDetailPage", () => {
     expect(screen.getByText("ABC123XY")).toBeInTheDocument();
   });
 
+  it("shows a shareable invite link pointing at the join flow", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    renderPage();
+    expect(screen.getByText(/\/join\/ABC123XY/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /copy invite link/i }),
+    ).toBeInTheDocument();
+  });
+
   it("has a back link to the leagues list", () => {
     mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
     renderPage();

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -278,6 +278,40 @@ export function LeagueDetailPage() {
                         </CopyButton>
                       </Group>
                     </Group>
+                    <Stack gap={4}>
+                      <Text size="sm" fw={500}>Share link</Text>
+                      <Group gap={4} wrap="nowrap">
+                        <Text
+                          ff="monospace"
+                          size="xs"
+                          c="dimmed"
+                          style={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {`${globalThis.location.origin}/join/${league.data.inviteCode}`}
+                        </Text>
+                        <CopyButton
+                          value={`${globalThis.location.origin}/join/${league.data.inviteCode}`}
+                        >
+                          {({ copied, copy }) => (
+                            <Tooltip label={copied ? "Copied" : "Copy"}>
+                              <ActionIcon
+                                variant="subtle"
+                                size="sm"
+                                color={copied ? "teal" : "gray"}
+                                onClick={copy}
+                                aria-label="Copy invite link"
+                              >
+                                {copied ? "✓" : "⎘"}
+                              </ActionIcon>
+                            </Tooltip>
+                          )}
+                        </CopyButton>
+                      </Group>
+                    </Stack>
                     <Group justify="space-between">
                       <Text size="sm" fw={500}>Created</Text>
                       <Text size="sm" c="dimmed">


### PR DESCRIPTION
## Summary
- Adds a full `${origin}/join/<inviteCode>` URL with a copy button in the League info card on the league detail page
- Lets commissioners share a one-click join link instead of asking teammates to enter a raw invite code

## Test plan
- [x] `deno task test:client` — 185 passing, including new TDD test for shareable invite link
- [ ] Visit a league detail page, verify the share link appears under the invite code and copies correctly
- [ ] Paste the copied URL in a new browser session and confirm it lands on the join flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)