### PR TITLE
ci(test): cap Test job at 5 minutes to fail fast on hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     services:
       postgres:
         image: postgres:17


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 5` to the `ci / Test` job so that hangs (e.g. [run 24287789969](https://github.com/Tiernebre/make-the-pick/actions/runs/24287789969/job/70919967680)) fail the job promptly instead of sitting for GitHub's default 6-hour limit.
- The healthy suite finishes in well under 3 minutes, so 5 minutes gives ~2x headroom. A root-cause fix for whatever is leaking a handle (likely in the vitest half of `deno task test`) will follow in a separate PR.

## Test plan
- [ ] CI runs this PR; the `Test` job either completes normally or fails at the 5-minute mark — no more 6-hour zombies.