### PR TITLE
fix(draft): improve contrast of live pool reveal heading

### DIFF
--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -673,7 +673,7 @@ export function DraftPoolPage() {
               <Group justify="space-between" align="center" wrap="wrap">
                 <Stack gap={4} style={{ flex: 1, minWidth: 240 }}>
                   <Group gap="sm" align="center">
-                    <Text fw={700} size="md" c="mint-green-9">
+                    <Text fw={700} size="md" c="dark.9">
                       Live pool reveal in progress
                     </Text>
                     <Badge color="mint-green" variant="filled" size="lg">


### PR DESCRIPTION
## Summary
- Heading text "Live pool reveal in progress" was `mint-green-9` on a `mint-green-0` panel, which didn't read cleanly against the pale mint background.
- Switched the heading color to `dark.9` so it's legible; surrounding mint-green accents (badge, border, buttons) still carry the status color.

## Test plan
- [ ] Start a league, enter the pooling phase, and visit the Draft Pool page — confirm the "Live pool reveal in progress" heading is clearly legible on the mint panel.