### PR TITLE
ci(test): add opt-in debug mode for client test handle leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   workflow_call:
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      debug_client_tests:
+        description: "Run client tests in debug mode (hanging-process reporter, single fork) to find leaked handles"
+        type: boolean
+        default: false
 
 jobs:
   lint:
@@ -63,7 +69,14 @@ jobs:
           deno-version: v2.7.11
       - run: deno install
       - run: deno task db:migrate
-      - run: deno task test
+      - name: Run tests
+        if: ${{ inputs.debug_client_tests != true }}
+        run: deno task test
+      - name: Run tests (client debug mode)
+        if: ${{ inputs.debug_client_tests == true }}
+        run: |
+          deno task test:server
+          deno task test:client:debug
 
   docker-smoke:
     name: Docker Smoke Test

--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,7 @@
     "test:e2e": "./bin/test-e2e",
     "test:server": "deno test server/ --allow-env --allow-net --allow-read --allow-sys --env=.env.example",
     "test:client": "cd client && deno run -A npm:vitest run",
+    "test:client:debug": "cd client && deno run -A npm:vitest run --reporter=default --reporter=hanging-process --pool=forks --poolOptions.forks.singleFork --logHeapUsage",
     "build": "cd client && deno task build",
     "start": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env main.ts",
     "db:start": "docker compose up -d --wait",


### PR DESCRIPTION
## Summary
- Adds a `deno task test:client:debug` that runs vitest with `--reporter=hanging-process`, `--pool=forks --poolOptions.forks.singleFork`, and `--logHeapUsage`. When the client suite hangs (see #78), this surfaces the exact open handle (timer, socket, worker, etc.) keeping the event loop alive.
- Adds a `workflow_dispatch` input `debug_client_tests` to `ci.yml`. Triggering CI manually with this flag runs the Test job in debug mode instead of the normal path.
- Kept opt-in rather than always-on: hanging-process output is noisy and singleFork is meaningfully slower, so we don't want it on the hot path for every PR.

## How to use
1. Actions → CI → Run workflow → set `debug_client_tests = true`.
2. When the 5-minute timeout trips, the job log will include the hanging-process reporter dump identifying the leaked handle.

## Test plan
- [x] `deno task test:client:debug` runs green locally (26 files, 214 tests, ~5s, no hanging handles reported — leak is likely CI-specific).
- [ ] CI passes on this PR in normal mode.
- [ ] Manual `workflow_dispatch` with `debug_client_tests=true` exercises the debug path.