### PR TITLE
feat(league): route pool generation through pooling and scouting phases

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -227,7 +227,7 @@ describe("LeagueDetailPage", () => {
     });
     renderPage();
     expect(
-      screen.getByRole("button", { name: /advance to drafting/i }),
+      screen.getByRole("button", { name: /advance to pooling/i }),
     ).toBeInTheDocument();
   });
 

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -46,7 +46,9 @@ import {
 } from "./use-leagues";
 
 const NEXT_STATUS: Record<string, string | null> = {
-  setup: "drafting",
+  setup: "pooling",
+  pooling: "scouting",
+  scouting: "drafting",
   drafting: "competing",
   competing: "complete",
   complete: null,

--- a/client/src/features/league/LifecycleStepper.tsx
+++ b/client/src/features/league/LifecycleStepper.tsx
@@ -1,10 +1,18 @@
 import { Box, Group, Text } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 
-type Phase = "setup" | "drafting" | "competing" | "complete";
+type Phase =
+  | "setup"
+  | "pooling"
+  | "scouting"
+  | "drafting"
+  | "competing"
+  | "complete";
 
 const PHASES: { id: Phase; label: string }[] = [
   { id: "setup", label: "Setup" },
+  { id: "pooling", label: "Pooling" },
+  { id: "scouting", label: "Scouting" },
   { id: "drafting", label: "Drafting" },
   { id: "competing", label: "Competing" },
   { id: "complete", label: "Complete" },

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -18,7 +18,7 @@ export const LEAGUE_STATUS_TRANSITIONS: Record<
   LeagueStatus,
   LeagueStatus | null
 > = {
-  setup: "drafting",
+  setup: "pooling",
   pooling: "scouting",
   scouting: "drafting",
   drafting: "competing",

--- a/server/features/draft-pool/draft-pool.repository.ts
+++ b/server/features/draft-pool/draft-pool.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import type { db } from "../../db/mod.ts";
 import { draftPool, draftPoolItem } from "../../db/mod.ts";
 import { logger } from "../../logger.ts";
@@ -40,13 +40,91 @@ export function createDraftPoolRepository(db: Database) {
       return result ?? null;
     },
 
-    async findItemsByPoolId(poolId: string): Promise<DraftPoolItemRow[]> {
-      log.debug({ poolId }, "finding items for draft pool");
-      const items = await db.select().from(draftPoolItem).where(
-        eq(draftPoolItem.draftPoolId, poolId),
+    async findItemsByPoolId(
+      poolId: string,
+      opts: { onlyRevealed?: boolean } = {},
+    ): Promise<DraftPoolItemRow[]> {
+      log.debug(
+        { poolId, onlyRevealed: opts.onlyRevealed ?? false },
+        "finding items for draft pool",
       );
+      const whereClause = opts.onlyRevealed
+        ? and(
+          eq(draftPoolItem.draftPoolId, poolId),
+          sql`${draftPoolItem.revealedAt} is not null`,
+        )
+        : eq(draftPoolItem.draftPoolId, poolId);
+      const items = await db.select().from(draftPoolItem).where(whereClause);
       log.debug({ poolId, count: items.length }, "findItemsByPoolId result");
       return items;
+    },
+
+    async countUnrevealedItems(poolId: string): Promise<number> {
+      log.debug({ poolId }, "counting unrevealed items");
+      const [row] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(draftPoolItem)
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        );
+      return row?.count ?? 0;
+    },
+
+    async revealNextItem(
+      poolId: string,
+      now: Date,
+    ): Promise<
+      { item: DraftPoolItemRow; remaining: number } | null
+    > {
+      log.debug({ poolId }, "revealing next draft pool item");
+      const [next] = await db
+        .select()
+        .from(draftPoolItem)
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        )
+        .orderBy(asc(draftPoolItem.revealOrder))
+        .limit(1);
+      if (!next) {
+        log.debug({ poolId }, "no unrevealed items remain");
+        return null;
+      }
+      const [updated] = await db
+        .update(draftPoolItem)
+        .set({ revealedAt: now })
+        .where(eq(draftPoolItem.id, next.id))
+        .returning();
+      const remaining = await this.countUnrevealedItems(poolId);
+      log.debug(
+        { poolId, itemId: updated.id, remaining },
+        "draft pool item revealed",
+      );
+      return { item: updated, remaining };
+    },
+
+    async revealAllItems(poolId: string, now: Date): Promise<number> {
+      log.debug({ poolId }, "revealing all remaining draft pool items");
+      const updated = await db
+        .update(draftPoolItem)
+        .set({ revealedAt: now })
+        .where(
+          and(
+            eq(draftPoolItem.draftPoolId, poolId),
+            isNull(draftPoolItem.revealedAt),
+          ),
+        )
+        .returning({ id: draftPoolItem.id });
+      log.debug(
+        { poolId, count: updated.length },
+        "all draft pool items revealed",
+      );
+      return updated.length;
     },
 
     async deleteByLeagueId(leagueId: string): Promise<void> {

--- a/server/features/draft-pool/draft-pool.repository_test.ts
+++ b/server/features/draft-pool/draft-pool.repository_test.ts
@@ -319,6 +319,167 @@ Deno.test({
 
 Deno.test({
   name:
+    "draftPoolRepository.findItemsByPoolId: filters to revealed items when onlyRevealed is true",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal Filter Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: new Date(),
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const all = await repo.findItemsByPoolId(pool.id);
+      assertEquals(all.length, 2);
+
+      const revealed = await repo.findItemsByPoolId(pool.id, {
+        onlyRevealed: true,
+      });
+      assertEquals(revealed.length, 1);
+      assertEquals(revealed[0].name, "bulbasaur");
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "draftPoolRepository.revealNextItem: reveals the lowest revealOrder unrevealed item",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal Next Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 2,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "squirtle",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const first = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(first?.item.name, "charmander");
+      assertEquals(first?.remaining, 2);
+
+      const second = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(second?.item.name, "squirtle");
+      assertEquals(second?.remaining, 1);
+
+      const third = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(third?.item.name, "bulbasaur");
+      assertEquals(third?.remaining, 0);
+
+      const fourth = await repo.revealNextItem(pool.id, new Date());
+      assertEquals(fourth, null);
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "draftPoolRepository.revealAllItems: stamps every unrevealed item with the given time",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createDraftPoolRepository(db);
+    const userId = crypto.randomUUID();
+
+    try {
+      await createTestUser(db, userId);
+      const testLeague = await createTestLeague(db, userId);
+      const pool = await repo.create(testLeague.id, "Reveal All Pool");
+
+      await repo.createItems([
+        {
+          draftPoolId: pool.id,
+          name: "bulbasaur",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 0,
+          revealedAt: null,
+        },
+        {
+          draftPoolId: pool.id,
+          name: "charmander",
+          thumbnailUrl: null,
+          metadata: null,
+          revealOrder: 1,
+          revealedAt: null,
+        },
+      ]);
+
+      const count = await repo.revealAllItems(pool.id, new Date());
+      assertEquals(count, 2);
+
+      const revealed = await repo.findItemsByPoolId(pool.id, {
+        onlyRevealed: true,
+      });
+      assertEquals(revealed.length, 2);
+
+      // Calling again reveals nothing new.
+      const second = await repo.revealAllItems(pool.id, new Date());
+      assertEquals(second, 0);
+    } finally {
+      await cleanup(db, client, [userId]);
+    }
+  },
+});
+
+Deno.test({
+  name:
     "draftPoolRepository.deleteByLeagueId: removes pool and cascades to items",
   sanitizeResources: false,
   sanitizeOps: false,

--- a/server/features/draft-pool/draft-pool.router.ts
+++ b/server/features/draft-pool/draft-pool.router.ts
@@ -16,5 +16,11 @@ export function createDraftPoolRouter(draftPoolService: DraftPoolService) {
       .query(({ ctx, input }) => {
         return draftPoolService.getByLeagueId(ctx.user.id, input.leagueId);
       }),
+
+    revealNext: protectedProcedure
+      .input(object({ leagueId: string().uuid() }))
+      .mutation(({ ctx, input }) => {
+        return draftPoolService.revealNext(ctx.user.id, input);
+      }),
   });
 }

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -370,10 +370,11 @@ export function createDraftPoolService(deps: {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
       }
 
-      if (league.status !== "setup") {
+      if (league.status !== "setup" && league.status !== "pooling") {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Draft pool can only be generated during league setup",
+          message:
+            "Draft pool can only be generated before the draft has started",
         });
       }
 
@@ -537,8 +538,10 @@ export function createDraftPoolService(deps: {
         "Draft Pool",
       );
 
-      // Map to pool items
-      const poolItems = selected.map((pokemon) => ({
+      // Map to pool items. `selected` is already fisher-yates shuffled, so
+      // using the array index as reveal_order gives a deterministic but
+      // random-looking showcase sequence without a second shuffle.
+      const poolItems = selected.map((pokemon, index) => ({
         draftPoolId: pool.id,
         name: pokemon.name,
         thumbnailUrl: pokemon.spriteUrl,
@@ -548,6 +551,8 @@ export function createDraftPoolService(deps: {
           baseStats: pokemon.baseStats,
           generation: pokemon.generation,
         },
+        revealOrder: index,
+        revealedAt: null,
       }));
 
       const items = await deps.draftPoolRepo.createItems(poolItems);
@@ -590,7 +595,14 @@ export function createDraftPoolService(deps: {
         });
       }
 
-      const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id);
+      // During the "pooling" phase the showcase is mid-reveal: members
+      // (including the commissioner running it) only see items the
+      // commissioner has actually revealed so far. Once the league has
+      // advanced to scouting or beyond, the filter drops and everything is
+      // visible.
+      const items = await deps.draftPoolRepo.findItemsByPoolId(pool.id, {
+        onlyRevealed: league.status === "pooling",
+      });
 
       const augmentedItems = augmentItems(
         items,
@@ -599,6 +611,59 @@ export function createDraftPoolService(deps: {
       );
 
       return { ...pool, items: augmentedItems };
+    },
+
+    async revealNext(userId: string, input: { leagueId: string }) {
+      log.debug(
+        { userId, leagueId: input.leagueId },
+        "revealing next draft pool item",
+      );
+
+      const league = await deps.leagueRepo.findById(input.leagueId);
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+      if (league.status !== "pooling") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Draft pool items can only be revealed during the pooling phase",
+        });
+      }
+      const player = await deps.leagueRepo.findPlayer(
+        input.leagueId,
+        userId,
+      );
+      if (player?.role !== "commissioner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the league commissioner can reveal draft pool items",
+        });
+      }
+
+      const pool = await deps.draftPoolRepo.findByLeagueId(input.leagueId);
+      if (!pool) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No draft pool has been generated for this league",
+        });
+      }
+
+      const result = await deps.draftPoolRepo.revealNextItem(
+        pool.id,
+        new Date(),
+      );
+      if (!result) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "All draft pool items have already been revealed",
+        });
+      }
+      return {
+        itemId: result.item.id,
+        revealOrder: result.item.revealOrder,
+        remaining: result.remaining,
+      };
     },
   };
 }

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -140,7 +140,11 @@ function createFakeDraftPoolRepo(
         })),
       ),
     findByLeagueId: (_leagueId) => Promise.resolve(null as FakePool),
