### PR TITLE
feat(draft-pool): add revealOrder and revealedAt columns

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -227,7 +227,7 @@ describe("LeagueDetailPage", () => {
     });
     renderPage();
     expect(
-      screen.getByRole("button", { name: /advance to drafting/i }),
+      screen.getByRole("button", { name: /advance to pooling/i }),
     ).toBeInTheDocument();
   });
 

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -46,7 +46,9 @@ import {
 } from "./use-leagues";
 
 const NEXT_STATUS: Record<string, string | null> = {
-  setup: "drafting",
+  setup: "pooling",
+  pooling: "scouting",
+  scouting: "drafting",
   drafting: "competing",
   competing: "complete",
   complete: null,

--- a/client/src/features/league/LifecycleStepper.tsx
+++ b/client/src/features/league/LifecycleStepper.tsx
@@ -1,10 +1,18 @@
 import { Box, Group, Text } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 
-type Phase = "setup" | "drafting" | "competing" | "complete";
+type Phase =
+  | "setup"
+  | "pooling"
+  | "scouting"
+  | "drafting"
+  | "competing"
+  | "complete";
 
 const PHASES: { id: Phase; label: string }[] = [
   { id: "setup", label: "Setup" },
+  { id: "pooling", label: "Pooling" },
+  { id: "scouting", label: "Scouting" },
   { id: "drafting", label: "Drafting" },
   { id: "competing", label: "Competing" },
   { id: "complete", label: "Complete" },

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -18,7 +18,7 @@ export const LEAGUE_STATUS_TRANSITIONS: Record<
   LeagueStatus,
   LeagueStatus | null
 > = {
-  setup: "drafting",
+  setup: "pooling",
   pooling: "scouting",
   scouting: "drafting",
   drafting: "competing",

--- a/server/db/migrations/0021_real_eternity.sql
+++ b/server/db/migrations/0021_real_eternity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "draft_pool_item" ADD COLUMN "reveal_order" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "draft_pool_item" ADD COLUMN "revealed_at" timestamp with time zone;

--- a/server/db/migrations/meta/0021_snapshot.json
+++ b/server/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1139 @@
+{
+  "id": "6a320ff0-9946-4911-bed1-e43f6f286358",
+  "prevId": "197c8a12-51d9-49da-a71a-7f9251dcdba9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft": {
+      "name": "draft",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "draft_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'snake'"
+        },
+        "status": {
+          "name": "status",
+          "type": "draft_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "pick_order": {
+          "name": "pick_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_pick": {
+          "name": "current_pick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_turn_deadline": {
+          "name": "current_turn_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_league_id_league_id_fk": {
+          "name": "draft_league_id_league_id_fk",
+          "tableFrom": "draft",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "draft_pool_id_draft_pool_id_fk": {
+          "name": "draft_pool_id_draft_pool_id_fk",
+          "tableFrom": "draft",
+          "tableTo": "draft_pool",
+          "columnsFrom": [
+            "pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_league_id_unique": {
+          "name": "draft_league_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pick": {
+      "name": "draft_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_item_id": {
+          "name": "pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_number": {
+          "name": "pick_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_at": {
+          "name": "picked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "auto_picked": {
+          "name": "auto_picked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pick_draft_id_draft_id_fk": {
+          "name": "draft_pick_draft_id_draft_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "draft",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "draft_pick_league_player_id_league_player_id_fk": {
+          "name": "draft_pick_league_player_id_league_player_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "draft_pick_pool_item_id_draft_pool_item_id_fk": {
+          "name": "draft_pick_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "draft_pick",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pick_position_unique": {
+          "name": "draft_pick_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "pick_number"
+          ]
+        },
+        "draft_pick_item_unique": {
+          "name": "draft_pick_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_id",
+            "pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pool": {
+      "name": "draft_pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pool_league_id_league_id_fk": {
+          "name": "draft_pool_league_id_league_id_fk",
+          "tableFrom": "draft_pool",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pool_league_id_unique": {
+          "name": "draft_pool_league_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_pool_item": {
+      "name": "draft_pool_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_pool_id": {
+          "name": "draft_pool_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reveal_order": {
+          "name": "reveal_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "revealed_at": {
+          "name": "revealed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_pool_item_draft_pool_id_draft_pool_id_fk": {
+          "name": "draft_pool_item_draft_pool_id_draft_pool_id_fk",
+          "tableFrom": "draft_pool_item",
+          "tableTo": "draft_pool",
+          "columnsFrom": [
+            "draft_pool_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "draft_pool_item_unique": {
+          "name": "draft_pool_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "draft_pool_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_checks": {
+      "name": "health_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league": {
+      "name": "league",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "league_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "sport_type": {
+          "name": "sport_type",
+          "type": "sport_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules_config": {
+          "name": "rules_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_created_by_user_id_fk": {
+          "name": "league_created_by_user_id_fk",
+          "tableFrom": "league",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_invite_code_unique": {
+          "name": "league_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_player": {
+      "name": "league_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "league_player_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_player_league_id_league_id_fk": {
+          "name": "league_player_league_id_league_id_fk",
+          "tableFrom": "league_player",
+          "tableTo": "league",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_player_user_id_user_id_fk": {
+          "name": "league_player_user_id_user_id_fk",
+          "tableFrom": "league_player",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "league_player_unique": {
+          "name": "league_player_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pool_item_note": {
+      "name": "pool_item_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_pool_item_id": {
+          "name": "draft_pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pool_item_note_league_player_id_league_player_id_fk": {
+          "name": "pool_item_note_league_player_id_league_player_id_fk",
+          "tableFrom": "pool_item_note",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pool_item_note_draft_pool_item_id_draft_pool_item_id_fk": {
+          "name": "pool_item_note_draft_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "pool_item_note",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "draft_pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pool_item_note_unique": {
+          "name": "pool_item_note_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_player_id",
+            "draft_pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_npc": {
+          "name": "is_npc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "npc_strategy": {
+          "name": "npc_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchlist_item": {
+      "name": "watchlist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_player_id": {
+          "name": "league_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_pool_item_id": {
+          "name": "draft_pool_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watchlist_item_league_player_id_league_player_id_fk": {
+          "name": "watchlist_item_league_player_id_league_player_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "league_player",
+          "columnsFrom": [
+            "league_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "watchlist_item_draft_pool_item_id_draft_pool_item_id_fk": {
+          "name": "watchlist_item_draft_pool_item_id_draft_pool_item_id_fk",
+          "tableFrom": "watchlist_item",
+          "tableTo": "draft_pool_item",
+          "columnsFrom": [
+            "draft_pool_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "watchlist_item_unique": {
+          "name": "watchlist_item_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "league_player_id",
+            "draft_pool_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.draft_format": {
+      "name": "draft_format",
+      "schema": "public",
+      "values": [
+        "snake"
+      ]
+    },
+    "public.draft_status": {
+      "name": "draft_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "paused",
+        "complete"
+      ]
+    },
+    "public.league_player_role": {
+      "name": "league_player_role",
+      "schema": "public",
+      "values": [
+        "commissioner",
+        "member"
+      ]
+    },
+    "public.league_status": {
+      "name": "league_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "pooling",
+        "scouting",
+        "drafting",
+        "competing",
+        "complete"
+      ]
+    },
+    "public.sport_type": {
+      "name": "sport_type",
+      "schema": "public",
+      "values": [
+        "pokemon"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1776320000000,
       "tag": "0020_brendan_may_npcs",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1776330000000,
+      "tag": "0021_real_eternity",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -147,6 +147,8 @@ export const draftPoolItem = pgTable("draft_pool_item", {
   name: text("name").notNull(),
   thumbnailUrl: text("thumbnail_url"),
   metadata: jsonb("metadata"),
+  revealOrder: integer("reveal_order").notNull().default(0),
+  revealedAt: timestamp("revealed_at", { withTimezone: true }),
 }, (table) => [
   unique("draft_pool_item_unique").on(table.draftPoolId, table.name),
 ]);

--- a/server/features/draft-pool/draft-pool.repository.ts
+++ b/server/features/draft-pool/draft-pool.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import type { db } from "../../db/mod.ts";
 import { draftPool, draftPoolItem } from "../../db/mod.ts";
 import { logger } from "../../logger.ts";
@@ -40,13 +40,91 @@ export function createDraftPoolRepository(db: Database) {
       return result ?? null;
     },
 
-    async findItemsByPoolId(poolId: string): Promise<DraftPoolItemRow[]> {
-      log.debug({ poolId }, "finding items for draft pool");
-      const items = await db.select().from(draftPoolItem).where(
-        eq(draftPoolItem.draftPoolId, poolId),
+    async findItemsByPoolId(
+      poolId: string,
+      opts: { onlyRevealed?: boolean } = {},
+    ): Promise<DraftPoolItemRow[]> {
+      log.debug(
+        { poolId, onlyRevealed: opts.onlyRevealed ?? false },
+        "finding items for draft pool",
       );
+      const whereClause = opts.onlyRevealed
+        ? and(
+          eq(draftPoolItem.draftPoolId, poolId),
+          sql`${draftPoolItem.revealedAt} is not null`,
+        )
+        : eq(draftPoolItem.draftPoolId, poolId);
+      const items = await db.select().from(draftPoolItem).where(whereClause);
       log.debug({ poolId, count: items.length }, "findItemsByPoolId result");
       return items;
+    },
+
+    async countUnrevealedItems(poolId: string): Promise<number> {
+      log.debug({ poolId }, "counting unrevealed items");
+      const [row] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(draftPoolItem)
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        );
+      return row?.count ?? 0;
+    },
+
+    async revealNextItem(
+      poolId: string,
+      now: Date,
+    ): Promise<
+      { item: DraftPoolItemRow; remaining: number } | null
+    > {
+      log.debug({ poolId }, "revealing next draft pool item");
+      const [next] = await db
+        .select()
+        .from(draftPoolItem)
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        )
+        .orderBy(asc(draftPoolItem.revealOrder))
+        .limit(1);
+      if (!next) {
+        log.debug({ poolId }, "no unrevealed items remain");
+        return null;
+      }
+      const [updated] = await db
+        .update(draftPoolItem)
+        .set({ revealedAt: now })
+        .where(eq(draftPoolItem.id, next.id))
+        .returning();
+      const remaining = await this.countUnrevealedItems(poolId);
+      log.debug(
+        { poolId, itemId: updated.id, remaining },
+        "draft pool item revealed",
+      );
+      return { item: updated, remaining };
+    },
+
+    async revealAllItems(poolId: string, now: Date): Promise<number> {
+      log.debug({ poolId }, "revealing all remaining draft pool items");
+      const updated = await db
+        .update(draftPoolItem)
+        .set({ revealedAt: now })
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        )
+        .returning({ id: draftPoolItem.id });
+      log.debug(
+        { poolId, count: updated.length },
+        "all draft pool items revealed",
+      );
+      return updated.length;
     },
 
     async deleteByLeagueId(leagueId: string): Promise<void> {

--- a/server/features/draft-pool/draft-pool.repository_test.ts
+++ b/server/features/draft-pool/draft-pool.repository_test.ts
@@ -319,6 +319,167 @@ Deno.test({
 
 Deno.test({
   name:
+    "draftPoolRepository.findItemsByPoolId: filters to revealed items when onlyRevealed is true",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal Filter Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: new Date(),
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const all = await repo.findItemsByPoolId(pool.id);
+      assertEquals(all.length, 2);
+
+      const revealed = await repo.findItemsByPoolId(pool.id, {
+        onlyRevealed: true,
+      });
+      assertEquals(revealed.length, 1);
+      assertEquals(revealed[0].name, "bulbasaur");
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "draftPoolRepository.revealNextItem: reveals the lowest revealOrder unrevealed item",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal Next Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 2,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "squirtle",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const first = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(first?.item.name, "charmander");
+      assertEquals(first?.remaining, 2);
+
+      const second = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(second?.item.name, "squirtle");
+      assertEquals(second?.remaining, 1);
+
+      const third = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(third?.item.name, "bulbasaur");
+      assertEquals(third?.remaining, 0);
+
+      const fourth = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(fourth, null);
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "draftPoolRepository.revealAllItems: stamps every unrevealed item with the given time",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal All Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const count = await repo.revealAllItems(pool.id, new Date());
+      assertEquals(count, 2);
+
+      const revealed = await repo.findItemsByPoolId(pool.id, {
+        onlyRevealed: true,
+      });
+      assertEquals(revealed.length, 2);
+
+      // Calling again reveals nothing new.
+      const second = await repo.revealAllItems(pool.id, new Date());
+      assertEquals(second, 0);
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
     "draftPoolRepository.deleteByLeagueId: removes pool and cascades to items",
   sanitizeResources: false,
   sanitizeOps: false,

--- a/server/features/draft-pool/draft-pool.router.ts
+++ b/server/features/draft-pool/draft-pool.router.ts
@@ -16,5 +16,11 @@ export function createDraftPoolRouter(draftPoolService: DraftPoolService) {
       .query(({ ctx, input }) => {
         return draftPoolService.getByLeagueId(ctx.user.id, input.leagueId);
       }),
+
+    revealNext: protectedProcedure
+      .input(object({ leagueId: string().uuid() }))
+      .mutation(({ ctx, input }) => {
+        return draftPoolService.revealNext(ctx.user.id, input);
+      }),
   });
 }

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -370,10 +370,11 @@ export function createDraftPoolService(deps: {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
       }
 
-      if (league.status !== "setup") {
+      if (league.status !== "setup" && league.status !== "pooling") {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Draft pool can only be generated during league setup",
+          message:
+            "Draft pool can only be generated before the draft has started",
         });
       }
 
@@ -537,8 +538,10 @@ export function createDraftPoolService(deps: {
         "Draft Pool",
       );
 
-      // Map to pool items
-      const poolItems = selected.map((pokemon) => ({
+      // Map to pool items. `selected` is already fisher-yates shuffled, so
+      // using the array index as reveal_order gives a deterministic but
+      // random-looking showcase sequence without a second shuffle.
+      const poolItems = selected.map((pokemon, index) => ({
         draftPoolId: pool.id,
         name: pokemon.name,
         thumbnailUrl: pokemon.spriteUrl,
@@ -548,6 +551,8 @@ export function createDraftPoolService(deps: {
           baseStats: pokemon.baseStats,
           generation: pokemon.generation,
         },
+        revealOrder: index,
+        revealedAt: null,
       }));
 
       const items = await deps.draftPoolRepo.createItems(poolItems);
@@ -590,7 +595,14 @@ export function createDraftPoolService(deps: {
         });
       }
 
-      const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id);
+      // During the "pooling" phase the showcase is mid-reveal: members
+      // (including the commissioner running it) only see items the
+      // commissioner has actually revealed so far. Once the league has
+      // advanced to scouting or beyond, the filter drops and everything is
+      // visible.
+      const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id, {
+        onlyRevealed: league.status === "pooling",
+      });
 
       const augmentedItems = augmentItems(
         items,
@@ -599,6 +611,59 @@ export function createDraftPoolService(deps: {
       );
 
       return { ...pool, items: augmentedItems };
+    },
+
+    async revealNext(userId: string, input: { leagueId: string }) {
+      log.debug(
+        { userId, leagueId: input.leagueId },
+        "revealing next draft pool item",
+      );
+
+      const league = await deps.leagueRepo.findById(input.leagueId);
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+      if (league.status !== "pooling") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Draft pool items can only be revealed during the pooling phase",
+        });
+      }
+      const player = await deps.leagueRepo.findPlayer(
+        input.leagueId,
+        userId,
+      );
+      if (player?.role !== "commissioner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the league commissioner can reveal draft pool items",
+        });
+      }
+
+      const pool = await deps.draftPoolRepo.findByLeagueId(input.leagueId);
+      if (!pool) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No draft pool has been generated for this league",
+        });
+      }
+
+      const result = await deps.draftPoolRepo.revealNextItem(
+        pool.id,
+        new Date(),
+      );
+      if (!result) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "All draft pool items have already been revealed",
+        });
+      }
+      return {
+        itemId: result.item.id,
+        revealOrder: result.item.revealOrder,
+        remaining: result.remaining,
+      };
     },
   };
 }

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -135,6 +135,8 @@ function createFakeDraftPoolRepo(
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       ),
     findByLeagueId: (_leagueId) => Promise.resolve(null as FakePool),
@@ -167,6 +169,8 @@ Deno.test("draftPoolService.generate: returns pool with correct number of items"
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -464,6 +468,8 @@ Deno.test("draftPoolService.generate: maps Pokemon metadata correctly", async ()
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -550,6 +556,8 @@ Deno.test("draftPoolService.getByLeagueId: returns pool with items", async () =>
       name: "pikachu",
       thumbnailUrl: null,
       metadata: null,
+      revealOrder: 0,
+      revealedAt: null,
     },
   ];
 
@@ -707,6 +715,8 @@ Deno.test("draftPoolService.generate: filters Pokemon by regional dex when gameV
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -846,6 +856,8 @@ Deno.test("draftPoolService.generate: excludes legendary Pokemon when excludeLeg
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -909,6 +921,8 @@ Deno.test("draftPoolService.generate: excludes starter Pokemon when excludeStart
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -964,6 +978,8 @@ Deno.test("draftPoolService.generate: excludes trade evolution Pokemon when excl
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -1030,6 +1046,8 @@ Deno.test("draftPoolService.generate: applies multiple exclusions together", asy
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -1164,6 +1182,8 @@ function createFakeStoredPoolItem(
       },
       generation: "generation-i",
     },
+    revealOrder: 0,
+    revealedAt: null,
   };
 }
 
@@ -1938,6 +1958,8 @@ Deno.test("draftPoolService.generate: drops Pokemon with no wild encounter and n
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },
@@ -2032,6 +2054,8 @@ Deno.test("draftPoolService.generate: keeps Pokemon whose pre-evolution has a wi
           name: item.name as string,
           thumbnailUrl: (item.thumbnailUrl as string) ?? null,
           metadata: item.metadata ?? null,
+          revealOrder: item.revealOrder ?? 0,
+          revealedAt: item.revealedAt ?? null,
         })),
       );
     },

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -140,7 +140,11 @@ function createFakeDraftPoolRepo(
         })),
       ),
     findByLeagueId: (_leagueId) => Promise.resolve(null as FakePool),
-    findItemsByPoolId: (_poolId) => Promise.resolve([] as FakePoolItem[]),
+    findItemsByPoolId: (_poolId, _opts) =>
+      Promise.resolve([] as FakePoolItem[]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
     deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };
@@ -2121,4 +2125,190 @@ Deno.test("draftPoolService.generate: catchability filter is a no-op when pokemo
     leagueId: fakeLeague.id,
   });
   assertEquals(result.items.length, 2);
+});
+
+// --- revealNext ---
+
+Deno.test("draftPoolService.revealNext: reveals the next item in pooling phase", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const revealedItem = {
+    id: crypto.randomUUID(),
+    draftPoolId: fakePool.id,
+    name: "pikachu",
+    thumbnailUrl: null,
+    metadata: null,
+    revealOrder: 0,
+    revealedAt: new Date(),
+  };
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealNextItem: (_poolId, _now) =>
+      Promise.resolve({ item: revealedItem, remaining: 4 }),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const result = await service.revealNext("user-1", {
+    leagueId: fakeLeague.id,
+  });
+  assertEquals(result.itemId, revealedItem.id);
+  assertEquals(result.revealOrder, 0);
+  assertEquals(result.remaining, 4);
+});
+
+Deno.test("draftPoolService.revealNext: rejects non-commissioners", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "FORBIDDEN");
+});
+
+Deno.test("draftPoolService.revealNext: rejects when league is not in pooling", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("draftPoolService.revealNext: rejects when all items are already revealed", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("draftPoolService.getByLeagueId: filters to revealed items during pooling", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  let capturedOpts: { onlyRevealed?: boolean } | undefined;
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId, opts) => {
+      capturedOpts = opts;
+      return Promise.resolve([]);
+    },
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  await service.getByLeagueId("user-1", fakeLeague.id);
+  assertEquals(capturedOpts?.onlyRevealed, true);
+});
+
+Deno.test("draftPoolService.getByLeagueId: does not filter during scouting", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  let capturedOpts: { onlyRevealed?: boolean } | undefined;
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId, opts) => {
+      capturedOpts = opts;
+      return Promise.resolve([]);
+    },
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  await service.getByLeagueId("user-1", fakeLeague.id);
+  assertEquals(capturedOpts?.onlyRevealed, false);
 });

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -110,6 +110,8 @@ function createFakePoolItem(
     name: "pikachu",
     thumbnailUrl: null,
     metadata: null,
+    revealOrder: 0,
+    revealedAt: null,
     ...overrides,
   };
 }

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -224,7 +224,10 @@ function createFakeDraftPoolRepo(
       }),
     createItems: (_items) => Promise.resolve([]),
     findByLeagueId: (_leagueId) => Promise.resolve(null as FakePool),
-    findItemsByPoolId: (_poolId) => Promise.resolve([]),
+    findItemsByPoolId: (_poolId, _opts) => Promise.resolve([]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
     deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
 import type { DraftRepository } from "../draft/draft.repository.ts";
+import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { DraftPoolService } from "../draft-pool/draft-pool.service.ts";
 import { logger } from "../../logger.ts";
 import type { LeagueRepository } from "./league.repository.ts";
@@ -27,6 +28,7 @@ export function createLeagueService(
   deps: {
     leagueRepo: LeagueRepository;
     draftRepo: DraftRepository;
+    draftPoolRepo: DraftPoolRepository;
     draftPoolService: DraftPoolService;
     startDraft?: (
       input: { userId: string; leagueId: string },
@@ -182,9 +184,24 @@ export function createLeagueService(
               "League settings must be fully configured before advancing from setup",
           });
         }
+        // Generate the pool on entry to pooling. Items are born hidden
+        // (revealed_at = null) so the showcase UI starts from zero. A
+        // commissioner that doesn't want the showcase can immediately
+        // advance from pooling to scouting below, which reveals the rest.
         await deps.draftPoolService.generate(userId, {
           leagueId: input.leagueId,
         });
+      }
+      if (league.status === "pooling") {
+        // "Advance to scouting" skips the showcase: reveal everything that
+        // the commissioner hasn't revealed manually so scouting starts with
+        // a fully-visible pool.
+        const pool = await deps.draftPoolRepo.findByLeagueId(
+          input.leagueId,
+        );
+        if (pool) {
+          await deps.draftPoolRepo.revealAllItems(pool.id, new Date());
+        }
       }
       if (league.status === "drafting") {
         const draft = await deps.draftRepo.findByLeagueId(input.leagueId);
@@ -204,7 +221,7 @@ export function createLeagueService(
         { leagueId: input.leagueId, newStatus: nextStatus },
         "league status advanced",
       );
-      if (league.status === "setup" && deps.startDraft) {
+      if (league.status === "scouting" && deps.startDraft) {
         await deps.startDraft({
           userId,
           leagueId: input.leagueId,

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { createLeagueService } from "./league.service.ts";
 import type { LeagueRepository } from "./league.repository.ts";
 import type { DraftRepository } from "../draft/draft.repository.ts";
+import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { DraftPoolService } from "../draft-pool/draft-pool.service.ts";
 
 type FakeLeague = Awaited<ReturnType<LeagueRepository["findById"]>>;
@@ -142,6 +143,34 @@ function createFakeDraftPoolService(
         createdAt: new Date(),
         items: [],
       }),
+    revealNext: (_userId, _input) =>
+      Promise.resolve({
+        itemId: crypto.randomUUID(),
+        revealOrder: 0,
+        remaining: 0,
+      }),
+    ...overrides,
+  };
+}
+
+function createFakeDraftPoolRepo(
+  overrides: Partial<DraftPoolRepository> = {},
+): DraftPoolRepository {
+  return {
+    create: (leagueId, name) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId,
+        name,
+        createdAt: new Date(),
+      }),
+    createItems: (_items) => Promise.resolve([]),
+    findByLeagueId: (_leagueId) => Promise.resolve(null),
+    findItemsByPoolId: (_poolId, _opts) => Promise.resolve([]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
+    deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };
 }
@@ -186,6 +215,7 @@ Deno.test("leagueService.create: creates a league with settings and generated in
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.create("user-1", validCreateInput);
@@ -209,6 +239,7 @@ Deno.test("leagueService.getById: returns league when found", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.getById(fakeLeague.id);
@@ -220,6 +251,7 @@ Deno.test("leagueService.getById: throws NOT_FOUND when missing", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -239,6 +271,7 @@ Deno.test("leagueService.join: joins a league via invite code", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-2", "JOIN1234");
@@ -250,6 +283,7 @@ Deno.test("leagueService.join: throws NOT_FOUND for invalid invite code", async 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -282,6 +316,7 @@ Deno.test("leagueService.delete: deletes a league when user is the commissioner"
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   await service.delete("user-1", fakeLeague.id);
@@ -293,6 +328,7 @@ Deno.test("leagueService.delete: throws NOT_FOUND when league does not exist", a
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -320,6 +356,7 @@ Deno.test("leagueService.delete: throws FORBIDDEN when user is not the commissio
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -362,6 +399,7 @@ Deno.test("leagueService.listPlayers: returns players for a league", async () =>
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.listPlayers(fakeLeague.id);
@@ -375,6 +413,7 @@ Deno.test("leagueService.listPlayers: throws NOT_FOUND when league does not exis
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -402,6 +441,7 @@ Deno.test("leagueService.join: throws BAD_REQUEST if already a member", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -453,6 +493,7 @@ Deno.test("leagueService.updateSettings: updates settings when user is commissio
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.updateSettings("user-1", validSettingsInput);
@@ -468,6 +509,7 @@ Deno.test("leagueService.updateSettings: throws NOT_FOUND when league does not e
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -495,6 +537,7 @@ Deno.test("leagueService.updateSettings: throws FORBIDDEN when user is not commi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -514,6 +557,7 @@ Deno.test("leagueService.updateSettings: throws FORBIDDEN when user is not a mem
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -537,6 +581,7 @@ Deno.test("leagueService.join: throws BAD_REQUEST when league is full", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -560,6 +605,7 @@ Deno.test("leagueService.join: allows join when under max_players", async () => 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-3", "OPEN0001");
@@ -578,6 +624,7 @@ Deno.test("leagueService.join: allows join when max_players is null", async () =
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-3", "NOLIM001");
@@ -591,6 +638,7 @@ Deno.test("leagueService.advanceStatus: throws NOT_FOUND when league does not ex
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -618,6 +666,7 @@ Deno.test("leagueService.advanceStatus: throws FORBIDDEN when user is not commis
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -637,6 +686,7 @@ Deno.test("leagueService.advanceStatus: throws FORBIDDEN when user is not a memb
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -664,6 +714,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when league is alread
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -695,6 +746,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -726,6 +778,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -736,7 +789,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   assertEquals(error.code, "BAD_REQUEST");
 });
 
-Deno.test("leagueService.advanceStatus: advances from setup to drafting and generates draft pool", async () => {
+Deno.test("leagueService.advanceStatus: advances from setup to pooling and generates draft pool", async () => {
   const fakeLeague = createFakeLeague({
     status: "setup",
     sportType: "pokemon",
@@ -781,19 +834,20 @@ Deno.test("leagueService.advanceStatus: advances from setup to drafting and gene
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService,
   });
   const result = await service.advanceStatus("user-1", {
     leagueId: fakeLeague.id,
   });
 
-  assertEquals(capturedStatus, "drafting");
-  assertEquals(result.status, "drafting");
+  assertEquals(capturedStatus, "pooling");
+  assertEquals(result.status, "pooling");
   assertEquals(generateCalledWith?.userId, "user-1");
   assertEquals(generateCalledWith?.leagueId, fakeLeague.id);
 });
 
-Deno.test("leagueService.advanceStatus: starts the draft after advancing from setup to drafting", async () => {
+Deno.test("leagueService.advanceStatus: does not start the draft when advancing from setup to pooling", async () => {
   const fakeLeague = createFakeLeague({
     status: "setup",
     sportType: "pokemon",
@@ -816,6 +870,42 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
         joinedAt: new Date(),
       }),
     updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "pooling" })),
+  });
+  let startDraftCalled = false;
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+    startDraft: (_input) => {
+      startDraftCalled = true;
+      return Promise.resolve();
+    },
+  });
+
+  await service.advanceStatus("user-1", { leagueId: fakeLeague.id });
+
+  assertEquals(
+    startDraftCalled,
+    false,
+    "startDraft must not fire on setup→pooling",
+  );
+});
+
+Deno.test("leagueService.advanceStatus: starts the draft after advancing from scouting to drafting", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
       Promise.resolve(createFakeLeague({ status: status as "drafting" })),
   });
   let startDraftCalledWith:
@@ -824,6 +914,7 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
     startDraft: (input) => {
       startDraftCalledWith = input;
@@ -835,6 +926,51 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
 
   assertEquals(startDraftCalledWith?.userId, "user-1");
   assertEquals(startDraftCalledWith?.leagueId, fakeLeague.id);
+});
+
+Deno.test("leagueService.advanceStatus: reveals remaining pool items when advancing from pooling to scouting", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Draft Pool",
+    createdAt: new Date(),
+  };
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "scouting" })),
+  });
+  let revealedPoolId: string | undefined;
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealAllItems: (poolId, _now) => {
+      revealedPoolId = poolId;
+      return Promise.resolve(3);
+    },
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo,
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const result = await service.advanceStatus("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  assertEquals(result.status, "scouting");
+  assertEquals(revealedPoolId, fakePool.id);
 });
 
 Deno.test("leagueService.advanceStatus: does not start the draft when advancing from drafting to competing", async () => {
@@ -862,6 +998,7 @@ Deno.test("leagueService.advanceStatus: does not start the draft when advancing 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
     startDraft: () => {
       startDraftCalled = true;
@@ -914,6 +1051,7 @@ Deno.test("leagueService.advanceStatus: does not advance from setup if draft poo
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService,
   });
 
@@ -953,6 +1091,7 @@ Deno.test("leagueService.advanceStatus: advances from drafting to competing when
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.advanceStatus("user-1", {
@@ -983,6 +1122,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1016,6 +1156,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1049,6 +1190,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1081,6 +1223,7 @@ Deno.test("leagueService.advanceStatus: advances from competing to complete", as
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.advanceStatus("user-1", {
@@ -1127,6 +1270,7 @@ Deno.test("leagueService.removePlayer: removes a player when user is commissione
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   await service.removePlayer("commissioner-1", {
@@ -1143,6 +1287,7 @@ Deno.test("leagueService.removePlayer: throws NOT_FOUND when league does not exi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1174,6 +1319,7 @@ Deno.test("leagueService.removePlayer: throws FORBIDDEN when user is not commiss
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1197,6 +1343,7 @@ Deno.test("leagueService.removePlayer: throws FORBIDDEN when user is not a membe
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1230,6 +1377,7 @@ Deno.test("leagueService.removePlayer: throws BAD_REQUEST when trying to remove 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1265,6 +1413,7 @@ Deno.test("leagueService.removePlayer: throws NOT_FOUND when target player is no
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1348,6 +1497,7 @@ Deno.test("leagueService.addNpcPlayer: picks a random NPC when no id is provided
     const service = createLeagueService({
       leagueRepo: repo,
       draftRepo: createFakeDraftRepo(),
+      draftPoolRepo: createFakeDraftPoolRepo(),
       draftPoolService: createFakeDraftPoolService(),
     });
     const result = await service.addNpcPlayer("commissioner-1", {
@@ -1385,6 +1535,7 @@ Deno.test("leagueService.addNpcPlayer: adds the specified NPC when npcUserId is 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.addNpcPlayer("commissioner-1", {
@@ -1406,6 +1557,7 @@ Deno.test("leagueService.addNpcPlayer: rejects an npcUserId that isn't available
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const error = await assertRejects(
@@ -1442,6 +1594,7 @@ Deno.test("leagueService.listAvailableNpcs: returns available NPCs for the commi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.listAvailableNpcs("commissioner-1", {
@@ -1472,6 +1625,7 @@ Deno.test("leagueService.listAvailableNpcs: forbids non-commissioners", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const error = await assertRejects(

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -123,6 +123,7 @@ export function createFeatureRouters(db: Database) {
   const leagueService = createLeagueService({
     leagueRepo,
     draftRepo,
+    draftPoolRepo,
     draftPoolService,
     startDraft: (input) => draftService.startDraft(input),
   });


### PR DESCRIPTION
## Summary
- Adds `reveal_order` (int, default 0) and `revealed_at` (timestamptz, nullable) to `draft_pool_item`.
- Additive only — no code path reads or filters on these columns yet.
- Bumps `_journal.json` `when` timestamps on the new migrations past 0017/0018's hand-stamped future dates so drizzle applies them in order.

## Why
Prep for the pooling-phase showcase reveal. A follow-up PR will route pool generation through the new `pooling` status, have the repo hide unrevealed items, and expose commissioner reveal mutations.

## Stacked on
#52 — just merged.

## Test plan
- [x] `deno lint` clean
- [x] `deno task test:server` — 235 passed (repository integration tests run against real PG with the new columns applied)
- [x] `deno task test:client` — 204 passed
- [x] Verified via \`\\d draft_pool_item\` that both columns exist after migration
- [ ] CI green