### PR TITLE
feat(draft): render species pool items as one row per species

### DIFF
--- a/client/src/features/draft/AllRostersPanel.tsx
+++ b/client/src/features/draft/AllRostersPanel.tsx
@@ -15,6 +15,7 @@ import {
   parseNpcStrategy,
 } from "@make-the-pick/shared";
 import { useMemo } from "react";
+import { getPoolItemDisplay } from "./pool-item-display";
 
 export interface AllRostersPanelProps {
   draftState: DraftState;
@@ -79,6 +80,7 @@ export function AllRostersPanel({
                       {picks.map((pick) => {
                         const item = poolItemsById[pick.poolItemId];
                         if (!item) return null;
+                        const display = getPoolItemDisplay(item);
                         return (
                           <Group key={pick.id} gap="xs" wrap="nowrap">
                             <Avatar
@@ -91,9 +93,9 @@ export function AllRostersPanel({
                               <Text size="sm" fw={500} tt="capitalize" truncate>
                                 {item.name}
                               </Text>
-                              {item.metadata && (
+                              {display && (
                                 <Group gap={4}>
-                                  {item.metadata.types.map((t) => (
+                                  {display.types.map((t) => (
                                     <Badge
                                       key={t}
                                       size="xs"

--- a/client/src/features/draft/AvailablePoolTable.tsx
+++ b/client/src/features/draft/AvailablePoolTable.tsx
@@ -20,6 +20,7 @@ import {
   useMantineReactTable,
 } from "mantine-react-table";
 import { PoolItemNoteIcon } from "./PoolItemNoteIcon";
+import { getPoolItemDisplay, getPoolItemStatTotal } from "./pool-item-display";
 import { usePoolItemNotes } from "./use-pool-item-notes";
 import {
   useAddToWatchlist,
@@ -51,16 +52,7 @@ const POKEMON_TYPE_COLORS: Record<string, string> = {
 const ALL_POKEMON_TYPES = Object.keys(POKEMON_TYPE_COLORS);
 
 function getStatTotal(item: DraftPoolItem): number | null {
-  const stats = item.metadata?.baseStats;
-  if (!stats) return null;
-  return (
-    stats.hp +
-    stats.attack +
-    stats.defense +
-    stats.specialAttack +
-    stats.specialDefense +
-    stats.speed
-  );
+  return getPoolItemStatTotal(item);
 }
 
 export interface AvailablePoolTableProps {
@@ -225,7 +217,7 @@ export function AvailablePoolTable({
       },
       {
         id: "types",
-        accessorFn: (row) => row.metadata?.types?.join(", ") ?? "",
+        accessorFn: (row) => getPoolItemDisplay(row)?.types.join(", ") ?? "",
         header: "Type",
         filterVariant: "multi-select",
         mantineFilterMultiSelectProps: {
@@ -236,65 +228,68 @@ export function AvailablePoolTable({
         },
         filterFn: (row, _columnId, filterValues: string[]) => {
           if (!filterValues || filterValues.length === 0) return true;
-          const types = row.original.metadata?.types ?? [];
+          const types = getPoolItemDisplay(row.original)?.types ?? [];
           return filterValues.some((filter) => types.includes(filter));
         },
-        Cell: ({ row }) =>
-          row.original.metadata
-            ? (
-              <Group gap={4}>
-                {row.original.metadata.types.map((type) => (
-                  <Badge
-                    key={type}
-                    size="md"
-                    variant="light"
-                    color={POKEMON_TYPE_COLORS[type] ?? "gray"}
-                    tt="capitalize"
-                  >
-                    {type}
-                  </Badge>
-                ))}
-              </Group>
-            )
-            : null,
+        Cell: ({ row }) => {
+          const display = getPoolItemDisplay(row.original);
+          if (!display) return null;
+          return (
+            <Group gap={4}>
+              {display.types.map((type) => (
+                <Badge
+                  key={type}
+                  size="md"
+                  variant="light"
+                  color={POKEMON_TYPE_COLORS[type] ?? "gray"}
+                  tt="capitalize"
+                >
+                  {type}
+                </Badge>
+              ))}
+            </Group>
+          );
+        },
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.hp ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.hp ?? null,
         id: "hp",
         header: "HP",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.attack ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.attack ?? null,
         id: "attack",
         header: "Attack",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.defense ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.defense ?? null,
         id: "defense",
         header: "Defense",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.specialAttack ?? null,
+        accessorFn: (row) =>
+          getPoolItemDisplay(row)?.baseStats.specialAttack ?? null,
         id: "specialAttack",
         header: "Sp. Atk",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.specialDefense ?? null,
+        accessorFn: (row) =>
+          getPoolItemDisplay(row)?.baseStats.specialDefense ?? null,
         id: "specialDefense",
         header: "Sp. Def",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.speed ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.speed ?? null,
         id: "speed",
         header: "Speed",
         grow: false,

--- a/client/src/features/draft/DraftPoolPage.test.tsx
+++ b/client/src/features/draft/DraftPoolPage.test.tsx
@@ -450,4 +450,97 @@ describe("DraftPoolPage", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("species mode", () => {
+    it("renders species-mode pool items as one row per species with terminal-final stats", () => {
+      const speciesPool = {
+        id: "pool-1",
+        leagueId: "league-1",
+        name: "Draft Pool",
+        createdAt: "2026-01-01T00:00:00Z",
+        items: [
+          {
+            id: "species-item-1",
+            draftPoolId: "pool-1",
+            name: "Ninetales",
+            thumbnailUrl: "https://example.com/ninetales.png",
+            availability: null,
+            encounter: null,
+            effort: null,
+            evolution: null,
+            metadata: {
+              mode: "species",
+              finals: [
+                {
+                  pokemonId: 38,
+                  name: "ninetales",
+                  regionalForm: null,
+                  types: ["fire"],
+                  baseStats: {
+                    hp: 73,
+                    attack: 76,
+                    defense: 75,
+                    specialAttack: 81,
+                    specialDefense: 100,
+                    speed: 100,
+                  },
+                  generation: "generation-i",
+                  spriteUrl: "https://example.com/ninetales.png",
+                },
+                {
+                  pokemonId: 10229,
+                  name: "ninetales",
+                  regionalForm: "alola",
+                  types: ["ice", "fairy"],
+                  baseStats: {
+                    hp: 73,
+                    attack: 67,
+                    defense: 75,
+                    specialAttack: 81,
+                    specialDefense: 100,
+                    speed: 109,
+                  },
+                  generation: "generation-vii",
+                  spriteUrl: "https://example.com/ninetales-alola.png",
+                },
+              ],
+              members: [
+                {
+                  pokemonId: 37,
+                  name: "vulpix",
+                  regionalForm: null,
+                  stage: "base",
+                },
+                {
+                  pokemonId: 38,
+                  name: "ninetales",
+                  regionalForm: null,
+                  stage: "final",
+                },
+              ],
+            },
+          },
+        ],
+      };
+
+      mockUseDraftPool.mockReturnValue({
+        data: speciesPool,
+        isLoading: false,
+      });
+
+      renderPage();
+
+      // Exactly one row for the Ninetales species — no second row for
+      // Alolan Ninetales, which is folded into the same species.
+      const rows = screen.getAllByRole("row", { name: /ninetales/i });
+      expect(rows.length).toBe(1);
+
+      // Primary (base-region) final's stats drive the row.
+      expect(screen.getByText("73")).toBeInTheDocument(); // HP
+      expect(screen.getByText("76")).toBeInTheDocument(); // Attack
+
+      // Primary final's type shows as a badge.
+      expect(screen.getByText("fire")).toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -34,6 +34,7 @@ import type {
   PoolItemAvailability,
   PoolItemEffort,
 } from "@make-the-pick/shared";
+import { getPoolItemDisplay, getPoolItemStatTotal } from "./pool-item-display";
 import { Link, useParams } from "wouter";
 import { useSession } from "../../auth";
 import {
@@ -77,17 +78,10 @@ const POKEMON_TYPE_COLORS: Record<string, string> = {
   fairy: "#D685AD",
 };
 
+// Back-compat wrapper so existing call sites keep working while the table
+// migrates to the shared `getPoolItemDisplay` helper.
 function getStatTotal(item: DraftPoolItem): number | null {
-  const stats = item.metadata?.baseStats;
-  if (!stats) return null;
-  return (
-    stats.hp +
-    stats.attack +
-    stats.defense +
-    stats.specialAttack +
-    stats.specialDefense +
-    stats.speed
-  );
+  return getPoolItemStatTotal(item);
 }
 
 const ALL_POKEMON_TYPES = Object.keys(POKEMON_TYPE_COLORS);
@@ -413,7 +407,7 @@ export function DraftPoolPage() {
       },
       {
         id: "types",
-        accessorFn: (row) => row.metadata?.types?.join(", ") ?? "",
+        accessorFn: (row) => getPoolItemDisplay(row)?.types.join(", ") ?? "",
         header: "Type",
         filterVariant: "multi-select",
         mantineFilterMultiSelectProps: {
@@ -424,27 +418,28 @@ export function DraftPoolPage() {
         },
         filterFn: (row, _columnId, filterValues: string[]) => {
           if (!filterValues || filterValues.length === 0) return true;
-          const types = row.original.metadata?.types ?? [];
+          const types = getPoolItemDisplay(row.original)?.types ?? [];
           return filterValues.some((filter) => types.includes(filter));
         },
-        Cell: ({ row }) =>
-          row.original.metadata
-            ? (
-              <Group gap={4}>
-                {row.original.metadata.types.map((type) => (
-                  <Badge
-                    key={type}
-                    size="md"
-                    variant="light"
-                    color={POKEMON_TYPE_COLORS[type] ?? "gray"}
-                    tt="capitalize"
-                  >
-                    {type}
-                  </Badge>
-                ))}
-              </Group>
-            )
-            : null,
+        Cell: ({ row }) => {
+          const display = getPoolItemDisplay(row.original);
+          if (!display) return null;
+          return (
+            <Group gap={4}>
+              {display.types.map((type) => (
+                <Badge
+                  key={type}
+                  size="md"
+                  variant="light"
+                  color={POKEMON_TYPE_COLORS[type] ?? "gray"}
+                  tt="capitalize"
+                >
+                  {type}
+                </Badge>
+              ))}
+            </Group>
+          );
+        },
       },
       {
         id: "availability",
@@ -529,42 +524,44 @@ export function DraftPoolPage() {
         Cell: ({ row }) => <EvolutionCell evolution={row.original.evolution} />,
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.hp ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.hp ?? null,
         id: "hp",
         header: "HP",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.attack ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.attack ?? null,
         id: "attack",
         header: "Attack",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.defense ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.defense ?? null,
         id: "defense",
         header: "Defense",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.specialAttack ?? null,
+        accessorFn: (row) =>
+          getPoolItemDisplay(row)?.baseStats.specialAttack ?? null,
         id: "specialAttack",
         header: "Sp. Atk",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.specialDefense ?? null,
+        accessorFn: (row) =>
+          getPoolItemDisplay(row)?.baseStats.specialDefense ?? null,
         id: "specialDefense",
         header: "Sp. Def",
         grow: false,
         filterVariant: "range",
       },
       {
-        accessorFn: (row) => row.metadata?.baseStats?.speed ?? null,
+        accessorFn: (row) => getPoolItemDisplay(row)?.baseStats.speed ?? null,
         id: "speed",
         header: "Speed",
         grow: false,

--- a/client/src/features/draft/pool-item-display.test.ts
+++ b/client/src/features/draft/pool-item-display.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { DraftPoolItem } from "@make-the-pick/shared";
+import { getPoolItemDisplay } from "./pool-item-display";
+
+const baseStats = {
+  hp: 78,
+  attack: 84,
+  defense: 78,
+  specialAttack: 109,
+  specialDefense: 85,
+  speed: 100,
+};
+
+function individualItem(): DraftPoolItem {
+  return {
+    id: "item-1",
+    draftPoolId: "pool-1",
+    name: "charizard",
+    thumbnailUrl: "https://example.com/charizard.png",
+    metadata: {
+      mode: "individual",
+      pokemonId: 6,
+      types: ["fire", "flying"],
+      baseStats,
+      generation: "generation-i",
+    },
+    availability: null,
+    encounter: null,
+    effort: null,
+    evolution: null,
+  } as unknown as DraftPoolItem;
+}
+
+function speciesItem(): DraftPoolItem {
+  return {
+    id: "item-2",
+    draftPoolId: "pool-1",
+    name: "ninetales",
+    thumbnailUrl: "https://example.com/ninetales.png",
+    metadata: {
+      mode: "species",
+      finals: [
+        {
+          pokemonId: 38,
+          name: "ninetales",
+          regionalForm: null,
+          types: ["fire"],
+          baseStats,
+          generation: "generation-i",
+          spriteUrl: "https://example.com/ninetales.png",
+        },
+        {
+          pokemonId: 10229,
+          name: "ninetales",
+          regionalForm: "alola",
+          types: ["ice", "fairy"],
+          baseStats: { ...baseStats, attack: 67, speed: 109 },
+          generation: "generation-vii",
+          spriteUrl: "https://example.com/ninetales-alola.png",
+        },
+      ],
+      members: [
+        {
+          pokemonId: 37,
+          name: "vulpix",
+          regionalForm: null,
+          stage: "base",
+        },
+        {
+          pokemonId: 38,
+          name: "ninetales",
+          regionalForm: null,
+          stage: "final",
+        },
+      ],
+    },
+    availability: null,
+    encounter: null,
+    effort: null,
+    evolution: null,
+  } as unknown as DraftPoolItem;
+}
+
+function legacyItemWithoutMode(): DraftPoolItem {
+  return {
+    id: "item-3",
+    draftPoolId: "pool-1",
+    name: "pikachu",
+    thumbnailUrl: null,
+    metadata: {
+      // no `mode` field — legacy row written before PR 2
+      pokemonId: 25,
+      types: ["electric"],
+      baseStats,
+      generation: "generation-i",
+    },
+    availability: null,
+    encounter: null,
+    effort: null,
+    evolution: null,
+  } as unknown as DraftPoolItem;
+}
+
+describe("getPoolItemDisplay", () => {
+  it("returns individual metadata projected onto the display shape", () => {
+    const display = getPoolItemDisplay(individualItem());
+    expect(display).not.toBeNull();
+    expect(display!.pokemonId).toBe(6);
+    expect(display!.types).toEqual(["fire", "flying"]);
+    expect(display!.baseStats).toEqual(baseStats);
+    expect(display!.generation).toBe("generation-i");
+    expect(display!.mode).toBe("individual");
+  });
+
+  it("returns legacy individual metadata (no mode field) as individual", () => {
+    const display = getPoolItemDisplay(legacyItemWithoutMode());
+    expect(display).not.toBeNull();
+    expect(display!.mode).toBe("individual");
+    expect(display!.pokemonId).toBe(25);
+    expect(display!.types).toEqual(["electric"]);
+  });
+
+  it("projects species metadata onto the terminal final", () => {
+    const display = getPoolItemDisplay(speciesItem());
+    expect(display).not.toBeNull();
+    expect(display!.mode).toBe("species");
+    // Primary final is the non-regional Ninetales — that is what the table
+    // row displays by default.
+    expect(display!.pokemonId).toBe(38);
+    expect(display!.types).toEqual(["fire"]);
+    expect(display!.generation).toBe("generation-i");
+    expect(display!.baseStats.attack).toBe(84);
+  });
+
+  it("exposes regional final variants so a row can hint at them", () => {
+    const display = getPoolItemDisplay(speciesItem());
+    expect(display!.regionalFinals.length).toBe(1);
+    expect(display!.regionalFinals[0].regionalForm).toBe("alola");
+    expect(display!.regionalFinals[0].types).toEqual(["ice", "fairy"]);
+  });
+
+  it("returns null metadata when the item has no metadata", () => {
+    const bare = {
+      ...individualItem(),
+      metadata: null,
+    } as unknown as DraftPoolItem;
+    expect(getPoolItemDisplay(bare)).toBeNull();
+  });
+});

--- a/client/src/features/draft/pool-item-display.ts
+++ b/client/src/features/draft/pool-item-display.ts
@@ -1,0 +1,104 @@
+import type { DraftPoolItem } from "@make-the-pick/shared";
+
+type BaseStats = {
+  hp: number;
+  attack: number;
+  defense: number;
+  specialAttack: number;
+  specialDefense: number;
+  speed: number;
+};
+
+type SpeciesFinalLike = {
+  pokemonId: number;
+  name: string;
+  regionalForm: string | null;
+  types: string[];
+  baseStats: BaseStats;
+  generation: string;
+  spriteUrl: string | null;
+};
+
+// Flat projection of a draft pool item's metadata regardless of drafting
+// mode. The table UI is one row per pool item in both modes — individual
+// rows render the Pokemon's own stats, species rows render the terminal
+// final form's stats — so callers should treat this as "the data for the
+// row" and avoid branching on `mode` themselves.
+export type PoolItemDisplay = {
+  // "individual" for Pokemon drafting (or legacy rows without a mode
+  // discriminator); "species" for species drafting. Exposed so callers that
+  // actually care (e.g. a cell that wants to show a "species" badge) can
+  // still branch.
+  mode: "individual" | "species";
+  pokemonId: number;
+  types: string[];
+  baseStats: BaseStats;
+  generation: string;
+  // For species rows, all finals beyond the primary — used to hint that
+  // a species has regional-variant finals (e.g. Alolan Ninetales).
+  // Empty for individual rows.
+  regionalFinals: SpeciesFinalLike[];
+};
+
+// Projects a draft pool item's metadata onto the flat `PoolItemDisplay`
+// shape. Returns null if the item has no metadata at all.
+//
+// In species mode the "primary" final is `metadata.finals[0]` — that is,
+// the base-region terminal — and any additional regional-variant finals
+// go into `regionalFinals`.
+//
+// Legacy rows persisted before the mode discriminator existed have no
+// `mode` field at all; we treat them as individual so older leagues keep
+// rendering.
+export function getPoolItemDisplay(
+  item: DraftPoolItem,
+): PoolItemDisplay | null {
+  const metadata = item.metadata as
+    | (PoolItemDisplay["mode"] extends string ? {
+        mode?: "individual" | "species";
+      } & Record<string, unknown>
+      : never)
+    | null;
+  if (!metadata) return null;
+
+  if (metadata.mode === "species") {
+    const speciesMeta = metadata as unknown as {
+      finals: SpeciesFinalLike[];
+    };
+    const [primary, ...regionalFinals] = speciesMeta.finals;
+    if (!primary) return null;
+    return {
+      mode: "species",
+      pokemonId: primary.pokemonId,
+      types: primary.types,
+      baseStats: primary.baseStats,
+      generation: primary.generation,
+      regionalFinals,
+    };
+  }
+
+  const individualMeta = metadata as unknown as {
+    pokemonId: number;
+    types: string[];
+    baseStats: BaseStats;
+    generation: string;
+  };
+  return {
+    mode: "individual",
+    pokemonId: individualMeta.pokemonId,
+    types: individualMeta.types,
+    baseStats: individualMeta.baseStats,
+    generation: individualMeta.generation,
+    regionalFinals: [],
+  };
+}
+
+// Convenience helper for code paths that only need the numeric base stat
+// total and want to handle the null-metadata case with a fall-through.
+export function getPoolItemStatTotal(item: DraftPoolItem): number | null {
+  const display = getPoolItemDisplay(item);
+  if (!display) return null;
+  const s = display.baseStats;
+  return s.hp + s.attack + s.defense + s.specialAttack + s.specialDefense +
+    s.speed;
+}


### PR DESCRIPTION
## Summary

- PR 5/6 in the species-drafting rollout. The pool and roster UI now understand species-mode metadata — a species is rendered as a single table row whose stats, types, sprite, and generation come from the terminal final form (\`metadata.finals[0]\`).
- **Keeps the table layout.** The pool table is load-bearing for data analysis during drafting, so species mode stays a row-per-species table rather than a card grid. Where the domain doc says \"species card\" it means the metadata shape, not a literal UI component — clarifying that in PR 6 alongside the rest of the client wiring.
- New \`client/src/features/draft/pool-item-display.ts\` helper centralizes metadata access: individual metadata passes through unchanged, legacy rows without a \`mode\` field are treated as individual (back-compat for items persisted before PR 2), and species metadata is projected onto the primary final with the remaining regional-variant finals exposed under \`regionalFinals\` for later iterations.
- Refactors \`DraftPoolPage\`, \`AvailablePoolTable\`, and \`AllRostersPanel\` to read stats / types / names through the helper. No functional change for individual-mode leagues.

## Test plan

- [x] Unit tests for the helper (individual / legacy no-mode / species with regional finals / null metadata)
- [x] Species-mode integration test on \`DraftPoolPage\`: dual-regional Ninetales renders **one** row with the primary final's stats and types
- [x] \`deno task test:client\` — 225 passed
- [x] \`deno task test:server\` — 261 passed
- [x] \`deno lint\` / \`deno fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)