### PR TITLE
feat(layout): add footer with copyright and GitHub repo link

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -202,6 +202,19 @@ describe("AppLayout shell", () => {
     renderLayout();
     expect(screen.getByLabelText("Toggle navigation")).toBeInTheDocument();
   });
+
+  it("renders a footer with a copyright notice and GitHub repo link", () => {
+    setupMocks();
+    renderLayout();
+    const footer = screen.getByRole("contentinfo");
+    expect(within(footer).getByText(/©/)).toBeInTheDocument();
+    expect(within(footer).getByText(/make the pick/i)).toBeInTheDocument();
+    const repoLink = within(footer).getByRole("link", { name: /github/i });
+    expect(repoLink).toHaveAttribute(
+      "href",
+      "https://github.com/Tiernebre/make-the-pick",
+    );
+  });
 });
 
 describe("AppLayout league mode", () => {

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -81,6 +81,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <AppShell
       header={{ height: 52 }}
+      footer={{ height: 40 }}
       navbar={{
         width: navbarWidth,
         breakpoint: "sm",
@@ -289,6 +290,24 @@ export function AppLayout({ children }: AppLayoutProps) {
       </AppShell.Navbar>
 
       <AppShell.Main>{children}</AppShell.Main>
+
+      <AppShell.Footer>
+        <Group h="100%" px="md" justify="space-between" gap="sm">
+          <Text size="xs" c="dimmed">
+            © {new Date().getFullYear()} Make the Pick
+          </Text>
+          <Text
+            component="a"
+            href="https://github.com/Tiernebre/make-the-pick"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="xs"
+            c="dimmed"
+          >
+            GitHub
+          </Text>
+        </Group>
+      </AppShell.Footer>
 
       <Modal
         opened={deleteOpened}


### PR DESCRIPTION
## Summary
- Adds an `AppShell.Footer` to `AppLayout` with `© {year} Make the Pick` and a GitHub link to https://github.com/Tiernebre/make-the-pick.
- TDD: new `AppLayout.test.tsx` case asserts the footer landmark, copyright text, and repo link.

## Test plan
- [x] `deno task test:client -- AppLayout`
- [ ] Visual check — footer visible on every authenticated page