### PR TITLE
feat(draft): explain effort score with header tooltip

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -14,11 +14,12 @@ import {
   Table,
   Text,
   Title,
+  Tooltip,
   UnstyledButton,
 } from "@mantine/core";
 import { WatchlistPanel } from "./WatchlistPanel";
 import { PoolItemNoteIcon } from "./PoolItemNoteIcon";
-import { IconStar, IconStarFilled } from "@tabler/icons-react";
+import { IconInfoCircle, IconStar, IconStarFilled } from "@tabler/icons-react";
 import type {
   DraftPoolItem,
   PokemonEncounterSummary,
@@ -465,6 +466,24 @@ export function DraftPoolPage() {
         grow: false,
         size: 90,
         filterVariant: "range",
+        Header: () => (
+          <Group gap={4} wrap="nowrap">
+            <span>Effort</span>
+            <Tooltip
+              label="How much work it takes to field this Pokémon — catching difficulty, how rare it is in the wild, and any evolution requirements (level, trade, items). 1 = easy, 5 = hard."
+              multiline
+              w={260}
+              withArrow
+              position="top"
+            >
+              <IconInfoCircle
+                size={14}
+                style={{ color: "var(--mantine-color-dimmed)" }}
+                aria-label="Effort column info"
+              />
+            </Tooltip>
+          </Group>
+        ),
         Cell: ({ row }) => <EffortMeter effort={row.original.effort} />,
       },
       {


### PR DESCRIPTION
## Summary
- Add an info icon + tooltip to the Effort column header on the draft pool page, explaining that the 1–5 score reflects catch difficulty, rarity, and evolution requirements.

## Test plan
- [ ] Hover the Effort column header on the draft pool page and confirm the tooltip renders with the explanatory text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)