### PR TITLE
fix(db): bump 0024 journal timestamp so drizzle applies it

### DIFF
--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -173,7 +173,7 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1775927221347,
+      "when": 1776360000000,
       "tag": "0024_loving_namorita",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Prod league deletes still fail with FK 23503 on `draft_pick_league_player_id_league_player_id_fk` even though #74 added `ON DELETE cascade` and generated migration 0024.
- Root cause: drizzle's postgres-js migrator (`pg-core/dialect.js:62`) applies a migration only when `lastDbMigration.created_at < migration.folderMillis`. The NPC rename migrations 0020–0023 were hand-timestamped in the 1776320000000–1776350000000 range, but 0024 was regenerated with a real `Date.now()` of 1775927221347 — *earlier* than 0023. After 0023 applied on prod, 0024 was silently skipped, so the FK cascade was never installed and league deletes continued to 500.
- Fix: bump 0024's `when` in `_journal.json` to 1776360000000 so it sorts after 0023 and drizzle picks it up on next deploy.

## Test plan
- [ ] Deploy auto-merges; watch `db.migrate` log for "migrations complete" on container start.
- [ ] On prod, attempt `league.delete` for a league that has draft picks — should succeed (no 23503).
- [ ] Verify in `__drizzle_migrations` that a row exists with `created_at = 1776360000000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)