### PR TITLE
fix(league): use NpcAvatar in available NPC picker

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -685,20 +685,12 @@ export function LeagueDetailPage() {
                   >
                     <Group justify="space-between" wrap="nowrap">
                       <Group gap="sm">
-                        <Avatar
-                          src={npc.image}
-                          alt={npc.name}
+                        <NpcAvatar
+                          name={npc.name}
+                          image={npc.image}
                           radius="xl"
                           size="sm"
-                          color="mint-green"
-                        >
-                          {npc.name
-                            .split(" ")
-                            .map((n) => n[0])
-                            .join("")
-                            .toUpperCase()
-                            .slice(0, 2)}
-                        </Avatar>
+                        />
                         <Text size="sm">{npc.name}</Text>
                       </Group>
                       {strategy && (


### PR DESCRIPTION
## Summary
- Replace plain Mantine `Avatar` in the "Choose an NPC trainer" modal with the shared `NpcAvatar` component so available NPCs render with the same deterministic background color and top-cropped sprite as participants already in the league.

## Test plan
- [ ] Open a league in setup, click "Add NPC" — verify each listed NPC's avatar matches how the same NPC appears in the participants list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)