### PR TITLE
feat(ui): make shell and league pages responsive on mobile

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -196,6 +196,12 @@ describe("AppLayout shell", () => {
     const nav = screen.getByRole("navigation");
     expect(within(nav).getByText(/make the pick/i)).toBeInTheDocument();
   });
+
+  it("renders a burger button in the header for opening the mobile nav", () => {
+    setupMocks();
+    renderLayout();
+    expect(screen.getByLabelText("Toggle navigation")).toBeInTheDocument();
+  });
 });
 
 describe("AppLayout league mode", () => {

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   Badge,
   Box,
+  Burger,
   Button,
   Divider,
   Group,
@@ -17,6 +18,7 @@ import {
   UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { useEffect } from "react";
 import {
   IconBinoculars,
   IconChevronLeft,
@@ -44,9 +46,15 @@ export function AppLayout({ children }: AppLayoutProps) {
   const user = session?.user;
   const [location] = useLocation();
   const [collapsed, { toggle: toggleCollapsed }] = useDisclosure(false);
+  const [mobileOpened, { toggle: toggleMobile, close: closeMobile }] =
+    useDisclosure(false);
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
     useDisclosure(false);
   const [leaguesOpened, { toggle: toggleLeagues }] = useDisclosure(true);
+
+  useEffect(() => {
+    closeMobile();
+  }, [location, closeMobile]);
 
   const leagues = useLeagues();
   const deleteAccount = trpc.user.deleteAccount.useMutation({
@@ -76,12 +84,19 @@ export function AppLayout({ children }: AppLayoutProps) {
       navbar={{
         width: navbarWidth,
         breakpoint: "sm",
-        collapsed: { mobile: true, desktop: false },
+        collapsed: { mobile: !mobileOpened, desktop: false },
       }}
       padding="md"
     >
       <AppShell.Header>
-        <Group h="100%" px="md" justify="space-between">
+        <Group h="100%" px="md" gap="sm">
+          <Burger
+            opened={mobileOpened}
+            onClick={toggleMobile}
+            hiddenFrom="sm"
+            size="sm"
+            aria-label="Toggle navigation"
+          />
           <Text size="sm" c="dimmed">
             {breadcrumbForLocation(location)}
           </Text>

--- a/client/src/features/league/CreateLeaguePage.tsx
+++ b/client/src/features/league/CreateLeaguePage.tsx
@@ -82,7 +82,7 @@ export function CreateLeaguePage() {
   };
 
   return (
-    <Container size="sm" py="xl">
+    <Container size="sm" py={{ base: "md", sm: "xl" }}>
       <Anchor component={Link} href="/leagues" mb="md" display="block">
         &larr; Back to Leagues
       </Anchor>

--- a/client/src/features/league/HomeDashboard.tsx
+++ b/client/src/features/league/HomeDashboard.tsx
@@ -27,7 +27,7 @@ export function HomeDashboard() {
   const userName = session?.user?.name ?? "Trainer";
 
   return (
-    <Container size="lg" py="xl">
+    <Container size="lg" py={{ base: "md", sm: "xl" }}>
       <Group justify="space-between" mb="lg">
         <Title order={1}>Welcome back, {userName.split(" ")[0]}</Title>
       </Group>

--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -124,7 +124,7 @@ describe("LeagueDetailPage", () => {
   it("displays the league status", () => {
     mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
     renderPage();
-    expect(screen.getByText(/setup/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/setup/i).length).toBeGreaterThan(0);
   });
 
   it("displays the invite code", () => {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -130,7 +130,7 @@ export function LeagueDetailPage() {
   }, [draft.data]);
 
   return (
-    <Container size="lg" py="xl" pos="relative">
+    <Container size="lg" py={{ base: "md", sm: "xl" }} pos="relative">
       <LoadingOverlay visible={league.isLoading} />
 
       <Anchor component={Link} href="/leagues" mb="md" display="block">
@@ -139,9 +139,9 @@ export function LeagueDetailPage() {
 
       {league.data && (
         <>
-          <Paper withBorder radius="md" p="lg" mb="lg">
+          <Paper withBorder radius="md" p={{ base: "md", sm: "lg" }} mb="lg">
             <Group justify="space-between" align="flex-start" wrap="wrap">
-              <Stack gap="xs" style={{ flex: 1, minWidth: 260 }}>
+              <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
                 <Title order={1}>{league.data.name}</Title>
                 {league.data.sportType && (
                   <Group gap="xs">
@@ -270,8 +270,17 @@ export function LeagueDetailPage() {
                         player.npcStrategy ?? null,
                       );
                       return (
-                        <Group key={player.id} justify="space-between">
-                          <Group gap="sm">
+                        <Group
+                          key={player.id}
+                          justify="space-between"
+                          wrap="nowrap"
+                          align="flex-start"
+                        >
+                          <Group
+                            gap="xs"
+                            wrap="wrap"
+                            style={{ flex: 1, minWidth: 0 }}
+                          >
                             {player.isNpc
                               ? (
                                 <NpcAvatar
@@ -297,7 +306,9 @@ export function LeagueDetailPage() {
                                     .slice(0, 2)}
                                 </Avatar>
                               )}
-                            <Text size="sm">{player.name}</Text>
+                            <Text size="sm" style={{ minWidth: 0 }} truncate>
+                              {player.name}
+                            </Text>
                             {player.isNpc && (
                               <Badge variant="light" color="grape" size="xs">
                                 NPC
@@ -315,7 +326,12 @@ export function LeagueDetailPage() {
                               </Tooltip>
                             )}
                           </Group>
-                          <Badge variant="light" size="sm" tt="capitalize">
+                          <Badge
+                            variant="light"
+                            size="sm"
+                            tt="capitalize"
+                            style={{ flexShrink: 0 }}
+                          >
                             {player.role}
                           </Badge>
                         </Group>
@@ -375,11 +391,21 @@ export function LeagueDetailPage() {
               <Stack gap="lg">
                 <Card shadow="sm" padding="lg" radius="md" withBorder>
                   <Title order={4} mb="sm">League info</Title>
-                  <Stack gap="xs">
-                    <Group justify="space-between">
+                  <Stack gap="md">
+                    <Stack gap={4}>
                       <Text size="sm" fw={500}>Invite code</Text>
-                      <Group gap={4}>
-                        <Text ff="monospace" size="sm">
+                      <Group gap={4} wrap="nowrap">
+                        <Text
+                          ff="monospace"
+                          size="sm"
+                          style={{
+                            flex: 1,
+                            minWidth: 0,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
                           {league.data.inviteCode}
                         </Text>
                         <CopyButton value={league.data.inviteCode}>
@@ -398,7 +424,7 @@ export function LeagueDetailPage() {
                           )}
                         </CopyButton>
                       </Group>
-                    </Group>
+                    </Stack>
                     <Stack gap={4}>
                       <Text size="sm" fw={500}>Share link</Text>
                       <Group gap={4} wrap="nowrap">
@@ -407,6 +433,8 @@ export function LeagueDetailPage() {
                           size="xs"
                           c="dimmed"
                           style={{
+                            flex: 1,
+                            minWidth: 0,
                             overflow: "hidden",
                             textOverflow: "ellipsis",
                             whiteSpace: "nowrap",
@@ -433,7 +461,7 @@ export function LeagueDetailPage() {
                         </CopyButton>
                       </Group>
                     </Stack>
-                    <Group justify="space-between">
+                    <Group justify="space-between" wrap="nowrap">
                       <Text size="sm" fw={500}>Created</Text>
                       <Text size="sm" c="dimmed">
                         {new Date(league.data.createdAt).toLocaleDateString()}

--- a/client/src/features/league/LeagueListPage.tsx
+++ b/client/src/features/league/LeagueListPage.tsx
@@ -166,11 +166,11 @@ export function LeagueListPage() {
   const isEmpty = !leagues.isLoading && data.length === 0;
 
   return (
-    <Container size="lg" py="xl" pos="relative">
+    <Container size="lg" py={{ base: "md", sm: "xl" }} pos="relative">
       <LoadingOverlay visible={leagues.isLoading} />
-      <Group justify="space-between" mb="lg">
+      <Group justify="space-between" mb="lg" wrap="wrap" gap="sm">
         <Title order={1}>My Leagues</Title>
-        <Group>
+        <Group gap="sm" wrap="wrap">
           <Button
             component={Link}
             href="/leagues/new"

--- a/client/src/features/league/LeagueSettingsPage.tsx
+++ b/client/src/features/league/LeagueSettingsPage.tsx
@@ -138,7 +138,7 @@ export function LeagueSettingsPage() {
   const saveCurrentSettings = () => saveSettings(currentSettings);
 
   return (
-    <Container size="sm" py="xl" pos="relative">
+    <Container size="sm" py={{ base: "md", sm: "xl" }} pos="relative">
       <LoadingOverlay visible={league.isLoading} />
 
       <Anchor component={Link} href={`/leagues/${id}`} mb="md" display="block">

--- a/client/src/features/league/LifecycleStepper.tsx
+++ b/client/src/features/league/LifecycleStepper.tsx
@@ -1,4 +1,4 @@
-import { Box, Group, Text } from "@mantine/core";
+import { Box, Group, Progress, Stack, Text } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 
 type Phase =
@@ -37,10 +37,38 @@ interface LifecycleStepperProps {
 
 export function LifecycleStepper({ currentPhase }: LifecycleStepperProps) {
   const currentIndex = PHASES.findIndex((p) => p.id === currentPhase);
+  const safeIndex = currentIndex < 0 ? 0 : currentIndex;
+  const currentLabel = PHASES[safeIndex]?.label ?? "";
+  const progressValue = ((safeIndex + 1) / PHASES.length) * 100;
   return (
     <>
       <style>{STEPPER_KEYFRAMES}</style>
-      <Group gap="xs" wrap="nowrap" role="group" aria-label="League lifecycle">
+      <Stack
+        gap={6}
+        hiddenFrom="sm"
+        role="group"
+        aria-label="League lifecycle (compact)"
+      >
+        <Group justify="space-between" gap="xs">
+          <Text size="sm" fw={700}>{currentLabel}</Text>
+          <Text size="xs" c="dimmed">
+            Step {safeIndex + 1} of {PHASES.length}
+          </Text>
+        </Group>
+        <Progress
+          value={progressValue}
+          color="mint-green"
+          size="sm"
+          radius="xl"
+        />
+      </Stack>
+      <Group
+        gap="xs"
+        wrap="nowrap"
+        role="group"
+        aria-label="League lifecycle"
+        visibleFrom="sm"
+      >
         {PHASES.map((phase, index) => {
           const isCurrent = index === currentIndex;
           const isPast = index < currentIndex;


### PR DESCRIPTION
## Summary

- Mobile users had no way to open the sidebar once closed — `AppShell` had `collapsed.mobile: true` but no burger button in the header, leaving phone users stranded without navigation. Adds a `Burger` in the header wired to `useDisclosure`, auto-closes on route change.
- `LifecycleStepper` now renders a compact "Step N of M + progress bar" on mobile (six phases won't fit a 375px viewport in a `nowrap` row).
- `LeagueDetailPage`: League info card no longer clips the invite code / share link, and "Who's in" player rows wrap their NPC/strategy badges cleanly instead of squeezing them off-screen.
- Responsive vertical padding on LeagueDetailPage, LeagueListPage, HomeDashboard, CreateLeaguePage, and LeagueSettingsPage. LeagueListPage action bar wraps so Create/Join buttons don't overflow the title row.

Punted: draft room mobile redesign, leagues table → card-list collapse, sticky bottom CTA bar (see `docs/product/006-ui-ux-dashboard-vision.md` for the full mobile vision).

## Test plan

- [x] `deno task test:client` (214 passing)
- [x] `deno lint`
- [ ] Manually verify on a phone viewport: burger opens the drawer, tapping a link closes it, compact stepper shows on <640px, invite code + share link don't clip, player rows wrap cleanly