### PR TITLE
feat(draft-pool): rebalance effort scoring toward higher values

### DIFF
--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -96,25 +96,40 @@ export function computeEffort(deps: {
   const reasons: string[] = [];
   let score = 1;
 
-  const bestChance = deps.encounter?.all.length
-    ? Math.max(...deps.encounter.all.map((e) => e.chance))
-    : null;
-  if (bestChance !== null && bestChance > 0 && bestChance < 10) {
-    reasons.push(`Rare encounter (${bestChance}% best chance)`);
-    score += 1;
+  if (deps.captureRate !== null) {
+    if (deps.captureRate <= 45) {
+      reasons.push(`Low catch rate (${deps.captureRate})`);
+      score += 2;
+    } else if (deps.captureRate <= 120) {
+      reasons.push(`Moderate catch rate (${deps.captureRate})`);
+      score += 1;
+    }
   }
 
   if (!deps.encounter || deps.encounter.all.length === 0) {
     reasons.push("No wild encounters in this version");
-    score += 1;
+    score += 2;
+  } else {
+    const bestChance = Math.max(...deps.encounter.all.map((e) => e.chance));
+    if (bestChance > 0 && bestChance < 5) {
+      reasons.push(`Very rare encounter (${bestChance}% best chance)`);
+      score += 2;
+    } else if (bestChance > 0 && bestChance < 15) {
+      reasons.push(`Rare encounter (${bestChance}% best chance)`);
+      score += 1;
+    }
+    if (deps.encounter.source) {
+      reasons.push(
+        `Must catch ${deps.encounter.source.name} and evolve it`,
+      );
+      score += 1;
+    }
   }
 
   if (deps.isTradeEvolution) {
     reasons.push("Trade evolution required");
-    score += 1;
-  }
-
-  if (deps.evolution && deps.evolution.triggers.length > 0) {
+    score += 2;
+  } else if (deps.evolution && deps.evolution.triggers.length > 0) {
     const hasComplex = deps.evolution.triggers.some(
       (t) => !isSimpleLevelUpTrigger(t),
     );
@@ -126,7 +141,10 @@ export function computeEffort(deps: {
         ...deps.evolution.triggers.map((t) => t.minLevel ?? 0),
         0,
       );
-      if (highestLevel >= 36) {
+      if (highestLevel >= 40) {
+        reasons.push(`Evolves at level ${highestLevel}`);
+        score += 2;
+      } else if (highestLevel >= 30) {
         reasons.push(`Evolves at level ${highestLevel}`);
         score += 1;
       }
@@ -137,7 +155,7 @@ export function computeEffort(deps: {
     reasons.push("Easy to obtain and field");
   }
 
-  return { score: Math.min(score, 5), reasons };
+  return { score: Math.max(1, Math.min(score, 5)), reasons };
 }
 
 export function computeAvailabilityBucket(
@@ -218,8 +236,11 @@ function augmentItems(
     let effort: PoolItemEffort | null = null;
     if (metadata) {
       const pokemon = pokemonById.get(metadata.pokemonId);
+      const captureSource = encounter?.source
+        ? pokemonById.get(encounter.source.pokemonId) ?? pokemon
+        : pokemon;
       effort = computeEffort({
-        captureRate: pokemon?.captureRate ?? null,
+        captureRate: captureSource?.captureRate ?? null,
         encounter,
         evolution,
         isTradeEvolution: ctx.tradeEvolutionIds.has(metadata.pokemonId),

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -81,7 +81,7 @@ function createFakePokemonData(count: number): Pokemon[] {
       speed: 50,
     },
     generation: "generation-i",
-    captureRate: 45,
+    captureRate: 190,
     spriteUrl: `https://example.com/sprite-${i + 1}.png`,
   }));
 }
@@ -1450,7 +1450,86 @@ Deno.test("computeEffort: high score when the Pokemon is rare, trade-evo, and la
     },
     isTradeEvolution: true,
   });
+  assertEquals(result.score, 5);
+});
+
+Deno.test("computeEffort: bumps score when pre-evolution must be caught", () => {
+  const result = computeEffort({
+    captureRate: 190,
+    encounter: {
+      primary: { location: "Route 111", method: "Walk" },
+      all: [
+        {
+          location: "Route 111",
+          method: "Walk",
+          minLevel: 18,
+          maxLevel: 22,
+          chance: 20,
+        },
+      ],
+      source: { pokemonId: 111, name: "Rhyhorn" },
+    },
+    evolution: {
+      pokemonId: 112,
+      chainId: 50,
+      evolvesFromId: 111,
+      triggers: [
+        {
+          trigger: "level-up",
+          minLevel: 42,
+          item: null,
+          heldItem: null,
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+    isTradeEvolution: false,
+  });
   assertEquals(result.score, 4);
+});
+
+Deno.test("computeEffort: mid-level evolution adds one point", () => {
+  const result = computeEffort({
+    captureRate: 190,
+    encounter: {
+      primary: { location: "Route 104", method: "Walk" },
+      all: [
+        {
+          location: "Route 104",
+          method: "Walk",
+          minLevel: 5,
+          maxLevel: 7,
+          chance: 25,
+        },
+      ],
+    },
+    evolution: {
+      pokemonId: 20,
+      chainId: 11,
+      evolvesFromId: 19,
+      triggers: [
+        {
+          trigger: "level-up",
+          minLevel: 31,
+          item: null,
+          heldItem: null,
+          knownMove: null,
+          minHappiness: null,
+          timeOfDay: null,
+          needsOverworldRain: false,
+          location: null,
+          tradeSpecies: null,
+        },
+      ],
+    },
+    isTradeEvolution: false,
+  });
+  assertEquals(result.score, 2);
 });
 
 Deno.test("computeEffort: flags held-item trade evolutions as complex", () => {


### PR DESCRIPTION
## Summary
- The prior effort algorithm clustered almost every Pokemon at 1-2/5, with 3+ rare and 4-5 essentially unreachable in practice. The column had little signal.
- Recalibrates `computeEffort` so realistic Emerald-era picks land across the full 1-5 range:
  - Actually uses `captureRate` (previously accepted but ignored): `<=45` +2, `<=120` +1. When encounter is sourced from a pre-evolution, uses that species' capture rate, since that's what the player is catching.
  - Tiered encounter rarity: `<5%` +2, `<15%` +1.
  - `+1` when catchable form is a pre-evolution (catch-then-evolve effort).
  - Trade evolution bumped to `+2` and no longer double-counts with the complex-evolution branch.
  - Tiered evolution level thresholds: `>=30` +1, `>=40` +2 (previously a single `>=36` step worth +1).

## Test plan
- [x] `deno task test:server` (227 passed)
- [ ] Load the Emerald draft pool in the app and sanity-check distribution across realistic picks (Rhydon, Skarmory, Beldum, Dodrio, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)