### PR TITLE
feat(league): let commissioners remove players during setup

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -13,6 +13,8 @@ const {
   mockUseAddNpcPlayer,
   mockAddNpcMutate,
   mockUseAvailableNpcs,
+  mockUseRemoveLeaguePlayer,
+  mockRemovePlayerMutate,
   mockUseDraft,
 } = vi.hoisted(
   () => ({
@@ -25,6 +27,8 @@ const {
     mockUseAddNpcPlayer: vi.fn(),
     mockAddNpcMutate: vi.fn(),
     mockUseAvailableNpcs: vi.fn(),
+    mockUseRemoveLeaguePlayer: vi.fn(),
+    mockRemovePlayerMutate: vi.fn(),
     mockUseDraft: vi.fn(),
   }),
 );
@@ -36,6 +40,7 @@ vi.mock("./use-leagues", () => ({
   useAdvanceLeagueStatus: mockUseAdvanceLeagueStatus,
   useAddNpcPlayer: mockUseAddNpcPlayer,
   useAvailableNpcs: mockUseAvailableNpcs,
+  useRemoveLeaguePlayer: mockUseRemoveLeaguePlayer,
 }));
 
 vi.mock("../draft/use-draft", () => ({
@@ -98,6 +103,13 @@ describe("LeagueDetailPage", () => {
       error: null,
     });
     mockUseDraft.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseRemoveLeaguePlayer.mockReturnValue({
+      mutate: mockRemovePlayerMutate,
+      reset: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -681,6 +693,152 @@ describe("LeagueDetailPage", () => {
 
     expect(mockAddNpcMutate).toHaveBeenCalledWith(
       { leagueId: "league-1", npcUserId: "npc-b" },
+      expect.anything(),
+    );
+  });
+
+  it("shows a remove-player button for other players when commissioner in setup", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /remove Bob/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a remove button for the commissioner themselves", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /remove Alice/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show remove buttons when user is not commissioner", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /remove Bob/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show remove buttons once the league has left setup", () => {
+    mockUseLeague.mockReturnValue({
+      data: { ...mockLeague, status: "pooling" },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /remove Bob/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls removePlayer mutate with the targeted player on confirm", async () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    screen.getByRole("button", { name: /remove Bob/i }).click();
+    const confirmBtn = await screen.findByRole("button", {
+      name: /^remove$/i,
+    });
+    confirmBtn.click();
+    expect(mockRemovePlayerMutate).toHaveBeenCalledWith(
+      { leagueId: "league-1", playerUserId: "user-2" },
       expect.anything(),
     );
   });

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -28,9 +28,10 @@ import {
   IconChevronDown,
   IconSettings,
   IconSparkles,
+  IconTrash,
 } from "@tabler/icons-react";
 import { npcStrategyColor, parseNpcStrategy } from "@make-the-pick/shared";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { AllRostersPanel } from "../draft/AllRostersPanel";
@@ -45,6 +46,7 @@ import {
   useDeleteLeague,
   useLeague,
   useLeaguePlayers,
+  useRemoveLeaguePlayer,
 } from "./use-leagues";
 
 const NEXT_STATUS: Record<string, string | null> = {
@@ -71,7 +73,11 @@ export function LeagueDetailPage() {
   const deleteLeague = useDeleteLeague();
   const advanceStatus = useAdvanceLeagueStatus();
   const addNpcPlayer = useAddNpcPlayer();
+  const removePlayer = useRemoveLeaguePlayer();
   const [, navigate] = useLocation();
+  const [playerToRemove, setPlayerToRemove] = useState<
+    { userId: string; name: string } | null
+  >(null);
 
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
     useDisclosure(false);
@@ -319,14 +325,40 @@ export function LeagueDetailPage() {
                                 {player.name}
                               </Text>
                             </Group>
-                            <Badge
-                              variant="light"
-                              size="sm"
-                              tt="capitalize"
+                            <Group
+                              gap="xs"
+                              wrap="nowrap"
                               style={{ flexShrink: 0 }}
                             >
-                              {player.role}
-                            </Badge>
+                              <Badge
+                                variant="light"
+                                size="sm"
+                                tt="capitalize"
+                              >
+                                {player.role}
+                              </Badge>
+                              {isCommissioner &&
+                                league.data.status === "setup" &&
+                                player.role !== "commissioner" && (
+                                <Tooltip label={`Remove ${player.name}`}>
+                                  <ActionIcon
+                                    variant="subtle"
+                                    color="red"
+                                    size="sm"
+                                    aria-label={`Remove ${player.name}`}
+                                    onClick={() => {
+                                      removePlayer.reset();
+                                      setPlayerToRemove({
+                                        userId: player.userId,
+                                        name: player.name,
+                                      });
+                                    }}
+                                  >
+                                    <IconTrash size={14} />
+                                  </ActionIcon>
+                                </Tooltip>
+                              )}
+                            </Group>
                           </Group>
                           {hasMetaBadges && (
                             <Group gap="xs" wrap="wrap" pl={34}>
@@ -721,6 +753,49 @@ export function LeagueDetailPage() {
                   {addNpcPlayer.error.message}
                 </Alert>
               )}
+            </Stack>
+          </Modal>
+
+          <Modal
+            opened={playerToRemove !== null}
+            onClose={() => setPlayerToRemove(null)}
+            title="Remove player"
+          >
+            <Stack gap="md">
+              <Text>
+                Are you sure you want to remove{" "}
+                <Text span fw={700}>{playerToRemove?.name}</Text>{" "}
+                from the league? They can rejoin with the invite code.
+              </Text>
+              {removePlayer.isError && (
+                <Alert color="red" title="Failed to remove">
+                  {removePlayer.error.message}
+                </Alert>
+              )}
+              <Group justify="flex-end">
+                <Button
+                  variant="default"
+                  onClick={() => setPlayerToRemove(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  color="red"
+                  loading={removePlayer.isPending}
+                  onClick={() => {
+                    if (!playerToRemove) return;
+                    removePlayer.mutate(
+                      {
+                        leagueId: id!,
+                        playerUserId: playerToRemove.userId,
+                      },
+                      { onSuccess: () => setPlayerToRemove(null) },
+                    );
+                  }}
+                >
+                  Remove
+                </Button>
+              </Group>
             </Stack>
           </Modal>
 

--- a/client/src/features/league/use-leagues.ts
+++ b/client/src/features/league/use-leagues.ts
@@ -68,6 +68,18 @@ export function useAvailableNpcs(leagueId: string, enabled: boolean) {
   );
 }
 
+export function useRemoveLeaguePlayer() {
+  const utils = trpc.useUtils();
+  return trpc.league.removePlayer.useMutation({
+    onSuccess: (_data, variables) => {
+      utils.league.listPlayers.invalidate({ leagueId: variables.leagueId });
+      utils.league.listAvailableNpcs.invalidate({
+        leagueId: variables.leagueId,
+      });
+    },
+  });
+}
+
 export function useDeleteLeague() {
   const utils = trpc.useUtils();
   return trpc.league.delete.useMutation({

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -401,6 +401,13 @@ export function createLeagueService(
         });
       }
 
+      if (league.status !== "setup") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Players can only be removed while the league is in setup",
+        });
+      }
+
       const target = await deps.leagueRepo.findPlayer(
         input.leagueId,
         input.playerUserId,

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -1488,6 +1488,40 @@ Deno.test("leagueService.removePlayer: throws BAD_REQUEST when trying to remove 
   assertEquals(error.code, "BAD_REQUEST");
 });
 
+Deno.test("leagueService.removePlayer: throws BAD_REQUEST when league is not in setup", async () => {
+  const fakeLeague = createFakeLeague({ status: "pooling" });
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (leagueId, userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId,
+        userId,
+        role: userId === "commissioner-1"
+          ? "commissioner" as const
+          : "member" as const,
+        joinedAt: new Date(),
+      }),
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const error = await assertRejects(
+    () =>
+      service.removePlayer("commissioner-1", {
+        leagueId: fakeLeague.id,
+        playerUserId: "member-1",
+      }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
 Deno.test("leagueService.removePlayer: throws NOT_FOUND when target player is not in league", async () => {
   const fakeLeague = createFakeLeague();
   const repo = createFakeRepo({


### PR DESCRIPTION
## Summary
- Gate the existing `league.removePlayer` service on `league.status === "setup"` (BAD_REQUEST otherwise). Removals after the draft pool is generated would leave dangling state, same reason settings/NPC adds are setup-only.
- Add a `useRemoveLeaguePlayer` client hook that invalidates `listPlayers` + `listAvailableNpcs` on success.
- Surface a trash ActionIcon + confirm modal in the "Who's in" list on the league detail page. Only rendered for commissioners during setup, and never on the commissioner's own row (service also blocks that).

## Test plan
- [x] `deno task test:server` — 261 passed (new service test: removePlayer throws BAD_REQUEST when league is not in setup)
- [x] `deno task test:client` — 219 passed (4 new LeagueDetailPage tests: button visible for commissioner in setup, hidden for own row, hidden for non-commissioner, hidden after setup, confirm flow sends correct payload)
- [x] `deno lint` on affected dirs — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)