### PR TITLE
feat(draft-pool): make page fluid to fill available width

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -584,7 +584,7 @@ export function DraftPoolPage() {
   });
 
   return (
-    <Container size={1800} py="xl" pos="relative">
+    <Container fluid py="xl" pos="relative">
       <LoadingOverlay visible={isLoading} />
 
       <Anchor


### PR DESCRIPTION
## Summary
- Swap fixed 1800px Container for a fluid one on the draft pool page so the table fills the available horizontal space.

## Test plan
- [x] `deno task test:client`
- [ ] Visit `/leagues/:id/draft/pool` on a wide monitor and confirm the table spans the full width