### PR TITLE
fix(ui): improve contrast on live pool reveal banner

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -676,7 +676,7 @@ export function DraftPoolPage() {
               <Group justify="space-between" align="center" wrap="wrap">
                 <Stack gap={4} style={{ flex: 1, minWidth: 240 }}>
                   <Group gap="sm" align="center">
-                    <Text fw={700} size="md">
+                    <Text fw={700} size="md" c="mint-green-9">
                       Live pool reveal in progress
                     </Text>
                     <Badge color="mint-green" variant="filled" size="lg">
@@ -684,7 +684,7 @@ export function DraftPoolPage() {
                       {draftPool.data?.totalItems ?? 0} revealed
                     </Badge>
                   </Group>
-                  <Text size="sm" c="dimmed">
+                  <Text size="sm" c="dark.6">
                     {isCommissioner
                       ? "Reveal Pokémon one at a time for everyone watching. The showcase finishes automatically when the last one is revealed."
                       : "Waiting on the commissioner to reveal the next Pokémon. The rest are hidden until then."}
@@ -694,8 +694,8 @@ export function DraftPoolPage() {
                   <Group gap="sm">
                     <Button
                       size="md"
-                      variant="subtle"
-                      color="gray"
+                      variant="outline"
+                      color="mint-green.9"
                       loading={advanceStatus.isPending}
                       onClick={() => advanceStatus.mutate({ leagueId: id! })}
                     >


### PR DESCRIPTION
## Summary
- The "Live pool reveal in progress" banner uses a fixed mint-green-0 background but theme-driven text colors, so in dark mode the title, body copy, and "Skip showcase" button all washed out into near-invisibility against the always-light banner.
- Locks title to `mint-green-9`, body to `dark.6`, and makes the skip button an outlined mint-green variant so they stay legible regardless of theme.

## Test plan
- [x] `deno task test:client`
- [ ] Toggle dark/light mode on the draft pool page during pooling and confirm the banner text + skip button are readable in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)