### PR TITLE
docs(domain): add user, watchlist, and pool-item-note domain docs

### DIFF
--- a/docs/domain/pool-item-note.md
+++ b/docs/domain/pool-item-note.md
@@ -1,0 +1,52 @@
+# Pool Item Note
+
+A pool item note is a player's private, freeform text annotation on a single
+draft pool item within a league. Notes are scoped per player — one note per
+(player, pool item) pair — and are intended for personal scouting commentary
+during the pre-draft period.
+
+## Entities
+
+### PoolItemNote
+
+| Field           | Type        | Constraints                                        |
+| --------------- | ----------- | -------------------------------------------------- |
+| id              | uuid        | PK, generated                                      |
+| leaguePlayerId  | uuid        | NOT NULL, FK → league_player.id (cascade delete)   |
+| draftPoolItemId | uuid        | NOT NULL, FK → draft_pool_item.id (cascade delete) |
+| content         | text        | NOT NULL                                           |
+| createdAt       | timestamptz | NOT NULL, default now()                            |
+| updatedAt       | timestamptz | NOT NULL, default now()                            |
+
+**Unique constraint:** (league_player_id, draft_pool_item_id) — a player has at
+most one note per pool item.
+
+## Relationships
+
+- **LeaguePlayer → PoolItemNote**: One-to-many. A player may annotate many pool
+  items within their league.
+- **DraftPoolItem → PoolItemNote**: One-to-many. A pool item may have notes from
+  multiple players (one per player).
+
+## Invariants
+
+1. Only a league member may manage notes for that league. A user who is not a
+   LeaguePlayer in the requested league receives a `FORBIDDEN` error.
+2. A player has at most one note per pool item (enforced by the unique
+   constraint). Creating a note for a pool item that already has one overwrites
+   the existing note (`upsert` semantics — `updatedAt` is refreshed on
+   conflict).
+3. `content` must be non-empty; the constraint is enforced at the database level
+   via `NOT NULL`.
+4. Deleting a LeaguePlayer or a DraftPoolItem cascades to remove the
+   corresponding PoolItemNote rows automatically.
+5. Notes are private to each player; the list operation returns only notes
+   belonging to the requesting player's league membership.
+
+## Operations
+
+| Operation | Description                                                                      |
+| --------- | -------------------------------------------------------------------------------- |
+| list      | Returns all pool item notes for the caller's player within the specified league. |
+| upsert    | Creates or updates the note for a given pool item (last write wins).             |
+| delete    | Removes the note for a given pool item.                                          |

--- a/docs/domain/user.md
+++ b/docs/domain/user.md
@@ -1,0 +1,60 @@
+# User
+
+A user is an authenticated human (or NPC) account. Users are created by the
+authentication provider (Better Auth) and are the root identity that all other
+domain entities — leagues, picks, watchlists, notes — hang from.
+
+## Fields
+
+### User
+
+| Field         | Type        | Constraints               |
+| ------------- | ----------- | ------------------------- |
+| id            | text        | PK (set by auth provider) |
+| name          | text        | NOT NULL                  |
+| email         | text        | NOT NULL, UNIQUE          |
+| emailVerified | boolean     | NOT NULL                  |
+| image         | text        | nullable                  |
+| isNpc         | boolean     | NOT NULL, default `false` |
+| npcStrategy   | text        | nullable                  |
+| createdAt     | timestamptz | NOT NULL                  |
+| updatedAt     | timestamptz | NOT NULL                  |
+
+### Session
+
+Managed by the auth layer. Each session token is unique and expires at a
+configured time. Sessions cascade-delete when the owning user is deleted.
+
+### Account
+
+Links a user to an external OAuth provider (e.g. Google). A user may have
+multiple accounts (one per provider). Accounts cascade-delete when the owning
+user is deleted.
+
+## Relationships
+
+- **User → Session**: One-to-many. A user may have multiple active sessions.
+- **User → Account**: One-to-many. A user may authenticate via multiple
+  providers.
+- **User → LeaguePlayer**: One-to-many. A user may be a member of many leagues.
+- **User → League** (created_by): One-to-many. A user may have created many
+  leagues.
+
+## Invariants
+
+1. The user's `id` is assigned by the authentication provider, not generated
+   server-side.
+2. `email` must be globally unique — the auth layer enforces this.
+3. Deleting a user cascades to their sessions, accounts, and league memberships
+   (LeaguePlayer rows).
+4. Application code exposes only one user-facing mutation: `deleteAccount`,
+   which removes the user by ID and relies on database cascades to clean up all
+   related data.
+
+## NPC Users
+
+When `isNpc` is `true`, the user is a non-player character injected into a
+league for development and testing purposes. NPCs are never real OAuth accounts.
+The optional `npcStrategy` field is reserved for future configuration of how an
+NPC selects picks during a draft (e.g. random selection). See the league domain
+doc for how NPCs are added to leagues and how auto-pick is triggered.

