### PR TITLE
feat(picks): add Picks page for competing phase

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,7 +40,7 @@ import {
   LeagueListPage,
   LeagueSettingsPage,
 } from "./features/league/mod";
-import { DraftPage, DraftPoolPage } from "./features/draft/mod";
+import { DraftPage, DraftPoolPage, PicksPage } from "./features/draft/mod";
 
 export function App() {
   return (
@@ -58,6 +58,13 @@ export function App() {
               <AuthGuard>
                 <AppLayout>
                   <CreateLeaguePage />
+                </AppLayout>
+              </AuthGuard>
+            </Route>
+            <Route path="/leagues/:id/picks">
+              <AuthGuard>
+                <AppLayout>
+                  <PicksPage />
                 </AppLayout>
               </AuthGuard>
             </Route>

--- a/client/src/features/draft/PicksPage.test.tsx
+++ b/client/src/features/draft/PicksPage.test.tsx
@@ -1,0 +1,189 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { PicksPage } from "./PicksPage";
+import { makeDraftState, makePick, makePlayer, makePoolItem } from "./fixtures";
+
+const {
+  mockUseLeague,
+  mockUseDraft,
+} = vi.hoisted(() => ({
+  mockUseLeague: vi.fn(),
+  mockUseDraft: vi.fn(),
+}));
+
+vi.mock("../league/use-leagues", () => ({
+  useLeague: mockUseLeague,
+}));
+
+vi.mock("./use-draft", () => ({
+  useDraft: mockUseDraft,
+}));
+
+vi.mock("wouter", async () => {
+  const actual = await vi.importActual<typeof import("wouter")>("wouter");
+  return {
+    ...actual,
+    useParams: () => ({ id: "league-1" }),
+  };
+});
+
+const players = [
+  makePlayer("p1", "Alice"),
+  makePlayer("p2", "Bob"),
+];
+
+const poolItems = [
+  makePoolItem("item-1", "bulbasaur", ["grass"]),
+  makePoolItem("item-2", "charmander", ["fire"]),
+  makePoolItem("item-3", "squirtle", ["water"]),
+  makePoolItem("item-4", "pikachu", ["electric"]),
+];
+
+const picks = [
+  makePick("item-2", "p1", 0),
+  makePick("item-3", "p2", 1),
+  makePick("item-4", "p2", 2),
+  makePick("item-1", "p1", 3),
+];
+
+function makeCompletedLeague(status: string) {
+  return {
+    id: "league-1",
+    name: "Test League",
+    status,
+    inviteCode: "ABC123XY",
+    sportType: "pokemon",
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 2,
+      pickTimeLimitSeconds: null,
+    },
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function renderPage() {
+  return render(
+    <MantineProvider>
+      <PicksPage />
+    </MantineProvider>,
+  );
+}
+
+describe("PicksPage", () => {
+  beforeEach(() => {
+    mockUseLeague.mockReturnValue({
+      data: makeCompletedLeague("competing"),
+      isLoading: false,
+    });
+    mockUseDraft.mockReturnValue({
+      data: makeDraftState({
+        status: "complete",
+        players,
+        poolItems,
+        picks,
+        currentPick: 4,
+      }),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the league name in the title", () => {
+    renderPage();
+    expect(screen.getByText("Test League — Picks")).toBeInTheDocument();
+  });
+
+  it("has a back link to the league detail page", () => {
+    renderPage();
+    expect(
+      screen.getByRole("link", { name: /back to league/i }),
+    ).toHaveAttribute("href", "/leagues/league-1");
+  });
+
+  it("shows a loading overlay while league or draft data is loading", () => {
+    mockUseLeague.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseDraft.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    renderPage();
+    expect(
+      document.querySelector(
+        "[data-mantine-loading-overlay],.mantine-LoadingOverlay-root",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders All Picks and By Team tabs", () => {
+    renderPage();
+    expect(
+      screen.getByRole("tab", { name: /all picks/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /by team/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("lists every pick in the All Picks table with pick number, round, team, and pokemon", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    // header row + 4 picks
+    expect(rows).toHaveLength(5);
+    expect(within(table).getByText("bulbasaur")).toBeInTheDocument();
+    expect(within(table).getByText("charmander")).toBeInTheDocument();
+    expect(within(table).getByText("squirtle")).toBeInTheDocument();
+    expect(within(table).getByText("pikachu")).toBeInTheDocument();
+  });
+
+  it("sorts the All Picks table by pick number ascending by default", () => {
+    renderPage();
+    const table = screen.getByRole("table");
+    const bodyRows = within(table).getAllByRole("row").slice(1);
+    // first pick is charmander (item-2), last is bulbasaur (item-1)
+    expect(bodyRows[0]).toHaveTextContent(/charmander/i);
+    expect(bodyRows[bodyRows.length - 1]).toHaveTextContent(/bulbasaur/i);
+  });
+
+  it("switches to the By Team tab to show the rosters panel", () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /by team/i }));
+    expect(screen.getByText(/alice/i)).toBeInTheDocument();
+    expect(screen.getByText(/bob/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the league is not yet competing", () => {
+    mockUseLeague.mockReturnValue({
+      data: makeCompletedLeague("drafting"),
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.getByText(/picks will be available once the draft is complete/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders picks when the league status is complete", () => {
+    mockUseLeague.mockReturnValue({
+      data: makeCompletedLeague("complete"),
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+});

--- a/client/src/features/draft/PicksPage.tsx
+++ b/client/src/features/draft/PicksPage.tsx
@@ -1,0 +1,212 @@
+import {
+  Anchor,
+  Avatar,
+  Badge,
+  Card,
+  Container,
+  Group,
+  LoadingOverlay,
+  Stack,
+  Tabs,
+  Text,
+  Title,
+} from "@mantine/core";
+import {
+  MantineReactTable,
+  type MRT_ColumnDef,
+  useMantineReactTable,
+} from "mantine-react-table";
+import { useMemo } from "react";
+import { Link, useParams } from "wouter";
+import type { DraftPoolItem } from "@make-the-pick/shared";
+import { useLeague } from "../league/use-leagues";
+import { AllRostersPanel } from "./AllRostersPanel";
+import { useDraft } from "./use-draft";
+import { roundForPick } from "./snake";
+
+interface PickRow {
+  id: string;
+  pickNumber: number;
+  round: number;
+  playerName: string;
+  pokemonName: string;
+  types: string[];
+  thumbnailUrl: string | null;
+  autoPicked: boolean;
+}
+
+export function PicksPage() {
+  const { id } = useParams<{ id: string }>();
+  const leagueId = id!;
+  const league = useLeague(leagueId);
+  const draft = useDraft(leagueId);
+
+  const isLoading = league.isLoading || draft.isLoading;
+  const status = league.data?.status;
+  const picksAvailable = status === "competing" || status === "complete";
+
+  const draftState = draft.data;
+
+  const poolItemsById = useMemo(() => {
+    const map: Record<string, DraftPoolItem> = {};
+    for (const item of draftState?.poolItems ?? []) {
+      map[item.id] = item;
+    }
+    return map;
+  }, [draftState]);
+
+  const pickRows = useMemo<PickRow[]>(() => {
+    if (!draftState) return [];
+    const playerNameById = new Map(
+      draftState.players.map((p) => [p.id, p.name]),
+    );
+    const playersCount = draftState.draft.pickOrder.length;
+    return [...draftState.picks]
+      .sort((a, b) => a.pickNumber - b.pickNumber)
+      .map((pick) => {
+        const item = poolItemsById[pick.poolItemId];
+        return {
+          id: pick.id,
+          pickNumber: pick.pickNumber + 1,
+          round: roundForPick(pick.pickNumber, playersCount) + 1,
+          playerName: playerNameById.get(pick.leaguePlayerId) ?? "—",
+          pokemonName: item?.name ?? "—",
+          types: item?.metadata?.types ?? [],
+          thumbnailUrl: item?.thumbnailUrl ?? null,
+          autoPicked: pick.autoPicked,
+        };
+      });
+  }, [draftState, poolItemsById]);
+
+  const columns = useMemo<MRT_ColumnDef<PickRow>[]>(
+    () => [
+      {
+        accessorKey: "pickNumber",
+        header: "Pick",
+        size: 70,
+      },
+      {
+        accessorKey: "round",
+        header: "Round",
+        size: 80,
+      },
+      {
+        accessorKey: "playerName",
+        header: "Team",
+      },
+      {
+        id: "pokemon",
+        header: "Pokémon",
+        accessorFn: (row) => row.pokemonName,
+        Cell: ({ row }) => (
+          <Group gap="xs" wrap="nowrap">
+            <Avatar
+              src={row.original.thumbnailUrl}
+              alt={row.original.pokemonName}
+              size="sm"
+              radius="sm"
+            />
+            <Text size="sm" fw={500} tt="capitalize">
+              {row.original.pokemonName}
+            </Text>
+          </Group>
+        ),
+      },
+      {
+        id: "types",
+        header: "Types",
+        accessorFn: (row) => row.types.join(", "),
+        Cell: ({ row }) => (
+          <Group gap={4}>
+            {row.original.types.map((t) => (
+              <Badge key={t} size="xs" variant="light" tt="capitalize">
+                {t}
+              </Badge>
+            ))}
+          </Group>
+        ),
+      },
+      {
+        accessorKey: "autoPicked",
+        header: "Auto",
+        size: 70,
+        Cell: ({ row }) =>
+          row.original.autoPicked
+            ? (
+              <Badge size="xs" color="orange" variant="light">
+                AUTO
+              </Badge>
+            )
+            : null,
+      },
+    ],
+    [],
+  );
+
+  const table = useMantineReactTable({
+    columns,
+    data: pickRows,
+    layoutMode: "grid",
+    enableColumnResizing: true,
+    enableGlobalFilter: true,
+    enableStickyHeader: true,
+    enableDensityToggle: true,
+    initialState: {
+      density: "xs",
+      showGlobalFilter: true,
+      sorting: [{ id: "pickNumber", desc: false }],
+    },
+    enablePagination: false,
+    mantineTableContainerProps: { style: { maxHeight: "640px" } },
+  });
+
+  return (
+    <Container size={1400} py="xl" pos="relative">
+      <LoadingOverlay visible={isLoading} />
+
+      <Anchor
+        component={Link}
+        href={`/leagues/${leagueId}`}
+        mb="md"
+        display="block"
+      >
+        &larr; Back to League
+      </Anchor>
+
+      {league.data && (
+        <Title order={1} mb="lg">
+          {league.data.name} — Picks
+        </Title>
+      )}
+
+      {!picksAvailable && !isLoading && (
+        <Card withBorder shadow="sm" padding="lg" radius="md">
+          <Stack gap="xs">
+            <Title order={3}>No picks yet</Title>
+            <Text c="dimmed">
+              Picks will be available once the draft is complete.
+            </Text>
+          </Stack>
+        </Card>
+      )}
+
+      {picksAvailable && draftState && (
+        <Tabs defaultValue="all" keepMounted={false}>
+          <Tabs.List>
+            <Tabs.Tab value="all">All Picks</Tabs.Tab>
+            <Tabs.Tab value="by-team">By Team</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="all" pt="md">
+            <MantineReactTable table={table} />
+          </Tabs.Panel>
+          <Tabs.Panel value="by-team" pt="md">
+            <AllRostersPanel
+              draftState={draftState}
+              poolItemsById={poolItemsById}
+            />
+          </Tabs.Panel>
+        </Tabs>
+      )}
+    </Container>
+  );
+}

--- a/client/src/features/draft/mod.ts
+++ b/client/src/features/draft/mod.ts
@@ -1,5 +1,6 @@
 export { DraftPage } from "./DraftPage.tsx";
 export { DraftPoolPage } from "./DraftPoolPage.tsx";
+export { PicksPage } from "./PicksPage.tsx";
 export { DraftBoard } from "./DraftBoard.tsx";
 export { DraftHeader } from "./DraftHeader.tsx";
 export { AvailablePoolTable } from "./AvailablePoolTable.tsx";

--- a/client/src/features/league/LeagueSidebar.test.tsx
+++ b/client/src/features/league/LeagueSidebar.test.tsx
@@ -172,6 +172,37 @@ describe("LeagueSidebar", () => {
     expect(overview.getAttribute("data-active")).toBe("true");
   });
 
+  it("has a Picks link when the league is competing", () => {
+    setup({ leagueStatus: "competing" });
+    renderSidebar({ leagueId: "L1", location: "/leagues/L1" });
+    const picks = screen.getByRole("link", { name: /picks/i });
+    expect(picks).toHaveAttribute("href", "/leagues/L1/picks");
+  });
+
+  it("has a Picks link when the league is complete", () => {
+    setup({ leagueStatus: "complete" });
+    renderSidebar({ leagueId: "L1", location: "/leagues/L1" });
+    const picks = screen.getByRole("link", { name: /picks/i });
+    expect(picks).toHaveAttribute("href", "/leagues/L1/picks");
+  });
+
+  it("disables the Picks link while the league is still drafting", () => {
+    setup({ leagueStatus: "drafting" });
+    renderSidebar({ leagueId: "L1", location: "/leagues/L1" });
+    expect(screen.queryByRole("link", { name: /picks/i })).toBeNull();
+    expect(screen.getByText(/picks/i)).toBeInTheDocument();
+  });
+
+  it("highlights Picks as active on the picks route", () => {
+    setup({ leagueStatus: "competing" });
+    const { container } = renderSidebar({
+      leagueId: "L1",
+      location: "/leagues/L1/picks",
+    });
+    const picks = within(container).getByRole("link", { name: /picks/i });
+    expect(picks.getAttribute("data-active")).toBe("true");
+  });
+
   it("highlights Draft Room as active on the draft route", () => {
     setup();
     const { container } = renderSidebar({

--- a/client/src/features/league/LeagueSidebar.tsx
+++ b/client/src/features/league/LeagueSidebar.tsx
@@ -56,16 +56,19 @@ export function LeagueSidebar(
 
   const status = league.data?.status ?? "setup";
   const draftEnabled = status !== "setup";
+  const picksEnabled = status === "competing" || status === "complete";
   const name = league.data?.name ?? "League";
 
   const overviewHref = `/leagues/${leagueId}`;
   const draftHref = `/leagues/${leagueId}/draft`;
   const poolHref = `/leagues/${leagueId}/draft/pool`;
+  const picksHref = `/leagues/${leagueId}/picks`;
   const settingsHref = `/leagues/${leagueId}/settings`;
 
   const isOverviewActive = location === overviewHref;
   const isDraftActive = location === draftHref;
   const isPoolActive = location === poolHref;
+  const isPicksActive = location === picksHref;
   const isSettingsActive = location === settingsHref;
 
   return (
@@ -132,11 +135,13 @@ export function LeagueSidebar(
           badge="Soon"
         />
         <LeagueNavItem
+          to={picksEnabled ? picksHref : undefined}
           label="Picks"
           icon={<IconChecklist size={20} />}
+          active={isPicksActive}
           collapsed={collapsed}
-          disabled
-          badge="Soon"
+          disabled={!picksEnabled}
+          tooltip={!picksEnabled ? "Available after the draft" : undefined}
         />
         {isCommissioner && (
           <LeagueNavItem


### PR DESCRIPTION
## Summary
- New `PicksPage` at `/leagues/:id/picks` with two tabs: **All Picks** (sortable MantineReactTable of every pick — pick #, round, team, pokemon, types, auto-pick badge) and **By Team** (reuses `AllRostersPanel`).
- Data comes from the existing `draft.getState` tRPC query (no new endpoint) — it already returns picks + players + pool items and only requires league membership.
- `LeagueSidebar` "Picks" nav item is no longer a "Soon" placeholder: it links to the new route when `league.status` is `competing` or `complete`, and stays disabled with a tooltip otherwise. The draft room already surfaces the roster/board during drafting, so Picks is exclusively a post-draft view.

## Test plan
- [x] `deno lint`
- [x] `deno task test:client` — 197 tests pass (9 new `PicksPage` tests, 4 new `LeagueSidebar` tests covering enable/disable/active states).
- [ ] CI: `deno task test:e2e`
- [ ] Manual: visit `/leagues/:id/picks` on a competing league, verify sort/filter in All Picks tab, switch to By Team tab, confirm sidebar link is disabled during `drafting` and active during `competing`/`complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)