### PR TITLE
feat(health): bake git commit SHA into /api/health for deploy verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,10 @@ jobs:
 
       - name: Build and push image
         run: |
-          docker build -t ghcr.io/tiernebre/make-the-pick:latest .
+          docker build \
+            --build-arg GIT_SHA="${{ github.sha }}" \
+            -t ghcr.io/tiernebre/make-the-pick:latest \
+            .
           docker push ghcr.io/tiernebre/make-the-pick:latest
 
       - name: Copy docker-compose.prod.yml to Droplet
@@ -86,14 +89,20 @@ jobs:
 
       - name: Smoke test
         run: |
+          expected="${{ github.sha }}"
           for i in $(seq 1 10); do
-            status=$(curl -s -o /dev/null -w '%{http_code}' https://makethepick.gg)
-            if [ "$status" = "200" ]; then
-              echo "Health check passed (HTTP $status)"
+            # Incident 002: assert /api/health.commit matches the SHA we
+            # just built, not just that _something_ returns 200. The old
+            # check-for-200 on / would have passed against a stale
+            # container that never received the new image.
+            body=$(curl -s https://makethepick.gg/api/health || echo "")
+            commit=$(printf '%s' "$body" | jq -r '.commit // empty' 2>/dev/null || echo "")
+            if [ "$commit" = "$expected" ]; then
+              echo "Health check passed: /api/health.commit = $commit"
               exit 0
             fi
-            echo "Attempt $i: HTTP $status, retrying in 5s..."
+            echo "Attempt $i: commit=$commit expected=$expected body=$body"
             sleep 5
           done
-          echo "Health check failed after 10 attempts"
+          echo "Health check failed after 10 attempts — deployed code did not reach prod"
           exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ FROM base AS production
 COPY . .
 COPY --from=build /app/client/dist ./client/dist
 
+# Baked at build time by CI (--build-arg GIT_SHA=$GITHUB_SHA) so the
+# running container can report which commit it's on via /api/health.
+# The smoke test asserts this matches the commit being deployed.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
 ENV DENO_ENV=production
 EXPOSE 3000
 

--- a/packages/shared/schemas/health.ts
+++ b/packages/shared/schemas/health.ts
@@ -4,9 +4,11 @@ import { object, string } from "zod";
 export const healthResponseSchema: z.ZodObject<{
   status: z.ZodString;
   timestamp: z.ZodString;
+  commit: z.ZodString;
 }> = object({
   status: string(),
   timestamp: string(),
+  commit: string(),
 });
 
 export type HealthResponse = z.infer<typeof healthResponseSchema>;

--- a/packages/shared/schemas/health_test.ts
+++ b/packages/shared/schemas/health_test.ts
@@ -5,10 +5,12 @@ Deno.test("healthResponseSchema parses a valid health response", () => {
   const result = healthResponseSchema.parse({
     status: "ok",
     timestamp: "2026-04-07T00:00:00.000Z",
+    commit: "abc123def456",
   });
 
   assertEquals(result.status, "ok");
   assertEquals(result.timestamp, "2026-04-07T00:00:00.000Z");
+  assertEquals(result.commit, "abc123def456");
 });
 
 Deno.test("healthResponseSchema rejects missing fields", () => {

--- a/server/main.ts
+++ b/server/main.ts
@@ -33,6 +33,7 @@ app.get("/api/health", async (c) => {
   const response: HealthResponse = {
     status: "ok",
     timestamp: check.checkedAt.toISOString(),
+    commit: Deno.env.get("GIT_SHA") ?? "unknown",
   };
   return c.json(response);
 });

--- a/server/main_test.ts
+++ b/server/main_test.ts
@@ -16,5 +16,28 @@ Deno.test({
 
     assertEquals(parsed.status, "ok");
     assertEquals(typeof parsed.timestamp, "string");
+    assertEquals(typeof parsed.commit, "string");
+  },
+});
+
+Deno.test({
+  name: "GET /api/health returns GIT_SHA env var as commit",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const previous = Deno.env.get("GIT_SHA");
+    Deno.env.set("GIT_SHA", "deadbeefcafef00d");
+    try {
+      const response = await app.request("/api/health");
+      const body = await response.json();
+      const parsed = healthResponseSchema.parse(body);
+      assertEquals(parsed.commit, "deadbeefcafef00d");
+    } finally {
+      if (previous === undefined) {
+        Deno.env.delete("GIT_SHA");
+      } else {
+        Deno.env.set("GIT_SHA", previous);
+      }
+    }
   },
 });

--- a/server/trpc/router.ts
+++ b/server/trpc/router.ts
@@ -9,6 +9,7 @@ const healthRouter = router({
     return {
       status: "ok",
       timestamp: check.checkedAt.toISOString(),
+      commit: Deno.env.get("GIT_SHA") ?? "unknown",
     };
   }),
 });


### PR DESCRIPTION
## Summary

Closes the last in-repo action item from [incident 002](../blob/main/docs/incidents/002-droplet-disk-full-silent-deploy-failure.md): the deploy smoke test had no way to tell whether the new code actually reached prod, only that *something* answered on 443. Incident 002 exploited exactly that — `docker pull` hit ENOSPC, `compose up -d` was a no-op, smoke test passed against the stale container, two "successful" deploys shipped nothing.

- Add `commit: string` to `healthResponseSchema` so client/server agree on shape.
- Wire `GIT_SHA` env var through `/api/health` and the `health.check` tRPC procedure (falls back to `"unknown"` for local dev).
- `Dockerfile`: `ARG GIT_SHA=unknown` + `ENV GIT_SHA=$GIT_SHA` after `COPY . .` so cache invalidation matches existing behaviour.
- `.github/workflows/deploy.yml`: build with `--build-arg GIT_SHA=${{ github.sha }}` and rewrite the smoke test to `curl /api/health`, parse `.commit` with `jq`, and assert it equals `github.sha` before declaring the deploy green.

TDD order: updated `health_test.ts` and `main_test.ts` first (red on `TS2339 — Property 'commit' does not exist`), then threaded the field through the schema → REST route → tRPC procedure until 254 server tests passed.

Remaining action item from the incident: turn on DO's free 80% disk alert via `doctl` (out of band, no repo change).

## Test plan

- [x] `deno task test:server` — 254 passed
- [x] `deno lint` clean
- [x] `deno fmt --check` clean
- [ ] Watch the Deploy run — confirm the new smoke test log shows `Health check passed: /api/health.commit = <sha>` matching this PR's merge commit
- [ ] After merge, `curl https://makethepick.gg/api/health | jq .commit` returns a real SHA, not `"unknown"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)