### PR TITLE
feat(league): show pretty Pokemon version name on league details

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -16,6 +16,7 @@ const {
   mockUseRemoveLeaguePlayer,
   mockRemovePlayerMutate,
   mockUseDraft,
+  mockUsePokemonVersions,
 } = vi.hoisted(
   () => ({
     mockUseLeague: vi.fn(),
@@ -30,6 +31,7 @@ const {
     mockUseRemoveLeaguePlayer: vi.fn(),
     mockRemovePlayerMutate: vi.fn(),
     mockUseDraft: vi.fn(),
+    mockUsePokemonVersions: vi.fn(),
   }),
 );
 
@@ -45,6 +47,10 @@ vi.mock("./use-leagues", () => ({
 
 vi.mock("../draft/use-draft", () => ({
   useDraft: mockUseDraft,
+}));
+
+vi.mock("../pokemon-version/use-pokemon-versions", () => ({
+  usePokemonVersions: mockUsePokemonVersions,
 }));
 
 vi.mock("../../auth", () => ({
@@ -103,6 +109,18 @@ describe("LeagueDetailPage", () => {
       error: null,
     });
     mockUseDraft.mockReturnValue({ data: undefined, isLoading: false });
+    mockUsePokemonVersions.mockReturnValue({
+      data: [
+        {
+          id: "scarlet-violet",
+          name: "Scarlet Violet",
+          versionGroup: "scarlet-violet",
+          region: "Paldea",
+          generation: 9,
+        },
+      ],
+      isLoading: false,
+    });
     mockUseRemoveLeaguePlayer.mockReturnValue({
       mutate: mockRemovePlayerMutate,
       reset: vi.fn(),
@@ -507,7 +525,7 @@ describe("LeagueDetailPage", () => {
     });
     renderPage();
     expect(screen.getByText(/game version/i)).toBeInTheDocument();
-    expect(screen.getByText(/scarlet-violet/i)).toBeInTheDocument();
+    expect(screen.getByText("Scarlet Violet")).toBeInTheDocument();
     expect(screen.getByText(/pool multiplier/i)).toBeInTheDocument();
     expect(screen.getByText(/2\.5x/)).toBeInTheDocument();
     expect(screen.getByText(/pick timer/i)).toBeInTheDocument();

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -36,6 +36,7 @@ import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { AllRostersPanel } from "../draft/AllRostersPanel";
 import { useDraft } from "../draft/use-draft";
+import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
 import { LifecycleStepper } from "./LifecycleStepper";
 import { NpcAvatar } from "./NpcAvatar";
 import { TrainerCard } from "./TrainerCard";
@@ -65,6 +66,15 @@ function capitalize(word: string): string {
 export function LeagueDetailPage() {
   const { id } = useParams<{ id: string }>();
   const league = useLeague(id!);
+  const pokemonVersions = usePokemonVersions();
+  const gameVersionName = useMemo(() => {
+    const rules = league.data?.rulesConfig as
+      | { gameVersion?: string }
+      | undefined;
+    if (!rules?.gameVersion) return undefined;
+    const match = pokemonVersions.data?.find((v) => v.id === rules.gameVersion);
+    return match?.name ?? rules.gameVersion;
+  }, [league.data?.rulesConfig, pokemonVersions.data]);
   const players = useLeaguePlayers(id!);
   const draft = useDraft(id!, {
     enabled: league.data?.status === "competing",
@@ -596,7 +606,7 @@ export function LeagueDetailPage() {
                             <Group justify="space-between">
                               <Text size="sm" c="dimmed">Game version</Text>
                               <Text size="sm">
-                                {rules.gameVersion ?? "All Pokemon"}
+                                {gameVersionName ?? "All Pokemon"}
                               </Text>
                             </Group>
                             <Group justify="space-between">


### PR DESCRIPTION
## Summary
- The league details page was rendering the raw kebab-case version id (e.g. `scarlet-violet`, `fire-red`) next to "Game version", which looked unpolished.
- Now looks the id up in the existing `usePokemonVersions` list and renders the proper display name (`Scarlet Violet`, `Fire Red`), falling back to the raw id if the list hasn't loaded yet.

## Test plan
- [x] `deno task test:client` — 229 tests pass (updated `LeagueDetailPage.test.tsx` to mock `usePokemonVersions` and assert the pretty name).
- [x] `deno lint` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)