### PR TITLE
feat(league): add draftMode setting defaulting to individual

### DIFF
--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -64,6 +64,8 @@ export {
   createLeagueSchema,
   type DraftFormat,
   draftFormatSchema,
+  type DraftMode,
+  draftModeSchema,
   type League,
   LEAGUE_STATUS_TRANSITIONS,
   type LeaguePlayer,

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -45,6 +45,13 @@ export const draftFormatSchema: z.ZodEnum<["snake", "linear"]> = enum_([
 
 export type DraftFormat = z.infer<typeof draftFormatSchema>;
 
+export const draftModeSchema: z.ZodEnum<["individual", "species"]> = enum_([
+  "individual",
+  "species",
+]);
+
+export type DraftMode = z.infer<typeof draftModeSchema>;
+
 export const rulesConfigSchema: z.ZodObject<{
   draftFormat: typeof draftFormatSchema;
   numberOfRounds: z.ZodNumber;
@@ -54,6 +61,7 @@ export const rulesConfigSchema: z.ZodObject<{
   excludeLegendaries: z.ZodOptional<z.ZodBoolean>;
   excludeStarters: z.ZodOptional<z.ZodBoolean>;
   excludeTradeEvolutions: z.ZodOptional<z.ZodBoolean>;
+  draftMode: z.ZodDefault<typeof draftModeSchema>;
 }> = object({
   draftFormat: draftFormatSchema,
   numberOfRounds: number().int().min(1),
@@ -63,6 +71,7 @@ export const rulesConfigSchema: z.ZodObject<{
   excludeLegendaries: boolean().optional(),
   excludeStarters: boolean().optional(),
   excludeTradeEvolutions: boolean().optional(),
+  draftMode: draftModeSchema.default("individual"),
 });
 
 export type RulesConfig = z.infer<typeof rulesConfigSchema>;

--- a/packages/shared/schemas/league_test.ts
+++ b/packages/shared/schemas/league_test.ts
@@ -56,3 +56,33 @@ Deno.test("createLeagueSchema rejects empty name", () => {
     createLeagueSchema.parse({ ...validSettings, name: "" });
   });
 });
+
+Deno.test("createLeagueSchema defaults draftMode to 'individual' when omitted", () => {
+  const result = createLeagueSchema.parse(validSettings);
+  assertEquals(result.rulesConfig.draftMode, "individual");
+});
+
+Deno.test("createLeagueSchema accepts draftMode: 'species'", () => {
+  const result = createLeagueSchema.parse({
+    ...validSettings,
+    rulesConfig: { ...validSettings.rulesConfig, draftMode: "species" },
+  });
+  assertEquals(result.rulesConfig.draftMode, "species");
+});
+
+Deno.test("createLeagueSchema accepts draftMode: 'individual' explicitly", () => {
+  const result = createLeagueSchema.parse({
+    ...validSettings,
+    rulesConfig: { ...validSettings.rulesConfig, draftMode: "individual" },
+  });
+  assertEquals(result.rulesConfig.draftMode, "individual");
+});
+
+Deno.test("createLeagueSchema rejects unknown draftMode values", () => {
+  assertThrows(() => {
+    createLeagueSchema.parse({
+      ...validSettings,
+      rulesConfig: { ...validSettings.rulesConfig, draftMode: "chickens" },
+    });
+  });
+});

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -65,6 +65,8 @@ export {
   createLeagueSchema,
   type DraftFormat,
   draftFormatSchema,
+  type DraftMode,
+  draftModeSchema,
   type League,
   LEAGUE_STATUS_TRANSITIONS,
   type LeaguePlayer,

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -185,6 +185,7 @@ const validCreateInput = {
     numberOfRounds: 6,
     pickTimeLimitSeconds: 60,
     poolSizeMultiplier: 2,
+    draftMode: "individual" as const,
   },
 };
 


### PR DESCRIPTION
## Summary

- PR 4/6 in the species-drafting rollout (see \`docs/domain/species-draft.md\`). Adds \`draftMode\` to \`rulesConfigSchema\` with values \`\"individual\"\` and \`\"species\"\`, defaulted to \`\"individual\"\` so every existing league is unaffected.
- Because tRPC validates league create / settings update against the shared schema, this plumbs the field through the router and service with no server-side glue. \`draftPoolService.generate\` already reads \`rulesConfig.draftMode\` (wired in PR 3), so creating a league with \`draftMode: \"species\"\` will emit species-shaped pool items the moment it advances from setup → pooling.
- **Invariant 6** — \"species drafting is fixed at league creation\" — is already enforced by the existing \`updateSettings\` gate on \`league.status === \"setup\"\`. Once the pool is generated, the league has advanced past setup and settings are frozen, so no separate mode-mismatch router check is needed.
- No new client wiring yet — PR 5/6 adds the UI. League creation currently only accepts \`draftMode\` via tRPC input; the shared schema just makes it a valid, typed option.

## Test plan

- [x] \`deno task test:server\` — 260 passed
- [x] \`deno task test:client\` — 214 passed
- [x] schema tests — default, explicit values, unknown-mode rejection
- [x] \`deno lint\` / \`deno fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)