### PR TITLE
feat(draft-pool): add species metadata schema and mode discriminator

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -42,8 +42,12 @@ export {
   draftPoolSchema,
   type GenerateDraftPoolInput,
   generateDraftPoolSchema,
+  type IndividualPoolItemMetadata,
+  individualPoolItemMetadataSchema,
   type PoolItemAvailability,
   poolItemAvailabilitySchema,
+  type SpeciesPoolItemMetadata,
+  speciesPoolItemMetadataSchema,
 } from "./schemas/mod.ts";
 export { type HealthResponse, healthResponseSchema } from "./schemas/mod.ts";
 export {

--- a/packages/shared/schemas/draft-pool.ts
+++ b/packages/shared/schemas/draft-pool.ts
@@ -1,5 +1,14 @@
 import type { z } from "zod";
-import { array, enum as enum_, nullable, number, object, string } from "zod";
+import {
+  array,
+  enum as enum_,
+  literal,
+  nullable,
+  number,
+  object,
+  string,
+  union,
+} from "zod";
 import {
   poolItemEffortSchema,
   poolItemEncounterSchema,
@@ -11,31 +20,100 @@ export const poolItemAvailabilitySchema: z.ZodEnum<["early", "mid", "late"]> =
 
 export type PoolItemAvailability = z.infer<typeof poolItemAvailabilitySchema>;
 
-export const draftPoolItemMetadataSchema: z.ZodObject<{
+const baseStatsSchema: z.ZodObject<{
+  hp: z.ZodNumber;
+  attack: z.ZodNumber;
+  defense: z.ZodNumber;
+  specialAttack: z.ZodNumber;
+  specialDefense: z.ZodNumber;
+  speed: z.ZodNumber;
+}> = object({
+  hp: number(),
+  attack: number(),
+  defense: number(),
+  specialAttack: number(),
+  specialDefense: number(),
+  speed: number(),
+});
+
+// Individual-mode metadata: the unit of drafting is a single Pokemon.
+// `mode` is defaulted so legacy rows written before species-mode existed
+// still validate — they get `mode: "individual"` added at parse time.
+export const individualPoolItemMetadataSchema: z.ZodObject<{
+  mode: z.ZodDefault<z.ZodLiteral<"individual">>;
   pokemonId: z.ZodNumber;
   types: z.ZodArray<z.ZodString>;
-  baseStats: z.ZodObject<{
-    hp: z.ZodNumber;
-    attack: z.ZodNumber;
-    defense: z.ZodNumber;
-    specialAttack: z.ZodNumber;
-    specialDefense: z.ZodNumber;
-    speed: z.ZodNumber;
-  }>;
+  baseStats: typeof baseStatsSchema;
   generation: z.ZodString;
 }> = object({
+  mode: literal("individual").default("individual"),
   pokemonId: number(),
   types: array(string()),
-  baseStats: object({
-    hp: number(),
-    attack: number(),
-    defense: number(),
-    specialAttack: number(),
-    specialDefense: number(),
-    speed: number(),
-  }),
+  baseStats: baseStatsSchema,
   generation: string(),
 });
+
+export type IndividualPoolItemMetadata = z.infer<
+  typeof individualPoolItemMetadataSchema
+>;
+
+const speciesFinalPoolItemSchema: z.ZodObject<{
+  pokemonId: z.ZodNumber;
+  name: z.ZodString;
+  regionalForm: z.ZodNullable<z.ZodString>;
+  types: z.ZodArray<z.ZodString>;
+  baseStats: typeof baseStatsSchema;
+  generation: z.ZodString;
+  spriteUrl: z.ZodNullable<z.ZodString>;
+}> = object({
+  pokemonId: number(),
+  name: string(),
+  regionalForm: nullable(string()),
+  types: array(string()),
+  baseStats: baseStatsSchema,
+  generation: string(),
+  spriteUrl: nullable(string()),
+});
+
+const speciesMemberPoolItemSchema: z.ZodObject<{
+  pokemonId: z.ZodNumber;
+  name: z.ZodString;
+  regionalForm: z.ZodNullable<z.ZodString>;
+  stage: z.ZodEnum<["base", "middle", "final"]>;
+}> = object({
+  pokemonId: number(),
+  name: string(),
+  regionalForm: nullable(string()),
+  stage: enum_(["base", "middle", "final"]),
+});
+
+// Species-mode metadata: the unit of drafting is an entire evolution line
+// rooted at a terminal final form. See docs/domain/species-draft.md.
+export const speciesPoolItemMetadataSchema: z.ZodObject<{
+  mode: z.ZodLiteral<"species">;
+  finals: z.ZodArray<typeof speciesFinalPoolItemSchema>;
+  members: z.ZodArray<typeof speciesMemberPoolItemSchema>;
+}> = object({
+  mode: literal("species"),
+  finals: array(speciesFinalPoolItemSchema),
+  members: array(speciesMemberPoolItemSchema),
+});
+
+export type SpeciesPoolItemMetadata = z.infer<
+  typeof speciesPoolItemMetadataSchema
+>;
+
+// Union covering both drafting modes. A discriminated union would be
+// stricter but would require every stored row to carry an explicit `mode`
+// field, which legacy individual-mode rows don't — the `.default` on the
+// individual variant lets the plain `union` fall through cleanly.
+export const draftPoolItemMetadataSchema: z.ZodUnion<[
+  typeof individualPoolItemMetadataSchema,
+  typeof speciesPoolItemMetadataSchema,
+]> = union([
+  individualPoolItemMetadataSchema,
+  speciesPoolItemMetadataSchema,
+]);
 
 export type DraftPoolItemMetadata = z.infer<typeof draftPoolItemMetadataSchema>;
 

--- a/packages/shared/schemas/draft-pool_test.ts
+++ b/packages/shared/schemas/draft-pool_test.ts
@@ -1,0 +1,142 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  draftPoolItemMetadataSchema,
+  individualPoolItemMetadataSchema,
+  speciesPoolItemMetadataSchema,
+} from "./draft-pool.ts";
+
+const individualWithoutMode = {
+  pokemonId: 6,
+  types: ["fire", "flying"],
+  baseStats: {
+    hp: 78,
+    attack: 84,
+    defense: 78,
+    specialAttack: 109,
+    specialDefense: 85,
+    speed: 100,
+  },
+  generation: "generation-i",
+};
+
+const individualWithMode = {
+  ...individualWithoutMode,
+  mode: "individual" as const,
+};
+
+const speciesMetadata = {
+  mode: "species" as const,
+  finals: [
+    {
+      pokemonId: 38,
+      name: "ninetales",
+      regionalForm: null,
+      types: ["fire"],
+      baseStats: {
+        hp: 73,
+        attack: 76,
+        defense: 75,
+        specialAttack: 81,
+        specialDefense: 100,
+        speed: 100,
+      },
+      generation: "generation-i",
+      spriteUrl: null,
+    },
+    {
+      pokemonId: 10229,
+      name: "ninetales",
+      regionalForm: "alola",
+      types: ["ice", "fairy"],
+      baseStats: {
+        hp: 73,
+        attack: 67,
+        defense: 75,
+        specialAttack: 81,
+        specialDefense: 100,
+        speed: 109,
+      },
+      generation: "generation-vii",
+      spriteUrl: null,
+    },
+  ],
+  members: [
+    {
+      pokemonId: 37,
+      name: "vulpix",
+      regionalForm: null,
+      stage: "base" as const,
+    },
+    {
+      pokemonId: 38,
+      name: "ninetales",
+      regionalForm: null,
+      stage: "final" as const,
+    },
+    {
+      pokemonId: 10228,
+      name: "vulpix-alola",
+      regionalForm: "alola",
+      stage: "base" as const,
+    },
+    {
+      pokemonId: 10229,
+      name: "ninetales-alola",
+      regionalForm: "alola",
+      stage: "final" as const,
+    },
+  ],
+};
+
+Deno.test("draftPoolItemMetadataSchema accepts legacy individual metadata without a mode field", () => {
+  const parsed = draftPoolItemMetadataSchema.parse(individualWithoutMode);
+  assertEquals(parsed.mode, "individual");
+  if (parsed.mode !== "individual") throw new Error("expected individual");
+  assertEquals(parsed.pokemonId, 6);
+  assertEquals(parsed.types, ["fire", "flying"]);
+});
+
+Deno.test("draftPoolItemMetadataSchema accepts individual metadata with an explicit mode", () => {
+  const parsed = draftPoolItemMetadataSchema.parse(individualWithMode);
+  assertEquals(parsed.mode, "individual");
+});
+
+Deno.test("draftPoolItemMetadataSchema accepts species metadata", () => {
+  const parsed = draftPoolItemMetadataSchema.parse(speciesMetadata);
+  if (parsed.mode !== "species") throw new Error("expected species");
+  assertEquals(parsed.finals.length, 2);
+  assertEquals(parsed.members.length, 4);
+  assertEquals(parsed.finals[0].regionalForm, null);
+  assertEquals(parsed.finals[1].regionalForm, "alola");
+});
+
+Deno.test("draftPoolItemMetadataSchema rejects species metadata missing finals", () => {
+  const broken = { ...speciesMetadata, finals: undefined };
+  assertThrows(() => draftPoolItemMetadataSchema.parse(broken));
+});
+
+Deno.test("draftPoolItemMetadataSchema rejects species metadata missing members", () => {
+  const broken = { ...speciesMetadata, members: undefined };
+  assertThrows(() => draftPoolItemMetadataSchema.parse(broken));
+});
+
+Deno.test("draftPoolItemMetadataSchema rejects unknown mode", () => {
+  assertThrows(() =>
+    draftPoolItemMetadataSchema.parse({
+      ...individualWithoutMode,
+      mode: "bogus",
+    })
+  );
+});
+
+Deno.test("individualPoolItemMetadataSchema validates the individual shape directly", () => {
+  const parsed = individualPoolItemMetadataSchema.parse(individualWithoutMode);
+  assertEquals(parsed.mode, "individual");
+  assertEquals(parsed.pokemonId, 6);
+});
+
+Deno.test("speciesPoolItemMetadataSchema validates the species shape directly", () => {
+  const parsed = speciesPoolItemMetadataSchema.parse(speciesMetadata);
+  assertEquals(parsed.mode, "species");
+  assertEquals(parsed.finals[0].pokemonId, 38);
+});

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -42,8 +42,12 @@ export {
   draftPoolSchema,
   type GenerateDraftPoolInput,
   generateDraftPoolSchema,
+  type IndividualPoolItemMetadata,
+  individualPoolItemMetadataSchema,
   type PoolItemAvailability,
   poolItemAvailabilitySchema,
+  type SpeciesPoolItemMetadata,
+  speciesPoolItemMetadataSchema,
 } from "./draft-pool.ts";
 
 export { type HealthResponse, healthResponseSchema } from "./health.ts";

--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -1,5 +1,6 @@
 import type {
   DraftPoolItemMetadata,
+  IndividualPoolItemMetadata,
   Pokemon,
   PokemonEncountersData,
   PokemonEvolution,
@@ -217,23 +218,33 @@ function augmentItems(
 
   return items.map((item) => {
     const metadata = item.metadata as DraftPoolItemMetadata | null;
+    // Species-mode augmentation lives in a later PR; today every persisted
+    // pool item is individual-mode, so narrow to that branch before reading
+    // pokemonId-anchored context. Legacy rows predate the discriminator and
+    // store no `mode` field, so treat "anything that isn't species" as
+    // individual rather than a strict equality check.
+    const individual: IndividualPoolItemMetadata | null =
+      metadata && metadata.mode !== "species"
+        ? (metadata as IndividualPoolItemMetadata)
+        : null;
 
     let availability: PoolItemAvailability | null = null;
-    if (metadata && dexSize > 0) {
-      const dexNumber = dexByPokemonId.get(metadata.pokemonId);
+    if (individual && dexSize > 0) {
+      const dexNumber = dexByPokemonId.get(individual.pokemonId);
       if (dexNumber !== undefined) {
         availability = computeAvailabilityBucket(dexNumber, dexSize);
       }
     }
 
     let evolution: PokemonEvolution | null = null;
-    if (metadata && ctx.evolutions) {
-      evolution = ctx.evolutions[String(metadata.pokemonId)] ?? null;
+    if (individual && ctx.evolutions) {
+      evolution = ctx.evolutions[String(individual.pokemonId)] ?? null;
     }
 
     let encounter: PoolItemEncounter | null = null;
-    if (metadata && ctx.encountersForVersion) {
-      const directEntry = ctx.encountersForVersion[String(metadata.pokemonId)];
+    if (individual && ctx.encountersForVersion) {
+      const directEntry =
+        ctx.encountersForVersion[String(individual.pokemonId)];
       if (directEntry && directEntry.encounters.length > 0) {
         encounter = {
           primary: directEntry.primary,
@@ -242,9 +253,9 @@ function augmentItems(
       } else if (ctx.evolutions) {
         // Evolved Pokemon are rarely catchable in the wild. Walk the
         // pre-evolution chain until we find a stage that has encounters.
-        const seen = new Set<number>([metadata.pokemonId]);
+        const seen = new Set<number>([individual.pokemonId]);
         let cursor =
-          ctx.evolutions[String(metadata.pokemonId)]?.evolvesFromId ??
+          ctx.evolutions[String(individual.pokemonId)]?.evolvesFromId ??
             null;
         while (cursor !== null && !seen.has(cursor)) {
           seen.add(cursor);
@@ -267,8 +278,8 @@ function augmentItems(
     }
 
     let effort: PoolItemEffort | null = null;
-    if (metadata) {
-      const pokemon = pokemonById.get(metadata.pokemonId);
+    if (individual) {
+      const pokemon = pokemonById.get(individual.pokemonId);
       const captureSource = encounter?.source
         ? pokemonById.get(encounter.source.pokemonId) ?? pokemon
         : pokemon;
@@ -276,7 +287,7 @@ function augmentItems(
         captureRate: captureSource?.captureRate ?? null,
         encounter,
         evolution,
-        isTradeEvolution: ctx.tradeEvolutionIds.has(metadata.pokemonId),
+        isTradeEvolution: ctx.tradeEvolutionIds.has(individual.pokemonId),
       });
     }
 

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -1237,7 +1237,14 @@ Deno.test("draftPoolService.getByLeagueId: derives availability from regional de
 
   const result = await service.getByLeagueId("user-2", fakeLeague.id);
   const byPokemonId = new Map(
-    result.items.map((item) => [item.metadata?.pokemonId, item.availability]),
+    result.items.map((
+      item,
+    ) => [
+      item.metadata && item.metadata.mode !== "species"
+        ? item.metadata.pokemonId
+        : undefined,
+      item.availability,
+    ]),
   );
   assertEquals(byPokemonId.get(1), "early");
   assertEquals(byPokemonId.get(3), "early");
@@ -1643,7 +1650,14 @@ Deno.test("draftPoolService.getByLeagueId: attaches encounter, effort, and evolu
 
   const result = await service.getByLeagueId("user-2", fakeLeague.id);
   const byId = new Map(
-    result.items.map((item) => [item.metadata?.pokemonId, item]),
+    result.items.map((
+      item,
+    ) => [
+      item.metadata && item.metadata.mode !== "species"
+        ? item.metadata.pokemonId
+        : undefined,
+      item,
+    ]),
   );
 
   const commonMon = byId.get(1)!;
@@ -1802,7 +1816,14 @@ Deno.test("draftPoolService.getByLeagueId: falls back to pre-evolution encounter
 
   const result = await service.getByLeagueId("user-2", fakeLeague.id);
   const byId = new Map(
-    result.items.map((item) => [item.metadata?.pokemonId, item]),
+    result.items.map((
+      item,
+    ) => [
+      item.metadata && item.metadata.mode !== "species"
+        ? item.metadata.pokemonId
+        : undefined,
+      item,
+    ]),
   );
 
   const firstStage = byId.get(2)!;


### PR DESCRIPTION
## Summary

- Adds `SpeciesPoolItemMetadata` and makes `DraftPoolItemMetadata` a union of `individual` / `species` variants keyed on a new `mode` discriminator — PR 2/6 in the species-drafting rollout (see `docs/domain/species-draft.md`).
- Individual variant's `mode` defaults to `"individual"` so legacy rows persisted before this change still validate. A plain `z.union` (not discriminated) is used for the same reason — discriminated unions require the raw input to carry the discriminator.
- Narrows `draft-pool.service` augmentation by `mode !== "species"` so legacy rows (read via an unchecked cast from jsonb, bypassing the parser's default) continue to flow through the individual branch. Leaves a clean seam for PR 3 to plug in species-mode augmentation.
- No runtime effect yet: pool generation still only emits individual items.

## Test plan

- [x] `deno test packages/shared/schemas/draft-pool_test.ts` — new schema tests pass (legacy no-mode, explicit individual, species, rejection cases)
- [x] `deno task test:server` — 253 passed, 0 failed
- [x] `deno task test:client` — 214 passed
- [x] `deno lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)