-    findItemsByPoolId: (_poolId) => Promise.resolve([] as FakePoolItem[]),
+    findItemsByPoolId: (_poolId, _opts) =>
+      Promise.resolve([] as FakePoolItem[]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
     deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };
@@ -2121,4 +2125,190 @@ Deno.test("draftPoolService.generate: catchability filter is a no-op when pokemo
     leagueId: fakeLeague.id,
   });
   assertEquals(result.items.length, 2);
+});
+
+// --- revealNext ---
+
+Deno.test("draftPoolService.revealNext: reveals the next item in pooling phase", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const revealedItem = {
+    id: crypto.randomUUID(),
+    draftPoolId: fakePool.id,
+    name: "pikachu",
+    thumbnailUrl: null,
+    metadata: null,
+    revealOrder: 0,
+    revealedAt: new Date(),
+  };
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealNextItem: (_poolId, _now) =>
+      Promise.resolve({ item: revealedItem, remaining: 4 }),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const result = await service.revealNext("user-1", {
+    leagueId: fakeLeague.id,
+  });
+  assertEquals(result.itemId, revealedItem.id);
+  assertEquals(result.revealOrder, 0);
+  assertEquals(result.remaining, 4);
+});
+
+Deno.test("draftPoolService.revealNext: rejects non-commissioners", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "FORBIDDEN");
+});
+
+Deno.test("draftPoolService.revealNext: rejects when league is not in pooling", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("draftPoolService.revealNext: rejects when all items are already revealed", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  const error = await assertRejects(
+    () => service.revealNext("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("draftPoolService.getByLeagueId: filters to revealed items during pooling", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  let capturedOpts: { onlyRevealed?: boolean } | undefined;
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId, opts) => {
+      capturedOpts = opts;
+      return Promise.resolve([]);
+    },
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  await service.getByLeagueId("user-1", fakeLeague.id);
+  assertEquals(capturedOpts?.onlyRevealed, true);
+});
+
+Deno.test("draftPoolService.getByLeagueId: does not filter during scouting", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Pool",
+    createdAt: new Date(),
+  };
+  let capturedOpts: { onlyRevealed?: boolean } | undefined;
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createMemberPlayer(fakeLeague.id)),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    findItemsByPoolId: (_poolId, opts) => {
+      capturedOpts = opts;
+      return Promise.resolve([]);
+    },
+  });
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData: createFakePokemonData(1),
+  });
+
+  await service.getByLeagueId("user-1", fakeLeague.id);
+  assertEquals(capturedOpts?.onlyRevealed, false);
 });

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -224,7 +224,10 @@ function createFakeDraftPoolRepo(
       }),
     createItems: (_items) => Promise.resolve([]),
     findByLeagueId: (_leagueId) => Promise.resolve(null as FakePool),
