### PR TITLE
feat(draft-pool): generate species-mode pools when league opts in

### DIFF
--- a/server/features/draft-pool/draft-pool.service.ts
+++ b/server/features/draft-pool/draft-pool.service.ts
@@ -11,8 +11,10 @@ import type {
   PoolItemEffort,
   PoolItemEncounter,
   RegionalPokedexEntry,
+  Species,
+  SpeciesPoolItemMetadata,
 } from "@make-the-pick/shared";
-import { LEAGUE_STATUS_TRANSITIONS } from "@make-the-pick/shared";
+import { buildSpecies, LEAGUE_STATUS_TRANSITIONS } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
 import { logger } from "../../logger.ts";
 import type { DraftEventPublisher } from "../draft/draft.events.ts";
@@ -30,6 +32,7 @@ interface RulesConfig {
   excludeLegendaries?: boolean;
   excludeStarters?: boolean;
   excludeTradeEvolutions?: boolean;
+  draftMode?: "individual" | "species";
 }
 
 interface StoredPoolItem {
@@ -523,10 +526,47 @@ export function createDraftPoolService(deps: {
 
       const multiplier = rulesConfig.poolSizeMultiplier ??
         DEFAULT_POOL_SIZE_MULTIPLIER;
+      const draftMode = rulesConfig.draftMode ?? "individual";
+
+      // In species mode the pool universe is the set of draftable species,
+      // not individual Pokemon, so compute both the universe and the per-
+      // species filter verdict up front. A species is eligible if *any* of
+      // its terminal finals survived the individual-level filters above —
+      // see species-draft.md invariant 5.
+      let speciesUniverse: Species[] = [];
+      if (draftMode === "species") {
+        if (!deps.pokemonEvolutions) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Species drafting requires Pokemon evolution data to be loaded",
+          });
+        }
+        const eligibleIds = new Set(eligiblePokemon.map((p) => p.id));
+        const allSpecies = buildSpecies(
+          deps.pokemonData,
+          deps.pokemonEvolutions,
+        );
+        speciesUniverse = allSpecies.filter((species) =>
+          species.finals.some((final) => eligibleIds.has(final.pokemonId))
+        );
+
+        if (speciesUniverse.length === 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "No eligible species remain after applying the league's filter rules",
+          });
+        }
+      }
+
+      const universeSize = draftMode === "species"
+        ? speciesUniverse.length
+        : eligiblePokemon.length;
       const rawPoolSize = Math.floor(
         rulesConfig.numberOfRounds * playerCount * multiplier,
       );
