### PR TITLE
feat(draft-pool): fall back to pre-evolution encounter locations

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -139,6 +139,7 @@ function LocationCell(
       | {
         primary: { location: string; method: string } | null;
         all: PokemonEncounterSummary[];
+        source?: { pokemonId: number; name: string };
       }
       | null;
   },
@@ -147,6 +148,7 @@ function LocationCell(
     return <span style={{ color: "#999" }}>—</span>;
   }
   const primary = encounter.primary;
+  const source = encounter.source;
   return (
     <Popover width={340} position="right" withArrow shadow="md">
       <Popover.Target>
@@ -163,13 +165,15 @@ function LocationCell(
           </Text>
           <br />
           <Text span size="xs" c="dimmed">
-            {primary.method}
+            {source ? `${primary.method} (as ${source.name})` : primary.method}
           </Text>
         </UnstyledButton>
       </Popover.Target>
       <Popover.Dropdown>
         <Text size="sm" fw={600} mb="xs">
-          All encounters
+          {source
+            ? `Encounters for pre-evolution ${source.name}`
+            : "All encounters"}
         </Text>
         <Table fz="xs" verticalSpacing={4} highlightOnHover>
           <Table.Thead>

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -90,6 +90,8 @@ export {
   poolItemEffortSchema,
   type PoolItemEncounter,
   poolItemEncounterSchema,
+  type PoolItemEncounterSource,
+  poolItemEncounterSourceSchema,
 } from "./schemas/mod.ts";
 export {
   type PokemonMovesEntry,

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -85,6 +85,8 @@ export {
   poolItemEffortSchema,
   type PoolItemEncounter,
   poolItemEncounterSchema,
+  type PoolItemEncounterSource,
+  poolItemEncounterSourceSchema,
 } from "./pokemon-encounters.ts";
 export {
   type EvolutionTrigger,

--- a/packages/shared/schemas/pokemon-encounters.ts
+++ b/packages/shared/schemas/pokemon-encounters.ts
@@ -1,5 +1,17 @@
 import type { z } from "zod";
-import { array, number, object, record, string } from "zod";
+import { array, number, object, optional, record, string } from "zod";
+
+export const poolItemEncounterSourceSchema: z.ZodObject<{
+  pokemonId: z.ZodNumber;
+  name: z.ZodString;
+}> = object({
+  pokemonId: number(),
+  name: string(),
+});
+
+export type PoolItemEncounterSource = z.infer<
+  typeof poolItemEncounterSourceSchema
+>;
 
 export const pokemonEncounterSummarySchema: z.ZodObject<{
   location: z.ZodString;
@@ -55,9 +67,11 @@ export type PokemonEncountersData = z.infer<
 export const poolItemEncounterSchema: z.ZodObject<{
   primary: z.ZodNullable<typeof pokemonEncounterPrimarySchema>;
   all: z.ZodArray<typeof pokemonEncounterSummarySchema>;
+  source: z.ZodOptional<typeof poolItemEncounterSourceSchema>;
 }> = object({
   primary: pokemonEncounterPrimarySchema.nullable(),
   all: array(pokemonEncounterSummarySchema),
+  source: optional(poolItemEncounterSourceSchema),
 });
 
 export type PoolItemEncounter = z.infer<typeof poolItemEncounterSchema>;

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -175,17 +175,44 @@ function augmentItems(
       }
     }
 
-    let encounter: PoolItemEncounter | null = null;
-    if (metadata && ctx.encountersForVersion) {
-      const entry = ctx.encountersForVersion[String(metadata.pokemonId)];
-      if (entry) {
-        encounter = { primary: entry.primary, all: entry.encounters };
-      }
-    }
-
     let evolution: PokemonEvolution | null = null;
     if (metadata && ctx.evolutions) {
       evolution = ctx.evolutions[String(metadata.pokemonId)] ?? null;
+    }
+
+    let encounter: PoolItemEncounter | null = null;
+    if (metadata && ctx.encountersForVersion) {
+      const directEntry = ctx.encountersForVersion[String(metadata.pokemonId)];
+      if (directEntry && directEntry.encounters.length > 0) {
+        encounter = {
+          primary: directEntry.primary,
+          all: directEntry.encounters,
+        };
+      } else if (ctx.evolutions) {
+        // Evolved Pokemon are rarely catchable in the wild. Walk the
+        // pre-evolution chain until we find a stage that has encounters.
+        const seen = new Set<number>([metadata.pokemonId]);
+        let cursor =
+          ctx.evolutions[String(metadata.pokemonId)]?.evolvesFromId ??
+            null;
+        while (cursor !== null && !seen.has(cursor)) {
+          seen.add(cursor);
+          const entry = ctx.encountersForVersion[String(cursor)];
+          if (entry && entry.encounters.length > 0) {
+            const sourcePokemon = pokemonById.get(cursor);
+            encounter = {
+              primary: entry.primary,
+              all: entry.encounters,
+              source: {
+                pokemonId: cursor,
+                name: sourcePokemon?.name ?? String(cursor),
+              },
+            };
+            break;
+          }
+          cursor = ctx.evolutions[String(cursor)]?.evolvesFromId ?? null;
+        }
+      }
     }
 
     let effort: PoolItemEffort | null = null;

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -1597,6 +1597,164 @@ Deno.test("draftPoolService.getByLeagueId: returns null encounter when species h
   assertEquals(result.items[0].evolution, null);
 });
 
+Deno.test("draftPoolService.getByLeagueId: falls back to pre-evolution encounters when evolved Pokemon has none", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "emerald",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  // pokemonId 3 evolves from 2, which evolves from 1. Only 1 has wild encounters.
+  const chainEncounters: PokemonEncountersData = {
+    emerald: {
+      "1": {
+        primary: { location: "Route 101", method: "Walk" },
+        encounters: [
+          {
+            location: "Route 101",
+            method: "Walk",
+            minLevel: 3,
+            maxLevel: 5,
+            chance: 30,
+          },
+        ],
+      },
+    },
+  };
+  const chainEvolutions: PokemonEvolutionsData = {
+    "1": { pokemonId: 1, chainId: 1, evolvesFromId: null, triggers: [] },
+    "2": {
+      pokemonId: 2,
+      chainId: 1,
+      evolvesFromId: 1,
+      triggers: [
+        {
+          trigger: "level-up",
+          minLevel: 16,
+          item: null,
+          heldItem: null,
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+    "3": {
+      pokemonId: 3,
+      chainId: 1,
+      evolvesFromId: 2,
+      triggers: [
+        {
+          trigger: "level-up",
+          minLevel: 36,
+          item: null,
+          heldItem: null,
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+  };
+  const storedItems = [
+    createFakeStoredPoolItem(fakePool.id, 2),
+    createFakeStoredPoolItem(fakePool.id, 3),
+  ];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(5),
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: fakeRegionalPokedexes,
+    pokemonEncounters: chainEncounters,
+    pokemonEvolutions: chainEvolutions,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  const byId = new Map(
+    result.items.map((item) => [item.metadata?.pokemonId, item]),
+  );
+
+  const firstStage = byId.get(2)!;
+  assertEquals(firstStage.encounter?.primary?.location, "Route 101");
+  assertEquals(firstStage.encounter?.source?.pokemonId, 1);
+  assertEquals(firstStage.encounter?.source?.name, "pokemon-1");
+
+  const secondStage = byId.get(3)!;
+  assertEquals(secondStage.encounter?.primary?.location, "Route 101");
+  assertEquals(secondStage.encounter?.all.length, 1);
+  assertEquals(secondStage.encounter?.source?.pokemonId, 1);
+  assertEquals(secondStage.encounter?.source?.name, "pokemon-1");
+});
+
+Deno.test("draftPoolService.getByLeagueId: base-stage encounters have no source", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 5,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      gameVersion: "emerald",
+    },
+  });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const storedItems = [createFakeStoredPoolItem(fakePool.id, 1)];
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId) => Promise.resolve(storedItems),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(5),
+    pokemonVersions: fakePokemonVersions,
+    regionalPokedexes: fakeRegionalPokedexes,
+    pokemonEncounters: fakeEncounters,
+    pokemonEvolutions: fakeEvolutions,
+  });
+
+  const result = await service.getByLeagueId("user-2", fakeLeague.id);
+  assertEquals(result.items[0].encounter?.source ?? null, null);
+});
+
 Deno.test("draftPoolService.generate: throws when all Pokemon are excluded by filters", async () => {
   const fakeLeague = createFakeLeague({
     rulesConfig: {


### PR DESCRIPTION
## Summary
- Evolved Pokemon in the draft pool showed an empty "Found at" column because they're not catchable in the wild. The service now walks `evolvesFromId` until it finds a stage that has encounters in the current game version, and returns those tagged with a new optional `encounter.source` field.
- `LocationCell` renders the source inline ("Walk (as charmander)") and updates the popover header so drafters know the encounters belong to the pre-evolution, not the drafted mon.
- Walks the full chain (not just one hop) so two-step evos like Charizard → Charmeleon → Charmander still resolve when the middle stage also has no wild spawns.

## Test plan
- [x] `deno task test:server` — 216 passing, includes two new tests covering the chain walk and the base-stage no-source case
- [x] `deno task test:client` — 187 passing
- [x] `deno lint`
- [ ] Spot-check in the UI: load a draft pool for a version where Charizard/Raichu are in the pool and confirm the fallback location renders with the pre-evo hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)