### PR TITLE
feat(npc): spoof Google profile bubble for Sugimori avatars

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -35,6 +35,7 @@ import { useSession } from "../../auth";
 import { AllRostersPanel } from "../draft/AllRostersPanel";
 import { useDraft } from "../draft/use-draft";
 import { LifecycleStepper } from "./LifecycleStepper";
+import { NpcAvatar } from "./NpcAvatar";
 import { TrainerCard } from "./TrainerCard";
 import {
   useAddNpcPlayer,
@@ -251,20 +252,31 @@ export function LeagueDetailPage() {
                       return (
                         <Group key={player.id} justify="space-between">
                           <Group gap="sm">
-                            <Avatar
-                              src={player.image}
-                              alt={player.name}
-                              radius="xl"
-                              size="sm"
-                              color="mint-green"
-                            >
-                              {player.name
-                                .split(" ")
-                                .map((n) => n[0])
-                                .join("")
-                                .toUpperCase()
-                                .slice(0, 2)}
-                            </Avatar>
+                            {player.isNpc
+                              ? (
+                                <NpcAvatar
+                                  name={player.name}
+                                  image={player.image}
+                                  radius="xl"
+                                  size="sm"
+                                />
+                              )
+                              : (
+                                <Avatar
+                                  src={player.image}
+                                  alt={player.name}
+                                  radius="xl"
+                                  size="sm"
+                                  color="mint-green"
+                                >
+                                  {player.name
+                                    .split(" ")
+                                    .map((n) => n[0])
+                                    .join("")
+                                    .toUpperCase()
+                                    .slice(0, 2)}
+                                </Avatar>
+                              )}
                             <Text size="sm">{player.name}</Text>
                             {player.isNpc && (
                               <Badge variant="light" color="grape" size="xs">

--- a/client/src/features/league/NpcAvatar.test.tsx
+++ b/client/src/features/league/NpcAvatar.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MantineProvider } from "@mantine/core";
+import { NpcAvatar } from "./NpcAvatar";
+
+function renderAvatar(props: Parameters<typeof NpcAvatar>[0]) {
+  return render(
+    <MantineProvider>
+      <NpcAvatar {...props} />
+    </MantineProvider>,
+  );
+}
+
+describe("NpcAvatar", () => {
+  afterEach(() => cleanup());
+
+  it("renders the sprite image with the provided src", () => {
+    renderAvatar({
+      name: "Professor Kukui",
+      image: "https://example.com/kukui.png",
+    });
+    const img = screen.getByAltText("Professor Kukui") as HTMLImageElement;
+    expect(img.src).toBe("https://example.com/kukui.png");
+  });
+
+  it("positions the sprite so the head lands inside the bubble", () => {
+    renderAvatar({
+      name: "Cynthia",
+      image: "https://example.com/cynthia.png",
+    });
+    const img = screen.getByAltText("Cynthia");
+    const styles = getComputedStyle(img);
+    expect(styles.objectFit).toBe("cover");
+    expect(styles.objectPosition).toContain("top");
+  });
+
+  it("falls back to initials when no image is provided", () => {
+    renderAvatar({ name: "Red Oak", image: null });
+    expect(screen.getByText("RO")).toBeInTheDocument();
+  });
+
+  it("gives the avatar a deterministic background color derived from the name", () => {
+    const { container: a } = renderAvatar({
+      name: "Archer",
+      image: "https://example.com/archer.png",
+    });
+    const rootA = a.querySelector<HTMLElement>("[data-npc-avatar-root]");
+    expect(rootA).not.toBeNull();
+    const bgA = rootA!.style.backgroundColor;
+    expect(bgA).not.toBe("");
+
+    cleanup();
+
+    const { container: b } = renderAvatar({
+      name: "Archer",
+      image: "https://example.com/archer.png",
+    });
+    const rootB = b.querySelector<HTMLElement>("[data-npc-avatar-root]");
+    expect(rootB!.style.backgroundColor).toBe(bgA);
+  });
+
+  it("gives different names different background colors", () => {
+    const { container: a } = renderAvatar({
+      name: "Cynthia",
+      image: null,
+    });
+    const bgA = a.querySelector<HTMLElement>("[data-npc-avatar-root]")!
+      .style.backgroundColor;
+
+    cleanup();
+
+    const { container: b } = renderAvatar({
+      name: "Giovanni",
+      image: null,
+    });
+    const bgB = b.querySelector<HTMLElement>("[data-npc-avatar-root]")!
+      .style.backgroundColor;
+
+    expect(bgA).not.toBe(bgB);
+  });
+});

--- a/client/src/features/league/NpcAvatar.tsx
+++ b/client/src/features/league/NpcAvatar.tsx
@@ -1,0 +1,56 @@
+import { Avatar, type AvatarProps } from "@mantine/core";
+
+interface NpcAvatarProps extends Omit<AvatarProps, "src" | "alt" | "children"> {
+  name: string;
+  image: string | null;
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase()
+    .slice(0, 2) || "??";
+}
+
+function hashName(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function backgroundColorFor(name: string): string {
+  const hue = hashName(name) % 360;
+  return `hsl(${hue}, 45%, 38%)`;
+}
+
+/**
+ * Spoofs a Google-profile-style bubble for NPC trainers: full-body Sugimori
+ * sprites are cropped to the top of the image so the head lands inside the
+ * circle, and the container gets a deterministic background color so the
+ * bubble still feels filled when the sprite is narrower than the container.
+ */
+export function NpcAvatar({ name, image, style, ...rest }: NpcAvatarProps) {
+  const background = backgroundColorFor(name);
+  return (
+    <Avatar
+      {...rest}
+      src={image ?? undefined}
+      alt={name}
+      data-npc-avatar-root
+      style={{ backgroundColor: background, ...style }}
+      styles={{
+        image: {
+          objectFit: "cover",
+          objectPosition: "center top",
+        },
+      }}
+    >
+      {initialsOf(name)}
+    </Avatar>
+  );
+}


### PR DESCRIPTION
## Summary
- New `NpcAvatar` wraps Mantine's `Avatar` for NPC trainers, top-aligning the Sugimori sprite (`object-position: center top`) so the head — not the torso — lands inside the bubble.
- Paints a deterministic hue-per-name HSL background behind the sprite so the bubble still reads as a filled Google-style profile photo when the sprite's transparent background would otherwise show through.
- Only applied when `player.isNpc === true`; real users' Google profile photos render the same as before.

## Why
The recent Ken Sugimori NPC art (#49) is full-body, and Mantine's default cover + center crop framed the bubble on the torso instead of the head. Fix is entirely client-side — no server/migration change needed.

## Test plan
- [x] TDD: NpcAvatar.test.tsx added with failing tests first, then implementation.
- [x] deno task test:client — 209/209 passing.
- [ ] Manual visual check: load a league detail page with several NPCs and confirm heads are visible in the "Who's in" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)