### PR TITLE
feat(draft): queue-based quick-draft and auto-pick

### DIFF
--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -187,6 +187,11 @@ export function DraftPage() {
               <WatchlistPanel
                 leagueId={leagueId}
                 poolItems={draftState.poolItems}
+                title="Queue"
+                emptyMessage="Star players from the pool to queue them up. The top of your queue auto-picks if your timer runs out."
+                onQuickDraft={handlePick}
+                quickDraftEnabled={isMyTurn}
+                isPicking={makePick.isPending}
               />
             </Grid.Col>
           </Grid>

--- a/client/src/features/draft/WatchlistPanel.tsx
+++ b/client/src/features/draft/WatchlistPanel.tsx
@@ -1,6 +1,7 @@
 import {
   ActionIcon,
   Avatar,
+  Button,
   Card,
   Group,
   Stack,
@@ -41,6 +42,9 @@ interface SortableWatchlistItemProps {
   note: string | undefined;
   leagueId: string;
   onRemove: (draftPoolItemId: string) => void;
+  onQuickDraft?: (draftPoolItemId: string) => void;
+  quickDraftDisabled?: boolean;
+  isPicking?: boolean;
 }
 
 function SortableWatchlistItem({
@@ -49,6 +53,9 @@ function SortableWatchlistItem({
   poolItem,
   note,
   onRemove,
+  onQuickDraft,
+  quickDraftDisabled,
+  isPicking,
 }: SortableWatchlistItemProps) {
   const {
     attributes,
@@ -103,6 +110,18 @@ function SortableWatchlistItem({
           </Text>
         )}
       </Stack>
+      {onQuickDraft && (
+        <Button
+          size="compact-xs"
+          variant="filled"
+          color="blue"
+          disabled={quickDraftDisabled}
+          loading={isPicking}
+          onClick={() => onQuickDraft(item.draftPoolItemId)}
+        >
+          Draft
+        </Button>
+      )}
       <ActionIcon
         variant="subtle"
         color="yellow"
@@ -118,9 +137,32 @@ function SortableWatchlistItem({
 interface WatchlistPanelProps {
   leagueId: string;
   poolItems: DraftPoolItem[];
+  /** Title shown at the top of the panel. Defaults to "Watchlist". */
+  title?: string;
+  /** Hint text shown when the list is empty. */
+  emptyMessage?: string;
+  /**
+   * When provided, renders a quick-draft button on each row that calls
+   * `onQuickDraft` with the pool item id. Use to turn the panel into a
+   * draftable queue during a live draft.
+   */
+  onQuickDraft?: (poolItemId: string) => void | Promise<void>;
+  /** Whether quick-draft buttons should be enabled (true on the user's turn). */
+  quickDraftEnabled?: boolean;
+  /** Whether a pick is currently in flight (renders the button as loading). */
+  isPicking?: boolean;
 }
 
-export function WatchlistPanel({ leagueId, poolItems }: WatchlistPanelProps) {
+export function WatchlistPanel({
+  leagueId,
+  poolItems,
+  title = "Watchlist",
+  emptyMessage =
+    "Click the star icon on any player to add them to your watchlist.",
+  onQuickDraft,
+  quickDraftEnabled = false,
+  isPicking = false,
+}: WatchlistPanelProps) {
   const watchlist = useWatchlist(leagueId);
   const removeFromWatchlist = useRemoveFromWatchlist();
   const reorderWatchlist = useReorderWatchlist();
@@ -166,12 +208,12 @@ export function WatchlistPanel({ leagueId, poolItems }: WatchlistPanelProps) {
   return (
     <Card withBorder p="md">
       <Title order={4} mb="sm">
-        Watchlist ({items.length})
+        {title} ({items.length})
       </Title>
       {items.length === 0
         ? (
           <Text size="sm" c="dimmed">
-            Click the star icon on any player to add them to your watchlist.
+            {emptyMessage}
           </Text>
         )
         : (
@@ -200,6 +242,13 @@ export function WatchlistPanel({ leagueId, poolItems }: WatchlistPanelProps) {
                       note={note}
                       leagueId={leagueId}
                       onRemove={handleRemove}
+                      onQuickDraft={onQuickDraft
+                        ? (id) => {
+                          void onQuickDraft(id);
+                        }
+                        : undefined}
+                      quickDraftDisabled={!quickDraftEnabled}
+                      isPicking={isPicking}
                     />
                   );
                 })}

--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -3,6 +3,7 @@ import type { DraftEvent, DraftState } from "@make-the-pick/shared";
 import { logger } from "../../logger.ts";
 import type { DraftPoolRepository } from "../draft-pool/draft-pool.repository.ts";
 import type { LeagueRepository } from "../league/league.repository.ts";
+import type { WatchlistRepository } from "../watchlist/watchlist.repository.ts";
 import {
   DraftPickConflictError,
   type DraftRepository,
@@ -192,6 +193,7 @@ export function createDraftService(deps: {
   draftRepo: DraftRepository;
   leagueRepo: LeagueRepository;
   draftPoolRepo: DraftPoolRepository;
+  watchlistRepo?: WatchlistRepository;
   draftEventPublisher?: DraftEventPublisher;
   clock?: Clock;
   timerScheduler?: DraftTimerScheduler;
@@ -202,7 +204,40 @@ export function createDraftService(deps: {
   const clock: Clock = deps.clock ?? { now: () => new Date() };
   const scheduler = deps.timerScheduler;
   const npcScheduler = deps.npcScheduler;
+  const watchlistRepo = deps.watchlistRepo;
   const randomFn = deps.randomFn ?? Math.random;
+
+  /**
+   * Auto-pick selection with the user's queue (watchlist) taking priority:
+   * pick the highest-ranked queue item that is still in the available pool.
+   * If the queue is empty or all queued items have been taken, fall back to
+   * `selectAutoPickItem` (highest BST). The queue lookup is best-effort —
+   * any error or missing repo silently degrades to BST so a stuck queue
+   * can never stall the draft.
+   */
+  async function selectQueueOrBstPick<
+    T extends PoolItemWithMetadata & { id: string },
+  >(
+    leaguePlayerId: string,
+    available: T[],
+  ): Promise<T | null> {
+    if (watchlistRepo) {
+      try {
+        const queue = await watchlistRepo.findByLeaguePlayerId(leaguePlayerId);
+        const availableById = new Map(available.map((item) => [item.id, item]));
+        for (const entry of queue) {
+          const match = availableById.get(entry.draftPoolItemId);
+          if (match) return match;
+        }
+      } catch (err) {
+        log.warn(
+          { err, leaguePlayerId },
+          "queue lookup failed during auto-pick — falling back to BST",
+        );
+      }
+    }
+    return selectAutoPickItem(available);
+  }
 
   function publishTurnChange(
     leagueId: string,
@@ -595,7 +630,7 @@ export function createDraftService(deps: {
       const picks = await deps.draftRepo.listPicks(draftRow.id);
       const pickedItemIds = new Set(picks.map((p) => p.poolItemId));
       const available = poolItems.filter((item) => !pickedItemIds.has(item.id));
-      const chosen = selectAutoPickItem(available);
+      const chosen = await selectQueueOrBstPick(currentPlayer.id, available);
       if (!chosen) return;
 
       let createdPickRow: Awaited<

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -10,7 +10,29 @@ import {
   type DraftRepository,
 } from "./draft.repository.ts";
 import type { DraftEventPublisher } from "./draft.events.ts";
+import type { WatchlistRepository } from "../watchlist/watchlist.repository.ts";
 import { createDraftService } from "./draft.service.ts";
+
+function createFakeWatchlistRepo(
+  overrides: Partial<WatchlistRepository> = {},
+): WatchlistRepository {
+  return {
+    findByLeaguePlayerId: (_leaguePlayerId) => Promise.resolve([]),
+    findByLeaguePlayerIdAndDraftPoolItemId: (_l, _d) => Promise.resolve(null),
+    getMaxPosition: (_leaguePlayerId) => Promise.resolve(null),
+    create: (data) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leaguePlayerId: data.leaguePlayerId,
+        draftPoolItemId: data.draftPoolItemId,
+        position: data.position,
+        createdAt: new Date(),
+      }),
+    deleteByLeaguePlayerIdAndDraftPoolItemId: (_l, _d) => Promise.resolve(),
+    replaceAllPositions: (_l, _ids) => Promise.resolve(),
+    ...overrides,
+  };
+}
 
 interface PublishedEvent {
   leagueId: string;
@@ -1721,6 +1743,228 @@ Deno.test("draftService.runAutoPick: completing auto-pick publishes draft:comple
     true,
   );
   assertEquals(scheduler.cancelled, [draft.id]);
+});
+
+Deno.test("draftService.runAutoPick: picks top available item from current player's queue before BST fallback", async () => {
+  const fx = setupMakePickFakes({ currentPick: 0 });
+  fx.league.rulesConfig = {
+    draftFormat: "snake",
+    numberOfRounds: 2,
+    pickTimeLimitSeconds: 10,
+    poolSizeMultiplier: 2,
+  };
+  const weakBut = {
+    ...fx.poolItems[2],
+    metadata: {
+      pokemonId: 10,
+      types: ["bug"],
+      baseStats: {
+        hp: 10,
+        attack: 10,
+        defense: 10,
+        specialAttack: 10,
+        specialDefense: 10,
+        speed: 10,
+      },
+      generation: "gen-1",
+    },
+  };
+  const strongBstItem = {
+    ...fx.poolItems[1],
+    metadata: {
+      pokemonId: 150,
+      types: ["psychic"],
+      baseStats: {
+        hp: 106,
+        attack: 110,
+        defense: 90,
+        specialAttack: 154,
+        specialDefense: 90,
+        speed: 130,
+      },
+      generation: "gen-1",
+    },
+  };
+  const items = [fx.poolItems[0], strongBstItem, weakBut, fx.poolItems[3]];
+
+  const draftWithDeadline = {
+    ...fx.draft,
+    currentTurnDeadline: new Date(Date.now() - 1000),
+  };
+
+  let createdPickInput:
+    | { poolItemId: string; autoPicked?: boolean; leaguePlayerId: string }
+    | null = null;
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draftWithDeadline),
+    listPicks: () => Promise.resolve([]),
+    createPick: (input) => {
+      createdPickInput = input;
+      return Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: input.autoPicked ?? false,
+      });
+    },
+    incrementCurrentPick: () => Promise.resolve(1),
+    updateTurnDeadline: () => Promise.resolve(),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(fx.league),
+    findPlayersByLeagueId: () => Promise.resolve([fx.playerA, fx.playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(fx.pool),
+    findItemsByPoolId: () => Promise.resolve(items),
+  });
+  const watchlistRepo = createFakeWatchlistRepo({
+    findByLeaguePlayerId: (leaguePlayerId) => {
+      if (leaguePlayerId !== fx.playerA.id) return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          id: crypto.randomUUID(),
+          leaguePlayerId: fx.playerA.id,
+          draftPoolItemId: weakBut.id,
+          position: 0,
+          createdAt: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          leaguePlayerId: fx.playerA.id,
+          draftPoolItemId: strongBstItem.id,
+          position: 1,
+          createdAt: new Date(),
+        },
+      ]);
+    },
+  });
+  const publisher = createRecordingPublisher();
+  const scheduler = createRecordingScheduler();
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    watchlistRepo,
+    draftEventPublisher: publisher,
+    timerScheduler: scheduler,
+  });
+
+  await service.runAutoPick({ leagueId: fx.league.id });
+
+  assertEquals(
+    (createdPickInput as unknown as { poolItemId: string } | null)?.poolItemId,
+    weakBut.id,
+  );
+  assertEquals(
+    (createdPickInput as unknown as { autoPicked?: boolean } | null)
+      ?.autoPicked,
+    true,
+  );
+});
+
+Deno.test("draftService.runAutoPick: falls back to highest-BST when queue has no available items", async () => {
+  const fx = setupMakePickFakes({ currentPick: 1 });
+  fx.league.rulesConfig = {
+    draftFormat: "snake",
+    numberOfRounds: 2,
+    pickTimeLimitSeconds: 10,
+    poolSizeMultiplier: 2,
+  };
+  const strongBstItem = {
+    ...fx.poolItems[2],
+    metadata: {
+      pokemonId: 6,
+      types: ["fire"],
+      baseStats: {
+        hp: 78,
+        attack: 84,
+        defense: 78,
+        specialAttack: 109,
+        specialDefense: 85,
+        speed: 100,
+      },
+      generation: "gen-1",
+    },
+  };
+  const items = [
+    fx.poolItems[0],
+    fx.poolItems[1],
+    strongBstItem,
+    fx.poolItems[3],
+  ];
+
+  const draftWithDeadline = {
+    ...fx.draft,
+    currentTurnDeadline: new Date(Date.now() - 1000),
+  };
+  const existingPicks: FakeDraftPick[] = [
+    {
+      id: crypto.randomUUID(),
+      draftId: fx.draft.id,
+      leaguePlayerId: fx.playerA.id,
+      poolItemId: fx.poolItems[0].id,
+      pickNumber: 0,
+      pickedAt: new Date(),
+      autoPicked: false,
+    },
+  ];
+  let createdPoolItemId: string | null = null;
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draftWithDeadline),
+    listPicks: () => Promise.resolve(existingPicks),
+    createPick: (input) => {
+      createdPoolItemId = input.poolItemId;
+      return Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: input.autoPicked ?? false,
+      });
+    },
+    incrementCurrentPick: () => Promise.resolve(2),
+    updateTurnDeadline: () => Promise.resolve(),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(fx.league),
+    findPlayersByLeagueId: () => Promise.resolve([fx.playerA, fx.playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(fx.pool),
+    findItemsByPoolId: () => Promise.resolve(items),
+  });
+  const watchlistRepo = createFakeWatchlistRepo({
+    findByLeaguePlayerId: (leaguePlayerId) => {
+      if (leaguePlayerId !== fx.playerB.id) return Promise.resolve([]);
+      return Promise.resolve([
+        {
+          id: crypto.randomUUID(),
+          leaguePlayerId: fx.playerB.id,
+          draftPoolItemId: fx.poolItems[0].id,
+          position: 0,
+          createdAt: new Date(),
+        },
+      ]);
+    },
+  });
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    watchlistRepo,
+    draftEventPublisher: createRecordingPublisher(),
+    timerScheduler: createRecordingScheduler(),
+  });
+
+  await service.runAutoPick({ leagueId: fx.league.id });
+
+  assertEquals(createdPoolItemId, strongBstItem.id);
 });
 
 // --- pauseDraft ----------------------------------------------------------

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -104,10 +104,12 @@ export function createFeatureRouters(db: Database) {
   // without resorting to `any` casts or module-level globals.
   const draftTimerScheduler = createDraftTimerScheduler({ draftRepo });
   const npcScheduler = createNpcScheduler();
+  const watchlistRepo = createWatchlistRepository(db);
   const draftService = createDraftService({
     draftRepo,
     leagueRepo,
     draftPoolRepo,
+    watchlistRepo,
     draftEventPublisher,
     timerScheduler: draftTimerScheduler,
     npcScheduler,
@@ -138,7 +140,6 @@ export function createFeatureRouters(db: Database) {
     pokemonVersionsJson as PokemonVersion[],
   );
 
-  const watchlistRepo = createWatchlistRepository(db);
   const watchlistService = createWatchlistService({
     watchlistRepo,
     leagueRepo,


### PR DESCRIPTION
## Summary
- Rename the draft-room panel from **Watchlist** to **Queue**; each row gets a one-click **Draft** button enabled only on the current player's turn. The pool research UI still labels it "Watchlist".
- \`runAutoPick\` now picks the highest-ranked still-available item from the current player's queue, falling back to the existing highest-BST rule only when the queue is empty or fully drafted. Wired \`watchlistRepo\` into the draft service.
- TDD: added two service tests covering queue-wins-over-BST and queue-empty fallback.

## Test plan
- [x] \`deno task test:server\` (263 passed)
- [x] \`vitest run src/features/draft\` (102 passed, 12 files)
- [x] \`deno lint\` on touched paths
- [ ] Manual: star a pool item, start a draft, confirm Draft button picks on click and the timer-expiry auto-pick honors queue order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)