-    findItemsByPoolId: (_poolId) => Promise.resolve([]),
+    findItemsByPoolId: (_poolId, _opts) => Promise.resolve([]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
     deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
 import type { DraftRepository } from "../draft/draft.repository.ts";
+import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { DraftPoolService } from "../draft-pool/draft-pool.service.ts";
 import { logger } from "../../logger.ts";
 import type { LeagueRepository } from "./league.repository.ts";
@@ -27,6 +28,7 @@ export function createLeagueService(
   deps: {
     leagueRepo: LeagueRepository;
     draftRepo: DraftRepository;
+    draftPoolRepo: DraftPoolRepository;
     draftPoolService: DraftPoolService;
     startDraft?: (
       input: { userId: string; leagueId: string },
@@ -182,9 +184,24 @@ export function createLeagueService(
               "League settings must be fully configured before advancing from setup",
           });
         }
+        // Generate the pool on entry to pooling. Items are born hidden
+        // (revealed_at = null) so the showcase UI starts from zero. A
+        // commissioner that doesn't want the showcase can immediately
+        // advance from pooling to scouting below, which reveals the rest.
         await deps.draftPoolService.generate(userId, {
           leagueId: input.leagueId,
         });
+      }
+      if (league.status === "pooling") {
+        // "Advance to scouting" skips the showcase: reveal everything that
+        // the commissioner hasn't revealed manually so scouting starts with
+        // a fully-visible pool.
+        const pool = await deps.draftPoolRepo.findByLeagueId(
+          input.leagueId,
+        );
+        if (pool) {
+          await deps.draftPoolRepo.revealAllItems(pool.id, new Date());
+        }
       }
       if (league.status === "drafting") {
         const draft = await deps.draftRepo.findByLeagueId(input.leagueId);
@@ -204,7 +221,7 @@ export function createLeagueService(
         { leagueId: input.leagueId, newStatus: nextStatus },
         "league status advanced",
       );
-      if (league.status === "setup" && deps.startDraft) {
+      if (league.status === "scouting" && deps.startDraft) {
         await deps.startDraft({
           userId,
           leagueId: input.leagueId,

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { createLeagueService } from "./league.service.ts";
 import type { LeagueRepository } from "./league.repository.ts";
 import type { DraftRepository } from "../draft/draft.repository.ts";
+import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { DraftPoolService } from "../draft-pool/draft-pool.service.ts";
 
 type FakeLeague = Awaited<ReturnType<LeagueRepository["findById"]>>;
@@ -142,6 +143,34 @@ function createFakeDraftPoolService(
         createdAt: new Date(),
         items: [],
       }),
+    revealNext: (_userId, _input) =>
+      Promise.resolve({
+        itemId: crypto.randomUUID(),
+        revealOrder: 0,
+        remaining: 0,
+      }),
+    ...overrides,
+  };
+}
+
+function createFakeDraftPoolRepo(
+  overrides: Partial<DraftPoolRepository> = {},
+): DraftPoolRepository {
+  return {
+    create: (leagueId, name) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId,
+        name,
+        createdAt: new Date(),
+      }),
+    createItems: (_items) => Promise.resolve([]),
+    findByLeagueId: (_leagueId) => Promise.resolve(null),
+    findItemsByPoolId: (_poolId, _opts) => Promise.resolve([]),
+    countUnrevealedItems: (_poolId) => Promise.resolve(0),
+    revealNextItem: (_poolId, _now) => Promise.resolve(null),
+    revealAllItems: (_poolId, _now) => Promise.resolve(0),
+    deleteByLeagueId: (_leagueId) => Promise.resolve(),
     ...overrides,
   };
 }
@@ -186,6 +215,7 @@ Deno.test("leagueService.create: creates a league with settings and generated in
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.create("user-1", validCreateInput);
@@ -209,6 +239,7 @@ Deno.test("leagueService.getById: returns league when found", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.getById(fakeLeague.id);
@@ -220,6 +251,7 @@ Deno.test("leagueService.getById: throws NOT_FOUND when missing", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -239,6 +271,7 @@ Deno.test("leagueService.join: joins a league via invite code", async () => {
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-2", "JOIN1234");
@@ -250,6 +283,7 @@ Deno.test("leagueService.join: throws NOT_FOUND for invalid invite code", async 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -282,6 +316,7 @@ Deno.test("leagueService.delete: deletes a league when user is the commissioner"
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   await service.delete("user-1", fakeLeague.id);
@@ -293,6 +328,7 @@ Deno.test("leagueService.delete: throws NOT_FOUND when league does not exist", a
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -320,6 +356,7 @@ Deno.test("leagueService.delete: throws FORBIDDEN when user is not the commissio
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -362,6 +399,7 @@ Deno.test("leagueService.listPlayers: returns players for a league", async () =>
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.listPlayers(fakeLeague.id);
@@ -375,6 +413,7 @@ Deno.test("leagueService.listPlayers: throws NOT_FOUND when league does not exis
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -402,6 +441,7 @@ Deno.test("leagueService.join: throws BAD_REQUEST if already a member", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -453,6 +493,7 @@ Deno.test("leagueService.updateSettings: updates settings when user is commissio
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.updateSettings("user-1", validSettingsInput);
@@ -468,6 +509,7 @@ Deno.test("leagueService.updateSettings: throws NOT_FOUND when league does not e
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -495,6 +537,7 @@ Deno.test("leagueService.updateSettings: throws FORBIDDEN when user is not commi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -514,6 +557,7 @@ Deno.test("leagueService.updateSettings: throws FORBIDDEN when user is not a mem
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -537,6 +581,7 @@ Deno.test("leagueService.join: throws BAD_REQUEST when league is full", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -560,6 +605,7 @@ Deno.test("leagueService.join: allows join when under max_players", async () => 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-3", "OPEN0001");
@@ -578,6 +624,7 @@ Deno.test("leagueService.join: allows join when max_players is null", async () =
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.join("user-3", "NOLIM001");
@@ -591,6 +638,7 @@ Deno.test("leagueService.advanceStatus: throws NOT_FOUND when league does not ex
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -618,6 +666,7 @@ Deno.test("leagueService.advanceStatus: throws FORBIDDEN when user is not commis
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -637,6 +686,7 @@ Deno.test("leagueService.advanceStatus: throws FORBIDDEN when user is not a memb
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -664,6 +714,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when league is alread
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -695,6 +746,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -726,6 +778,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -736,7 +789,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from s
   assertEquals(error.code, "BAD_REQUEST");
 });
 
-Deno.test("leagueService.advanceStatus: advances from setup to drafting and generates draft pool", async () => {
+Deno.test("leagueService.advanceStatus: advances from setup to pooling and generates draft pool", async () => {
   const fakeLeague = createFakeLeague({
     status: "setup",
     sportType: "pokemon",
@@ -781,19 +834,20 @@ Deno.test("leagueService.advanceStatus: advances from setup to drafting and gene
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService,
   });
   const result = await service.advanceStatus("user-1", {
     leagueId: fakeLeague.id,
   });
 
-  assertEquals(capturedStatus, "drafting");
-  assertEquals(result.status, "drafting");
+  assertEquals(capturedStatus, "pooling");
+  assertEquals(result.status, "pooling");
   assertEquals(generateCalledWith?.userId, "user-1");
   assertEquals(generateCalledWith?.leagueId, fakeLeague.id);
 });
 
-Deno.test("leagueService.advanceStatus: starts the draft after advancing from setup to drafting", async () => {
+Deno.test("leagueService.advanceStatus: does not start the draft when advancing from setup to pooling", async () => {
   const fakeLeague = createFakeLeague({
     status: "setup",
     sportType: "pokemon",
@@ -816,6 +870,42 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
         joinedAt: new Date(),
       }),
     updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "pooling" })),
+  });
+  let startDraftCalled = false;
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+    startDraft: (_input) => {
+      startDraftCalled = true;
+      return Promise.resolve();
+    },
+  });
+
+  await service.advanceStatus("user-1", { leagueId: fakeLeague.id });
+
+  assertEquals(
+    startDraftCalled,
+    false,
+    "startDraft must not fire on setup→pooling",
+  );
+});
+
+Deno.test("leagueService.advanceStatus: starts the draft after advancing from scouting to drafting", async () => {
+  const fakeLeague = createFakeLeague({ status: "scouting" });
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
       Promise.resolve(createFakeLeague({ status: status as "drafting" })),
   });
   let startDraftCalledWith:
@@ -824,6 +914,7 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
     startDraft: (input) => {
       startDraftCalledWith = input;
@@ -835,6 +926,51 @@ Deno.test("leagueService.advanceStatus: starts the draft after advancing from se
 
   assertEquals(startDraftCalledWith?.userId, "user-1");
   assertEquals(startDraftCalledWith?.leagueId, fakeLeague.id);
+});
+
+Deno.test("leagueService.advanceStatus: reveals remaining pool items when advancing from pooling to scouting", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const fakePool = {
+    id: crypto.randomUUID(),
+    leagueId: fakeLeague.id,
+    name: "Draft Pool",
+    createdAt: new Date(),
+  };
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "user-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+    updateStatus: (_id, status) =>
+      Promise.resolve(createFakeLeague({ status: status as "scouting" })),
+  });
+  let revealedPoolId: string | undefined;
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: (_leagueId) => Promise.resolve(fakePool),
+    revealAllItems: (poolId, _now) => {
+      revealedPoolId = poolId;
+      return Promise.resolve(3);
+    },
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo,
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const result = await service.advanceStatus("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  assertEquals(result.status, "scouting");
+  assertEquals(revealedPoolId, fakePool.id);
 });
 
 Deno.test("leagueService.advanceStatus: does not start the draft when advancing from drafting to competing", async () => {
@@ -862,6 +998,7 @@ Deno.test("leagueService.advanceStatus: does not start the draft when advancing 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
     startDraft: () => {
       startDraftCalled = true;
@@ -914,6 +1051,7 @@ Deno.test("leagueService.advanceStatus: does not advance from setup if draft poo
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService,
   });
 
@@ -953,6 +1091,7 @@ Deno.test("leagueService.advanceStatus: advances from drafting to competing when
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.advanceStatus("user-1", {
@@ -983,6 +1122,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1016,6 +1156,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1049,6 +1190,7 @@ Deno.test("leagueService.advanceStatus: throws BAD_REQUEST when advancing from d
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo,
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1081,6 +1223,7 @@ Deno.test("leagueService.advanceStatus: advances from competing to complete", as
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.advanceStatus("user-1", {
@@ -1127,6 +1270,7 @@ Deno.test("leagueService.removePlayer: removes a player when user is commissione
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   await service.removePlayer("commissioner-1", {
@@ -1143,6 +1287,7 @@ Deno.test("leagueService.removePlayer: throws NOT_FOUND when league does not exi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1174,6 +1319,7 @@ Deno.test("leagueService.removePlayer: throws FORBIDDEN when user is not commiss
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1197,6 +1343,7 @@ Deno.test("leagueService.removePlayer: throws FORBIDDEN when user is not a membe
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1230,6 +1377,7 @@ Deno.test("leagueService.removePlayer: throws BAD_REQUEST when trying to remove 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1265,6 +1413,7 @@ Deno.test("leagueService.removePlayer: throws NOT_FOUND when target player is no
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
 
@@ -1343,6 +1492,7 @@ Deno.test("leagueService.addNpcPlayer: picks a random NPC when no id is provided
     const service = createLeagueService({
       leagueRepo: repo,
       draftRepo: createFakeDraftRepo(),
+      draftPoolRepo: createFakeDraftPoolRepo(),
       draftPoolService: createFakeDraftPoolService(),
     });
     const result = await service.addNpcPlayer("commissioner-1", {
@@ -1380,6 +1530,7 @@ Deno.test("leagueService.addNpcPlayer: adds the specified NPC when npcUserId is 
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.addNpcPlayer("commissioner-1", {
@@ -1401,6 +1552,7 @@ Deno.test("leagueService.addNpcPlayer: rejects an npcUserId that isn't available
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const error = await assertRejects(
@@ -1427,6 +1579,7 @@ Deno.test("leagueService.listAvailableNpcs: returns available NPCs for the commi
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const result = await service.listAvailableNpcs("commissioner-1", {
@@ -1447,6 +1600,7 @@ Deno.test("leagueService.listAvailableNpcs: forbids non-commissioners", async ()
   const service = createLeagueService({
     leagueRepo: repo,
     draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
     draftPoolService: createFakeDraftPoolService(),
   });
   const error = await assertRejects(

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -123,6 +123,7 @@ export function createFeatureRouters(db: Database) {
   const leagueService = createLeagueService({
     leagueRepo,
     draftRepo,
+    draftPoolRepo,
     draftPoolService,
     startDraft: (input) => draftService.startDraft(input),
   });


### PR DESCRIPTION
## Summary
Flips the league lifecycle so advancing from `setup` no longer jumps to `drafting`. Instead:

- `setup → pooling` generates a pool with items born hidden (`revealed_at = null`). Draft is NOT started.
- `pooling → scouting` fast-forwards the showcase by stamping every remaining unrevealed item. This is the "skip the ceremony" path.
- `scouting → drafting` is now where `startDraft` fires.

During `pooling`, `draftPool.getByLeagueId` filters unrevealed items so every viewer — including the commissioner — experiences the reveal in real time. Once the league advances to `scouting` or later, the filter drops.

## New surface
- Repo: `findItemsByPoolId(poolId, { onlyRevealed })`, `countUnrevealedItems`, `revealNextItem`, `revealAllItems`
- Service: `draftPool.revealNext(userId, { leagueId })` — commissioner-only, rejects outside `pooling`
- Router: `draftPool.revealNext` tRPC mutation
- Client: `LifecycleStepper` renders all 6 phases; `NEXT_STATUS` on the league detail page walks the new chain

## Deferred
Live SSE broadcasts per reveal — the client currently refetches the pool query after `revealNext`. A follow-up PR will wire the existing draft SSE channel to carry `draftPool:item_revealed` events so members tune in live.

## Stacked on
#56 (`feat/draft-pool-reveal-columns`) — needs to land first so the new columns exist.

## Test plan
- [x] `deno lint` clean
- [x] `deno task test:server` — 246 passed (added repo integration tests for filter/revealNext/revealAll, service tests for revealNext and the pooling filter, and advanceStatus tests for the new transitions)
- [x] `deno task test:client` — 204 passed
- [ ] CI green