-      const poolSize = Math.min(rawPoolSize, eligiblePokemon.length);
+      const poolSize = Math.min(rawPoolSize, universeSize);
 
       log.debug(
         {
@@ -534,6 +574,8 @@ export function createDraftPoolService(deps: {
           playerCount,
           numberOfRounds: rulesConfig.numberOfRounds,
           multiplier,
+          draftMode,
+          universeSize,
           poolSize,
         },
         "calculated pool size",
@@ -542,32 +584,64 @@ export function createDraftPoolService(deps: {
       // Delete existing pool (re-roll support)
       await deps.draftPoolRepo.deleteByLeagueId(input.leagueId);
 
-      // Shuffle and select
-      const shuffled = fisherYatesShuffle(eligiblePokemon);
-      const selected = shuffled.slice(0, poolSize);
-
       // Create pool
       const pool = await deps.draftPoolRepo.create(
         input.leagueId,
         "Draft Pool",
       );
 
-      // Map to pool items. `selected` is already fisher-yates shuffled, so
-      // using the array index as reveal_order gives a deterministic but
-      // random-looking showcase sequence without a second shuffle.
-      const poolItems = selected.map((pokemon, index) => ({
-        draftPoolId: pool.id,
-        name: pokemon.name,
-        thumbnailUrl: pokemon.spriteUrl,
-        metadata: {
-          pokemonId: pokemon.id,
-          types: pokemon.types,
-          baseStats: pokemon.baseStats,
-          generation: pokemon.generation,
-        },
-        revealOrder: index,
-        revealedAt: null,
-      }));
+      // Map to pool items. In both modes the source array is already
+      // fisher-yates shuffled, so using the array index as reveal_order
+      // gives a deterministic but random-looking showcase sequence without
+      // a second shuffle.
+      let poolItems: Array<{
+        draftPoolId: string;
+        name: string;
+        thumbnailUrl: string | null;
+        metadata: IndividualPoolItemMetadata | SpeciesPoolItemMetadata;
+        revealOrder: number;
+        revealedAt: null;
+      }>;
+      if (draftMode === "species") {
+        const shuffled = fisherYatesShuffle(speciesUniverse);
+        const selected = shuffled.slice(0, poolSize);
+        poolItems = selected.map((species, index) => {
+          const firstFinal = species.finals[0];
+          const metadata: SpeciesPoolItemMetadata = {
+            mode: "species",
+            finals: species.finals,
+            members: species.members,
+          };
+          return {
+            draftPoolId: pool.id,
+            name: species.name,
+            thumbnailUrl: firstFinal?.spriteUrl ?? null,
+            metadata,
+            revealOrder: index,
+            revealedAt: null,
+          };
+        });
+      } else {
+        const shuffled = fisherYatesShuffle(eligiblePokemon);
+        const selected = shuffled.slice(0, poolSize);
+        poolItems = selected.map((pokemon, index) => {
+          const metadata: IndividualPoolItemMetadata = {
+            mode: "individual",
+            pokemonId: pokemon.id,
+            types: pokemon.types,
+            baseStats: pokemon.baseStats,
+            generation: pokemon.generation,
+          };
+          return {
+            draftPoolId: pool.id,
+            name: pokemon.name,
+            thumbnailUrl: pokemon.spriteUrl,
+            metadata,
+            revealOrder: index,
+            revealedAt: null,
+          };
+        });
+      }
 
       const items = await deps.draftPoolRepo.createItems(poolItems);
 

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -7,6 +7,7 @@ import type {
   PokemonGiftsData,
   PokemonVersion,
   RegionalPokedexEntry,
+  SpeciesPoolItemMetadata,
 } from "@make-the-pick/shared";
 import type { LeagueRepository } from "../league/league.repository.ts";
 import type { DraftPoolRepository } from "./draft-pool.repository.ts";
@@ -2452,4 +2453,260 @@ Deno.test("draftPoolService.getByLeagueId: does not filter during scouting", asy
 
   await service.getByLeagueId("user-1", fakeLeague.id);
   assertEquals(capturedOpts?.onlyRevealed, false);
+});
+
+// --- generate: species mode ---
+
+// Three-species fixture:
+//   pokemon-1 — single-stage terminal → species {1}
+//   pokemon-2 → pokemon-3            → species {3} owning {2, 3}
+//   pokemon-4 — single-stage terminal → species {4}
+function createSpeciesFixture(): {
+  pokemonData: Pokemon[];
+  pokemonEvolutions: PokemonEvolutionsData;
+} {
+  const base = createFakePokemonData(4);
+  const pokemonEvolutions: PokemonEvolutionsData = {
+    "1": { pokemonId: 1, chainId: 1, evolvesFromId: null, triggers: [] },
+    "2": { pokemonId: 2, chainId: 2, evolvesFromId: null, triggers: [] },
+    "3": { pokemonId: 3, chainId: 2, evolvesFromId: 2, triggers: [] },
+    "4": { pokemonId: 4, chainId: 3, evolvesFromId: null, triggers: [] },
+  };
+  return { pokemonData: base, pokemonEvolutions };
+}
+
+Deno.test("draftPoolService.generate: species mode emits species-shaped pool items", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 1,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 1.5,
+      draftMode: "species",
+    },
+  });
+  const { pokemonData, pokemonEvolutions } = createSpeciesFixture();
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(2),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    pokemonEvolutions,
+  });
+
+  const result = await service.generate("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  // 1 round * 2 players * 1.5 multiplier = 3, clamped against 3 species.
+  assertEquals(result.items.length, 3);
+
+  for (const item of result.items) {
+    const metadata = item.metadata as SpeciesPoolItemMetadata;
+    assertEquals(metadata.mode, "species");
+    assertEquals(metadata.finals.length >= 1, true);
+    const terminalName = metadata.finals[0].name;
+    assertEquals(item.name, terminalName);
+    // Non-terminal base forms must never become pool items.
+    assertEquals(item.name === "pokemon-2", false);
+  }
+
+  // Species universe shape: {1}, {3 owning 2,3}, {4}.
+  const names = new Set(result.items.map((i) => i.name));
+  assertEquals(names.has("pokemon-1"), true);
+  assertEquals(names.has("pokemon-3"), true);
+  assertEquals(names.has("pokemon-4"), true);
+});
+
+Deno.test("draftPoolService.generate: species mode includes members for branching/linear chains", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 10,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 3,
+      draftMode: "species",
+    },
+  });
+  const { pokemonData, pokemonEvolutions } = createSpeciesFixture();
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(4),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    pokemonEvolutions,
+  });
+
+  const result = await service.generate("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  const byName = new Map(
+    result.items.map((i) => [
+      i.name,
+      i.metadata as SpeciesPoolItemMetadata,
+    ]),
+  );
+
+  const linear = byName.get("pokemon-3");
+  assertEquals(linear !== undefined, true);
+  assertEquals(linear!.members.length, 2);
+  assertEquals(linear!.members.map((m) => m.pokemonId).sort(), [2, 3]);
+  assertEquals(linear!.members.find((m) => m.pokemonId === 3)?.stage, "final");
+  assertEquals(linear!.members.find((m) => m.pokemonId === 2)?.stage, "base");
+
+  const single = byName.get("pokemon-1");
+  assertEquals(single!.members.length, 1);
+  assertEquals(single!.members[0].stage, "final");
+});
+
+Deno.test("draftPoolService.generate: species mode clamps pool size to the species universe", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 100,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 3,
+      draftMode: "species",
+    },
+  });
+  const { pokemonData, pokemonEvolutions } = createSpeciesFixture();
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(10),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    pokemonEvolutions,
+  });
+
+  const result = await service.generate("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  // 100 * 10 * 3 = 3000 — clamped to 3 species, not 4 pokemon.
+  assertEquals(result.items.length, 3);
+});
+
+Deno.test("draftPoolService.generate: species mode thumbnailUrl comes from the terminal final", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 10,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 3,
+      draftMode: "species",
+    },
+  });
+  const { pokemonData, pokemonEvolutions } = createSpeciesFixture();
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(4),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    pokemonEvolutions,
+  });
+
+  const result = await service.generate("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  // pokemon-3 is a linear-chain terminal — its thumbnail must be the
+  // terminal final's sprite, not the base form (pokemon-2)'s.
+  const pokemon3 = result.items.find((i) => i.name === "pokemon-3");
+  assertEquals(pokemon3?.thumbnailUrl, "https://example.com/sprite-3.png");
+});
+
+Deno.test("draftPoolService.generate: species mode throws when evolution data is missing", async () => {
+  const fakeLeague = createFakeLeague({
+    rulesConfig: {
+      draftFormat: "snake",
+      numberOfRounds: 1,
+      pickTimeLimitSeconds: null,
+      poolSizeMultiplier: 2,
+      draftMode: "species",
+    },
+  });
+  const { pokemonData } = createSpeciesFixture();
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(2),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+    // intentionally omit pokemonEvolutions
+  });
+
+  const error = await assertRejects(
+    () => service.generate("user-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("draftPoolService.generate: individual mode (default) emits mode: 'individual' metadata", async () => {
+  const fakeLeague = createFakeLeague();
+  const pokemonData = createFakePokemonData(10);
+
+  const leagueRepo = createFakeLeagueRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve(createCommissionerPlayer(fakeLeague.id)),
+    countPlayers: (_leagueId) => Promise.resolve(2),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo();
+
+  const service = createDraftPoolService({
+    draftPoolRepo,
+    leagueRepo,
+    pokemonData,
+  });
+
+  const result = await service.generate("user-1", {
+    leagueId: fakeLeague.id,
+  });
+
+  for (const item of result.items) {
+    const metadata = item.metadata as { mode: string; pokemonId: number };
+    assertEquals(metadata.mode, "individual");
+    assertEquals(typeof metadata.pokemonId, "number");
+  }
 });


