### PR TITLE
ci(test): retry failing test job up to 5 times with 3m timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:17
@@ -71,12 +71,20 @@ jobs:
       - run: deno task db:migrate
       - name: Run tests
         if: ${{ inputs.debug_client_tests != true }}
-        run: deno task test
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 3
+          max_attempts: 5
+          command: deno task test
       - name: Run tests (client debug mode)
         if: ${{ inputs.debug_client_tests == true }}
-        run: |
-          deno task test:server
-          deno task test:client:debug
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 3
+          max_attempts: 5
+          command: |
+            deno task test:server
+            deno task test:client:debug
 
   docker-smoke:
     name: Docker Smoke Test


### PR DESCRIPTION
## Summary
- Wrap the Test job's run steps in `nick-fields/retry@v3` (max 5 attempts) so flakes/transient failures don't immediately tank the PR.
- Cap each attempt at 3 minutes explicitly via `timeout_minutes`.
- Raise job-level `timeout-minutes` from 5 → 20 to leave headroom for all 5 attempts plus Deno/postgres setup.

## Test plan
- [ ] CI green on this PR