### PR TITLE
feat(npc): swap professors + team rocket anime duo for Smogon-sprited NPCs

### DIFF
--- a/server/db/migrations/0022_smogon_npc_avatars.sql
+++ b/server/db/migrations/0022_smogon_npc_avatars.sql
@@ -4,11 +4,13 @@
 -- back to noncanonical (reconstructed) sprites for post-gen4 characters that
 -- Smogon only ships in that directory.
 --
--- The following NPCs are intentionally left on their Bulbapedia Sugimori URLs:
--- Professors Elm, Rowan, Sycamore, and Magnolia have no trainer sprite in the
--- Smogon repo at all, and Jessie and James are anime-only — the Smogon set
--- only contains in-game trainer classes, so there is no pixel sprite to
--- migrate to for these six.
+-- Six NPCs have no trainer sprite in the Smogon repo at all (Professors Elm,
+-- Rowan, Sycamore, Magnolia have no game sprite; Jessie and James are anime
+-- only). Rather than leaving them on Bulbapedia and breaking the visual
+-- consistency of the NPC roster, we repurpose their row to a thematically
+-- similar character from the same region (or the same antagonist team) that
+-- does have a sprite. We update the display name and email in place but keep
+-- the existing user id so any foreign keys (league_player, etc.) stay intact.
 
 UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen1/red-blue/Oak.png'         WHERE id = 'npc-professor-oak';
 UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen3/ruby-sapphire/Birch.png'  WHERE id = 'npc-professor-birch';
@@ -34,3 +36,53 @@ UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/mast
 UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen4/diamond-pearl/Cyrus.png'  WHERE id = 'npc-cyrus';
 UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen3/ruby-sapphire/Brendan.png' WHERE id = 'npc-brendan';
 UPDATE "user" SET image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen3/ruby-sapphire/May.png'    WHERE id = 'npc-may';
+
+-- Professor Elm -> Jasmine (Olivine City, Johto gen2). Gentle, studious gym
+-- leader known for caring for a sick Ampharos — the closest Johto stand-in
+-- for Elm's quiet academic energy.
+UPDATE "user" SET
+  name = 'Jasmine',
+  email = 'npc-jasmine@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen2/gold-silver/Jasmine.png'
+WHERE id = 'npc-professor-elm';
+
+-- Professor Rowan -> Bertha (Sinnoh Elite Four, gen4). Grandmotherly ground-
+-- type expert; matches Rowan as the older, wiser Sinnoh voice.
+UPDATE "user" SET
+  name = 'Bertha',
+  email = 'npc-bertha@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen4/diamond-pearl/Bertha.png'
+WHERE id = 'npc-professor-rowan';
+
+-- Professor Sycamore -> Clemont (Lumiose City, Kalos gen6). Inventor gym
+-- leader — Kalos's closest "scientist in a lab coat" analogue for Sycamore.
+UPDATE "user" SET
+  name = 'Clemont',
+  email = 'npc-clemont@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/noncanonical/trainers/gen6/x-y/Clemont.png'
+WHERE id = 'npc-professor-sycamore';
+
+-- Professor Magnolia -> Drasna (Kalos Elite Four, gen6). Galar has no trainer
+-- sprites in the Smogon repo at all, so we bridge to Kalos with Drasna, the
+-- other notable elder female scholar with a sprite.
+UPDATE "user" SET
+  name = 'Drasna',
+  email = 'npc-drasna@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/noncanonical/trainers/gen6/x-y/Drasna.png'
+WHERE id = 'npc-professor-magnolia';
+
+-- Jessie -> Ariana (Team Rocket executive, gen4 HGSS). Replaces the anime
+-- Rocket duo with the in-game Rocket Executive pair for matching chaos vibes.
+UPDATE "user" SET
+  name = 'Ariana',
+  email = 'npc-ariana@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen4/heartgold-soulsilver/Ariana.png'
+WHERE id = 'npc-jessie';
+
+-- James -> Proton (Team Rocket executive, gen4 HGSS). Paired with Ariana
+-- above; canonically described as the scariest Rocket — fits "chaos".
+UPDATE "user" SET
+  name = 'Proton',
+  email = 'npc-proton@npc.local',
+  image = 'https://raw.githubusercontent.com/smogon/sprites/master/src/_uncategorized/canonical/trainers/gen4/heartgold-soulsilver/Proton.png'
+WHERE id = 'npc-james';


### PR DESCRIPTION
## Summary
Follow-up to #69. The previous PR left six NPCs on Bulbapedia fallbacks because the `smogon/sprites` repo has no trainer sprite for them (Professors Elm, Rowan, Sycamore, Magnolia, and the anime-only Jessie/James). This swaps those six rows to thematically matched substitutes that do have sprites, so the whole NPC roster renders consistent Smogon pixel art.

- Professor Elm → Jasmine (Johto gen2 gym leader)
- Professor Rowan → Bertha (Sinnoh gen4 Elite Four)
- Professor Sycamore → Clemont (Kalos gen6 inventor gym leader)
- Professor Magnolia → Drasna (Kalos gen6 Elite Four — Galar has no trainer sprites in the Smogon repo, so we bridge to the nearest elder scholar with one)
- Jessie → Ariana (Team Rocket executive, gen4 HGSS)
- James → Proton (Team Rocket executive, gen4 HGSS)

Each existing `npc-*` id is preserved so `league_player` and other foreign keys stay intact — only `name`, `email`, and `image` rotate.

## Test plan
- [x] `deno task test:client` (213 tests passing)
- [x] `deno lint`
- [x] All 6 replacement raw.githubusercontent.com URLs return 200
- [ ] Spot check renamed NPCs in the dev UI after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)