### PR DESCRIPTION
## Summary

- PR 3/6 in the species-drafting rollout (see \`docs/domain/species-draft.md\`). The \`generate\` path in \`draft-pool.service\` now branches on \`rulesConfig.draftMode\`. Default stays \`\"individual\"\`; setting it to \`\"species\"\` makes the unit of drafting an entire evolution line rooted at a terminal final form.
- Species universe is built from the full Pokemon catalogue via \`buildSpecies\` (PR 1), then filtered at the species level — a species is kept iff *any* of its terminal finals passed the same regional-dex / catchability / category filters as individual mode (invariant 5 in the domain doc). Pool size is then clamped against the species-count universe so \`rounds × players × multiplier\` applies at the coarser unit.
- Selected species are written as pool items with the \`SpeciesPoolItemMetadata\` envelope shipped in PR 2 — \`mode: \"species\"\`, full \`finals\` and \`members\` lists. \`name\`/\`thumbnailUrl\` come from the terminal final so existing showcase/roster views still render something sensible before PR 5 swaps in a dedicated species card.
- Species mode hard-errors if evolution data isn't loaded (only reachable in tests today). Individual metadata now carries an explicit \`mode: \"individual\"\` literal, matching the default the shared schema already injects.
- PR 4 (league setting) still needs to wire \`draftMode\` through league creation — today only tests can set it.

## Test plan

- [x] \`deno task test:server\` — 259 passed (was 253; +6 new species-mode tests)
- [x] \`deno task test:client\` — 214 passed
- [x] \`deno lint\` / \`deno fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)