### PR TITLE
fix(draft-pool): widen Effort column so header is not truncated

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -468,7 +468,7 @@ export function DraftPoolPage() {
         accessorFn: (row) => row.effort?.score ?? null,
         header: "Effort",
         grow: false,
-        size: 90,
+        size: 140,
         filterVariant: "range",
         Header: () => (
           <Group gap={4} wrap="nowrap">


### PR DESCRIPTION
## Summary
- The Effort column header was rendering as "Effc..." because `size: 90` didn't leave room for the label + info tooltip icon + sort arrow + column actions menu.
- Bumped to 140px — enough for all header controls without eating into space used by the rest of the table.

## Test plan
- [x] `deno task test:client` (200 passed)
- [ ] Visually confirm the Effort header renders fully on `/leagues/:id/draft-pool`