--- a/docs/domain/watchlist.md
+++ b/docs/domain/watchlist.md
@@ -1,0 +1,54 @@
+# Watchlist
+
+A watchlist is a player's personal, ordered list of draft pool items they intend
+to track or prioritize during a draft. Each league player maintains their own
+independent watchlist scoped to that league.
+
+## Entities
+
+### WatchlistItem
+
+A single entry in a player's watchlist. Links a league player to a draft pool
+item and records the item's position within that player's list.
+
+| Field           | Type        | Constraints                                        |
+| --------------- | ----------- | -------------------------------------------------- |
+| id              | uuid        | PK, generated                                      |
+| leaguePlayerId  | uuid        | NOT NULL, FK → league_player.id (cascade delete)   |
+| draftPoolItemId | uuid        | NOT NULL, FK → draft_pool_item.id (cascade delete) |
+| position        | integer     | NOT NULL                                           |
+| createdAt       | timestamptz | NOT NULL, default now()                            |
+
+**Unique constraint:** (league_player_id, draft_pool_item_id) — a player can
+only add a given pool item to their watchlist once.
+
+## Relationships
+
+- **LeaguePlayer → WatchlistItem**: One-to-many. A player has many watchlist
+  entries, each scoped to their league membership.
+- **DraftPoolItem → WatchlistItem**: One-to-many. A pool item may appear on
+  multiple players' watchlists (one per player).
+
+## Invariants
+
+1. Only a league member may manage a watchlist for that league. A user who is
+   not a LeaguePlayer in the requested league receives a `FORBIDDEN` error.
+2. A pool item can appear at most once per player's watchlist (enforced by the
+   unique constraint).
+3. Position values are zero-based integers. When an item is appended, its
+   position is set to `max(existing positions) + 1`. An empty watchlist starts
+   at position 0.
+4. Reordering replaces all position values atomically in a single database
+   transaction. Only items belonging to the requesting player are updated; the
+   operation ignores IDs that do not belong to the player.
+5. Deleting a LeaguePlayer or a DraftPoolItem cascades to remove the
+   corresponding WatchlistItem rows automatically.
+
+## Operations
+
+| Operation | Description                                                               |
+| --------- | ------------------------------------------------------------------------- |
+| list      | Returns all watchlist items for the caller's player, ordered by position. |
+| add       | Appends a pool item to the end of the watchlist.                          |
+| remove    | Removes a pool item from the watchlist.                                   |
+| reorder   | Replaces the full position sequence given an ordered list of item IDs.    |


### PR DESCRIPTION
## Summary

- Audit identified `user`, `watchlist`, and `pool-item-note` as undocumented domains relative to `draft` and `league`.
- Adding domain docs so future work has the same ubiquitous-language reference as the existing documented domains.
- Docs are derived strictly from the code in `server/features/` and `server/db/schema.ts` — no speculative content.

## Test plan

- [ ] Verify the three new files render correctly on GitHub: `docs/domain/user.md`, `docs/domain/watchlist.md`, `docs/domain/pool-item-note.md`
- [ ] Confirm field tables match `server/db/schema.ts` definitions
- [ ] Confirm invariants match service/repository logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)