### PR TITLE
feat(draft-pool): move watchlist into sticky popover

### DIFF
--- a/client/src/features/draft/DraftPoolPage.test.tsx
+++ b/client/src/features/draft/DraftPoolPage.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MantineProvider } from "@mantine/core";
 import { DraftPoolPage } from "./DraftPoolPage";
@@ -294,5 +300,24 @@ describe("DraftPoolPage", () => {
     renderPage();
     const images = screen.getAllByRole("img");
     expect(images.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows a watchlist toggle button with the current count", () => {
+    renderPage();
+    const button = screen.getByRole("button", { name: /watchlist \(0\)/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("keeps the watchlist panel hidden until the toggle is clicked", async () => {
+    renderPage();
+    expect(
+      screen.queryByText(/click the star icon on any player/i),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /watchlist \(0\)/i }));
+
+    expect(
+      await screen.findByText(/click the star icon on any player/i),
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -3,8 +3,8 @@ import {
   Anchor,
   Avatar,
   Badge,
+  Button,
   Container,
-  Grid,
   Group,
   HoverCard,
   List,
@@ -19,7 +19,12 @@ import {
 } from "@mantine/core";
 import { WatchlistPanel } from "./WatchlistPanel";
 import { PoolItemNoteIcon } from "./PoolItemNoteIcon";
-import { IconInfoCircle, IconStar, IconStarFilled } from "@tabler/icons-react";
+import {
+  IconChevronDown,
+  IconInfoCircle,
+  IconStar,
+  IconStarFilled,
+} from "@tabler/icons-react";
 import type {
   DraftPoolItem,
   PokemonEncounterSummary,
@@ -593,21 +598,47 @@ export function DraftPoolPage() {
 
       {league.data && (
         <>
-          <Title order={1} mb="lg">
-            {league.data.name} — Draft Pool
-          </Title>
+          <Group
+            justify="space-between"
+            align="center"
+            mb="lg"
+            style={{
+              position: "sticky",
+              top: 0,
+              zIndex: 3,
+              backgroundColor: "var(--mantine-color-body)",
+              paddingTop: "var(--mantine-spacing-md)",
+              paddingBottom: "var(--mantine-spacing-sm)",
+            }}
+          >
+            <Title order={1}>
+              {league.data.name} — Draft Pool
+            </Title>
+            <Popover
+              width={360}
+              position="bottom-end"
+              withArrow
+              shadow="md"
+              trapFocus
+            >
+              <Popover.Target>
+                <Button
+                  variant="default"
+                  rightSection={<IconChevronDown size={16} />}
+                >
+                  Watchlist ({watchlist.data?.length ?? 0})
+                </Button>
+              </Popover.Target>
+              <Popover.Dropdown p={0}>
+                <WatchlistPanel
+                  leagueId={id!}
+                  poolItems={draftPool.data?.items ?? []}
+                />
+              </Popover.Dropdown>
+            </Popover>
+          </Group>
 
-          <Grid>
-            <Grid.Col span={{ base: 12, lg: 9 }}>
-              <MantineReactTable table={table} />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, lg: 3 }}>
-              <WatchlistPanel
-                leagueId={id!}
-                poolItems={draftPool.data?.items ?? []}
-              />
-            </Grid.Col>
-          </Grid>
+          <MantineReactTable table={table} />
         </>
       )}
     </Container>


### PR DESCRIPTION
## Summary
- Replace the right-hand `WatchlistPanel` sidebar with a sticky header button (`Watchlist (N)`) that opens the panel in a Mantine `Popover`, letting the pool table reclaim full container width and removing the large empty gutter below the sidebar.
- Since each pool row already has a star indicator for watchlisted players, making the full list one click away preserves glanceability where it matters.
- Added tests for the toggle button and for the panel being hidden until clicked.

## Test plan
- [x] `deno task test:client -- DraftPoolPage` (202 passing)
- [x] `cd client && deno task build`
- [ ] Manual: open a league's draft pool, confirm the table uses full width, toggle the watchlist popover, and verify drag-reorder still works inside the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)