### PR TITLE
feat(league): disable Add random NPC when league is at max players

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -655,6 +655,39 @@ describe("LeagueDetailPage", () => {
     expect(mockAddNpcMutate).toHaveBeenCalledWith({ leagueId: "league-1" });
   });
 
+  it("disables the Add random NPC button when the league is at max players", () => {
+    mockUseLeague.mockReturnValue({
+      data: { ...mockLeague, maxPlayers: 2 },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "p2",
+          userId: "user-2",
+          name: "Bob",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    const randomBtn = screen.getByRole("button", { name: /add random npc/i });
+    expect(randomBtn).toBeDisabled();
+    randomBtn.click();
+    expect(mockAddNpcMutate).not.toHaveBeenCalled();
+  });
+
   it("opens the choose NPC modal and sends the chosen npcUserId", async () => {
     mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
     mockUseLeaguePlayers.mockReturnValue({

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -107,6 +107,9 @@ export function LeagueDetailPage() {
   const setupPrerequisitesMet = league.data?.status !== "setup" ||
     persistedSettingsValid;
 
+  const atMaxPlayers = !!league.data?.maxPlayers &&
+    (players.data?.length ?? 0) >= league.data.maxPlayers;
+
   const handleDelete = () => {
     deleteLeague.mutate(
       { id: id! },
@@ -398,6 +401,7 @@ export function LeagueDetailPage() {
                           variant="light"
                           size="xs"
                           loading={addNpcPlayer.isPending}
+                          disabled={atMaxPlayers}
                           onClick={() =>
                             addNpcPlayer.mutate({ leagueId: id! })}
                           style={{


### PR DESCRIPTION
## Summary
- Disable the "+ Add random NPC" button in the league detail page once the player count has reached `maxPlayers`, so commissioners can't fire a request the server would reject.
- Added a vitest case covering the disabled state and that clicking the button does not invoke the mutation.

## Test plan
- [x] `deno task test:client` (LeagueDetailPage suite)
- [x] `deno lint` on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)