### PR TITLE
fix(deploy): harden droplet deploy script against silent failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,14 +45,44 @@ jobs:
 
       - name: Deploy to Droplet
         uses: appleboy/ssh-action@v1
+        env:
+          IMAGE: ghcr.io/tiernebre/make-the-pick:latest
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: IMAGE
           script: |
+            set -euo pipefail
             cd /opt/make-the-pick
-            docker pull ghcr.io/tiernebre/make-the-pick:latest
+
+            # Incident 002: fail fast on disk pressure before docker pull
+            # wastes bandwidth and leaves orphaned overlay snapshots behind.
+            used=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+            if [ "$used" -ge 85 ]; then
+              echo "Aborting deploy: root FS is ${used}% full (threshold 85%)."
+              df -h /
+              exit 1
+            fi
+
+            docker pull "$IMAGE"
             docker compose -f docker-compose.prod.yml up -d
+
+            # Incident 002: prove the running container is actually on the
+            # image we just pushed. A silent no-op recreate (e.g. ENOSPC
+            # during extract) would otherwise leave the old container up.
+            expected=$(docker image inspect "$IMAGE" --format '{{.Id}}')
+            actual=$(docker inspect make-the-pick-app-1 --format '{{.Image}}')
+            if [ "$expected" != "$actual" ]; then
+              echo "Deploy verification failed: app container is on $actual, expected $expected"
+              exit 1
+            fi
+
+            # Incident 002: keep the last 24h of images for fast rollback,
+            # drop the rest so /var/lib/docker doesn't fill up again. Runs
+            # only after the digest check passes so a failed deploy keeps
+            # its rollback image intact.
+            docker image prune -a -f --filter "until=24h"
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
## Summary

Lands four compounding fixes on the deploy script from [incident 002](../blob/main/docs/incidents/002-droplet-disk-full-silent-deploy-failure.md), all on the same ssh-action step:

- `set -euo pipefail` so any intermediate failure (`docker pull`, `image inspect`, digest mismatch) aborts the step instead of being swallowed.
- Pre-flight disk check — abort if root FS is ≥85% full before `docker pull` burns bandwidth and leaves orphaned overlay snapshots.
- Post-deploy digest verification — compare the running app container's image ID against the image we just pulled. The exact shape of incident 002 (silent no-op recreate) now fails the step loudly.
- Post-deploy `docker image prune -a -f --filter "until=24h"` — keep a day of images for rollback, drop the rest so `/var/lib/docker` stops drifting to 100% full. Runs *after* the digest check so a failed deploy keeps its rollback image intact.

Still open from the incident triage:
- [ ] Bake commit SHA into `/api/health` + assert it in smoke test (separate PR, touches app code)
- [ ] Turn on DO's free 80% disk alert (doctl, not in repo)

## Test plan

- [ ] CI passes on the PR
- [ ] On merge, watch the Deploy run end-to-end — the digest-verify + prune steps should appear in the ssh-action log
- [ ] Confirm `docker system df` on the Droplet shows fewer images after the deploy settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)