### PR TITLE
feat(league): show rosters on competing status

### DIFF
--- a/client/src/features/draft/use-draft.ts
+++ b/client/src/features/draft/use-draft.ts
@@ -4,8 +4,11 @@ export function useDraftPool(leagueId: string) {
   return trpc.draftPool.getByLeagueId.useQuery({ leagueId });
 }
 
-export function useDraft(leagueId: string) {
-  return trpc.draft.getState.useQuery({ leagueId });
+export function useDraft(
+  leagueId: string,
+  options?: { enabled?: boolean },
+) {
+  return trpc.draft.getState.useQuery({ leagueId }, options);
 }
 
 export function useMakePick(leagueId: string) {

--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -12,6 +12,7 @@ const {
   mockAdvanceMutate,
   mockUseAddNpcPlayer,
   mockAddNpcMutate,
+  mockUseDraft,
 } = vi.hoisted(
   () => ({
     mockUseLeague: vi.fn(),
@@ -22,6 +23,7 @@ const {
     mockAdvanceMutate: vi.fn(),
     mockUseAddNpcPlayer: vi.fn(),
     mockAddNpcMutate: vi.fn(),
+    mockUseDraft: vi.fn(),
   }),
 );
 
@@ -31,6 +33,10 @@ vi.mock("./use-leagues", () => ({
   useDeleteLeague: mockUseDeleteLeague,
   useAdvanceLeagueStatus: mockUseAdvanceLeagueStatus,
   useAddNpcPlayer: mockUseAddNpcPlayer,
+}));
+
+vi.mock("../draft/use-draft", () => ({
+  useDraft: mockUseDraft,
 }));
 
 vi.mock("../../auth", () => ({
@@ -80,6 +86,7 @@ describe("LeagueDetailPage", () => {
       mutate: mockAddNpcMutate,
       isPending: false,
     });
+    mockUseDraft.mockReturnValue({ data: undefined, isLoading: false });
   });
 
   afterEach(() => {
@@ -477,6 +484,122 @@ describe("LeagueDetailPage", () => {
     expect(screen.getByText(/legendaries/i)).toBeInTheDocument();
     expect(screen.getByText(/trade evolutions/i)).toBeInTheDocument();
     expect(screen.queryByText(/^starters$/i)).not.toBeInTheDocument();
+  });
+
+  it("renders rosters for each player when league is competing", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        status: "competing",
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          numberOfRounds: 2,
+          pickTimeLimitSeconds: null,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    mockUseDraft.mockReturnValue({
+      data: {
+        draft: {
+          id: "d1",
+          leagueId: "league-1",
+          status: "completed",
+          currentPick: 4,
+          pickOrder: ["p1", "p2"],
+        },
+        players: [
+          {
+            id: "p1",
+            userId: "user-1",
+            name: "Alice",
+            image: null,
+            isNpc: false,
+            role: "commissioner",
+            joinedAt: "2026-01-01T00:00:00Z",
+          },
+          {
+            id: "p2",
+            userId: "user-2",
+            name: "Bob",
+            image: null,
+            isNpc: false,
+            role: "member",
+            joinedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        picks: [
+          {
+            id: "pk1",
+            draftId: "d1",
+            leaguePlayerId: "p1",
+            poolItemId: "pi1",
+            pickNumber: 1,
+            pickedAt: "2026-01-01T00:00:00Z",
+            autoPicked: false,
+          },
+          {
+            id: "pk2",
+            draftId: "d1",
+            leaguePlayerId: "p2",
+            poolItemId: "pi2",
+            pickNumber: 2,
+            pickedAt: "2026-01-01T00:00:00Z",
+            autoPicked: false,
+          },
+        ],
+        poolItems: [
+          {
+            id: "pi1",
+            name: "pikachu",
+            thumbnailUrl: null,
+            metadata: { types: ["electric"] },
+          },
+          {
+            id: "pi2",
+            name: "charizard",
+            thumbnailUrl: null,
+            metadata: { types: ["fire", "flying"] },
+          },
+        ],
+        availableItemIds: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByRole("heading", { name: /^rosters$/i }))
+      .toBeInTheDocument();
+    expect(screen.getByText(/pikachu/i)).toBeInTheDocument();
+    expect(screen.getByText(/charizard/i)).toBeInTheDocument();
+  });
+
+  it("does not fetch draft state when league is in setup", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    renderPage();
+    expect(mockUseDraft).toHaveBeenCalledWith("league-1", { enabled: false });
   });
 
   it("does not render a Save Settings button", () => {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -21,8 +21,11 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconSettings, IconSparkles } from "@tabler/icons-react";
+import { useMemo } from "react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
+import { AllRostersPanel } from "../draft/AllRostersPanel";
+import { useDraft } from "../draft/use-draft";
 import { LifecycleStepper } from "./LifecycleStepper";
 import { TrainerCard } from "./TrainerCard";
 import {
@@ -50,6 +53,9 @@ export function LeagueDetailPage() {
   const { id } = useParams<{ id: string }>();
   const league = useLeague(id!);
   const players = useLeaguePlayers(id!);
+  const draft = useDraft(id!, {
+    enabled: league.data?.status === "competing",
+  });
   const { data: session } = useSession();
   const deleteLeague = useDeleteLeague();
   const advanceStatus = useAdvanceLeagueStatus();
@@ -98,6 +104,17 @@ export function LeagueDetailPage() {
   const currentUserPlayer = players.data?.find(
     (p) => p.userId === session?.user?.id,
   );
+
+  const poolItemsById = useMemo(() => {
+    const map: Record<
+      string,
+      NonNullable<typeof draft.data>["poolItems"][number]
+    > = {};
+    for (const item of draft.data?.poolItems ?? []) {
+      map[item.id] = item;
+    }
+    return map;
+  }, [draft.data]);
 
   return (
     <Container size="lg" py="xl" pos="relative">
@@ -409,6 +426,15 @@ export function LeagueDetailPage() {
               </Stack>
             </Grid.Col>
           </Grid>
+
+          {league.data.status === "competing" && draft.data && (
+            <Card shadow="sm" padding="lg" radius="md" withBorder mt="lg">
+              <AllRostersPanel
+                draftState={draft.data}
+                poolItemsById={poolItemsById}
+              />
+            </Card>
+          )}
 
           {isCommissioner && (
             <Group justify="flex-end" mt="xl">


### PR DESCRIPTION
## Summary
- Render each player's drafted roster on the league detail page once the league reaches the `competing` status
- Reuses the existing `AllRostersPanel` from the draft feature, hydrated via `draft.getState` (the procedure already returns picks + players + pool items regardless of draft status)
- `useDraft` now accepts an `enabled` option so setup/drafting leagues don't fire the extra query

## Test plan
- [x] `deno task test:client` (186/186)
- [x] `deno lint`
- [ ] Manually verify a competing league shows rosters and a drafting league does not