### PR TITLE
feat(league): expose draftMode in create/settings forms (PR 6/6)

### DIFF
--- a/client/src/features/league/CreateLeaguePage.test.tsx
+++ b/client/src/features/league/CreateLeaguePage.test.tsx
@@ -72,6 +72,8 @@ describe("CreateLeaguePage", () => {
       .toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: /^draft format/i }))
       .toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /^draft mode/i }))
+      .toBeInTheDocument();
     expect(screen.getByLabelText(/^number of rounds/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/^max players/i)).toBeInTheDocument();
   });
@@ -95,10 +97,18 @@ describe("CreateLeaguePage", () => {
         rulesConfig: expect.objectContaining({
           draftFormat: "snake",
           numberOfRounds: 6,
+          draftMode: "individual",
         }),
       }),
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
+  });
+
+  it("renders a draft mode select with individual and species options", () => {
+    renderPage();
+    const draftMode = screen.getByRole("textbox", { name: /^draft mode/i });
+    expect(draftMode).toBeInTheDocument();
+    expect(draftMode).toHaveValue("Individual");
   });
 
   it("navigates to the league detail page after successful create", () => {

--- a/client/src/features/league/CreateLeaguePage.tsx
+++ b/client/src/features/league/CreateLeaguePage.tsx
@@ -23,6 +23,7 @@ export function CreateLeaguePage() {
   const [name, setName] = useState("");
   const [sportType, setSportType] = useState<string | null>("pokemon");
   const [draftFormat, setDraftFormat] = useState<string | null>("snake");
+  const [draftMode, setDraftMode] = useState<string | null>("individual");
   const [numberOfRounds, setNumberOfRounds] = useState<number | string>("");
   const [pickTimeLimitSeconds, setPickTimeLimitSeconds] = useState<
     number | string
@@ -49,7 +50,7 @@ export function CreateLeaguePage() {
       return;
     }
     if (
-      !sportType || !draftFormat || !numberOfRounds || !maxPlayers
+      !sportType || !draftFormat || !draftMode || !numberOfRounds || !maxPlayers
     ) {
       return;
     }
@@ -62,6 +63,7 @@ export function CreateLeaguePage() {
         maxPlayers: Number(maxPlayers),
         rulesConfig: {
           draftFormat: draftFormat as "snake" | "linear",
+          draftMode: draftMode as "individual" | "species",
           numberOfRounds: Number(numberOfRounds),
           pickTimeLimitSeconds: pickTimeLimitSeconds
             ? Number(pickTimeLimitSeconds)
@@ -165,6 +167,17 @@ export function CreateLeaguePage() {
               ]}
               value={draftFormat}
               onChange={setDraftFormat}
+              required
+            />
+            <Select
+              label="Draft Mode"
+              description="Individual drafts single Pokemon. Species drafts whole evolution lines at once."
+              data={[
+                { value: "individual", label: "Individual" },
+                { value: "species", label: "Species" },
+              ]}
+              value={draftMode}
+              onChange={setDraftMode}
               required
             />
             <NumberInput

--- a/client/src/features/league/LeagueSettingsPage.test.tsx
+++ b/client/src/features/league/LeagueSettingsPage.test.tsx
@@ -111,8 +111,44 @@ describe("LeagueSettingsPage", () => {
     renderPage();
     expect(screen.getByText(/sport type/i)).toBeInTheDocument();
     expect(screen.getByText(/draft format/i)).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /^draft mode/i }))
+      .toBeInTheDocument();
     expect(screen.getByText(/number of rounds/i)).toBeInTheDocument();
     expect(screen.getByText(/max players/i)).toBeInTheDocument();
+  });
+
+  it("shows draft mode in the locked read-only view", () => {
+    mockUseLeague.mockReturnValue({
+      data: {
+        ...mockLeague,
+        status: "drafting",
+        sportType: "pokemon",
+        maxPlayers: 8,
+        rulesConfig: {
+          draftFormat: "snake",
+          draftMode: "species",
+          numberOfRounds: 6,
+          pickTimeLimitSeconds: null,
+        },
+      },
+      isLoading: false,
+    });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText(/^draft mode$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^species$/i)).toBeInTheDocument();
   });
 
   it("shows read-only view for non-commissioners", () => {

--- a/client/src/features/league/LeagueSettingsPage.tsx
+++ b/client/src/features/league/LeagueSettingsPage.tsx
@@ -32,6 +32,7 @@ export function LeagueSettingsPage() {
 
   const [sportType, setSportType] = useState<string | null>(null);
   const [draftFormat, setDraftFormat] = useState<string | null>("snake");
+  const [draftMode, setDraftMode] = useState<string | null>("individual");
   const [numberOfRounds, setNumberOfRounds] = useState<number | string>("");
   const [pickTimeLimitSeconds, setPickTimeLimitSeconds] = useState<
     number | string
@@ -51,6 +52,7 @@ export function LeagueSettingsPage() {
       if (league.data.maxPlayers) setMaxPlayers(league.data.maxPlayers);
       const rules = league.data.rulesConfig as {
         draftFormat?: string;
+        draftMode?: string;
         numberOfRounds?: number;
         pickTimeLimitSeconds?: number | null;
         poolSizeMultiplier?: number;
@@ -61,6 +63,7 @@ export function LeagueSettingsPage() {
       } | null;
       if (rules) {
         if (rules.draftFormat) setDraftFormat(rules.draftFormat);
+        if (rules.draftMode) setDraftMode(rules.draftMode);
         if (rules.numberOfRounds) setNumberOfRounds(rules.numberOfRounds);
         if (rules.pickTimeLimitSeconds) {
           setPickTimeLimitSeconds(rules.pickTimeLimitSeconds);
@@ -86,6 +89,7 @@ export function LeagueSettingsPage() {
   type SettingsState = {
     sportType: string | null;
     draftFormat: string | null;
+    draftMode: string | null;
     numberOfRounds: number | string;
     pickTimeLimitSeconds: number | string;
     maxPlayers: number | string;
@@ -99,6 +103,7 @@ export function LeagueSettingsPage() {
   const currentSettings: SettingsState = {
     sportType,
     draftFormat,
+    draftMode,
     numberOfRounds,
     pickTimeLimitSeconds,
     maxPlayers,
@@ -110,7 +115,7 @@ export function LeagueSettingsPage() {
   };
 
   const isSettingsStateValid = (s: SettingsState) =>
-    !!s.sportType && !!s.draftFormat &&
+    !!s.sportType && !!s.draftFormat && !!s.draftMode &&
     Number(s.numberOfRounds) >= 1 && Number(s.maxPlayers) >= 2 &&
     Number(s.poolSizeMultiplier) >= 1.5 && Number(s.poolSizeMultiplier) <= 3;
 
@@ -122,6 +127,7 @@ export function LeagueSettingsPage() {
       maxPlayers: Number(s.maxPlayers),
       rulesConfig: {
         draftFormat: s.draftFormat as "snake" | "linear",
+        draftMode: s.draftMode as "individual" | "species",
         numberOfRounds: Number(s.numberOfRounds),
         pickTimeLimitSeconds: s.pickTimeLimitSeconds
           ? Number(s.pickTimeLimitSeconds)
@@ -258,6 +264,23 @@ export function LeagueSettingsPage() {
                     }}
                     required
                   />
+                  <Select
+                    label="Draft Mode"
+                    description="Individual drafts single Pokemon. Species drafts whole evolution lines at once."
+                    data={[
+                      { value: "individual", label: "Individual" },
+                      { value: "species", label: "Species" },
+                    ]}
+                    value={draftMode}
+                    onChange={(value) => {
+                      setDraftMode(value);
+                      saveSettings({
+                        ...currentSettings,
+                        draftMode: value,
+                      });
+                    }}
+                    required
+                  />
                   <NumberInput
                     label="Number of Rounds"
                     min={1}
@@ -344,6 +367,14 @@ export function LeagueSettingsPage() {
                           {(league.data
                             .rulesConfig as { draftFormat: string })
                             .draftFormat}
+                        </Badge>
+                      </Group>
+                      <Group>
+                        <Text fw={500}>Draft Mode</Text>
+                        <Badge variant="light">
+                          {(league.data
+                            .rulesConfig as { draftMode?: string })
+                            .draftMode ?? "individual"}
                         </Badge>
                       </Group>
                       <Group>


### PR DESCRIPTION
## Summary
- Final PR in the species-drafting rollout: adds a **Draft Mode** Select (Individual / Species) to `CreateLeaguePage` and `LeagueSettingsPage`, wired into the `rulesConfig.draftMode` field that PR 4 added.
- Defaults to `individual`, so existing flows behave identically. Species leagues can now be created without hand-crafted API calls.
- Settings page shows the current mode as a badge in its locked read-only view (falls back to `individual` for pre-rollout leagues).

Invariant 6 (mode fixed at league creation) is still enforced by the existing `status === "setup"` gate on settings edits — no server changes needed.

## Test plan
- [x] \`deno task test:client\` — 228 passing
- [x] \`deno lint\` — clean
- [ ] Manual: create a league with Draft Mode = Species and confirm the pool generates as species-shaped
- [ ] Manual: confirm locked settings view shows the Draft Mode badge for a post-setup league