### PR TITLE
refactor(league): split LeagueDetailPage into focused subcomponents

### DIFF
--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -1,45 +1,29 @@
 import {
-  ActionIcon,
-  Alert,
   Anchor,
-  Avatar,
-  Badge,
-  Box,
   Button,
   Card,
   Container,
-  CopyButton,
-  Flex,
   Grid,
   Group,
-  Loader,
   LoadingOverlay,
-  Menu,
-  Modal,
-  Paper,
   Stack,
-  Text,
-  Title,
-  Tooltip,
-  UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import {
-  IconChevronDown,
-  IconSettings,
-  IconSparkles,
-  IconTrash,
-} from "@tabler/icons-react";
-import { npcStrategyColor, parseNpcStrategy } from "@make-the-pick/shared";
 import { useMemo, useState } from "react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
 import { AllRostersPanel } from "../draft/AllRostersPanel";
 import { useDraft } from "../draft/use-draft";
 import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
-import { LifecycleStepper } from "./LifecycleStepper";
-import { NpcAvatar } from "./NpcAvatar";
-import { TrainerCard } from "./TrainerCard";
+import { AdvanceLeagueModal } from "./components/AdvanceLeagueModal";
+import { ChooseNpcModal } from "./components/ChooseNpcModal";
+import { DeleteLeagueModal } from "./components/DeleteLeagueModal";
+import { LeagueHeader } from "./components/LeagueHeader";
+import { LeagueInfoCard } from "./components/LeagueInfoCard";
+import { LeaguePlayersCard } from "./components/LeaguePlayersCard";
+import { LeagueRulesCard } from "./components/LeagueRulesCard";
+import { LeagueYourTeamPanel } from "./components/LeagueYourTeamPanel";
+import { RemovePlayerModal } from "./components/RemovePlayerModal";
 import {
   useAddNpcPlayer,
   useAdvanceLeagueStatus,
@@ -58,10 +42,6 @@ const NEXT_STATUS: Record<string, string | null> = {
   competing: "complete",
   complete: null,
 };
-
-function capitalize(word: string): string {
-  return word.charAt(0).toUpperCase() + word.slice(1);
-}
 
 export function LeagueDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -159,480 +139,61 @@ export function LeagueDetailPage() {
 
       {league.data && (
         <>
-          <Paper withBorder radius="md" p={{ base: "md", sm: "lg" }} mb="lg">
-            <Flex
-              direction={{ base: "column", sm: "row" }}
-              justify="space-between"
-              align={{ base: "stretch", sm: "flex-start" }}
-              gap="md"
-            >
-              <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
-                <Title order={1} style={{ wordBreak: "break-word" }}>
-                  {league.data.name}
-                </Title>
-                {league.data.sportType && (
-                  <Group gap="xs">
-                    <Badge color="mint-green" variant="light" tt="capitalize">
-                      {league.data.sportType}
-                    </Badge>
-                  </Group>
-                )}
-                <Box mt="xs">
-                  <LifecycleStepper currentPhase={league.data.status} />
-                </Box>
-              </Stack>
-
-              <Group gap="sm" wrap="wrap">
-                {(league.data.status === "pooling" ||
-                  league.data.status === "scouting") && (
-                  <Button
-                    component={Link}
-                    href={`/leagues/${league.data.id}/draft/pool`}
-                    size="md"
-                    color={league.data.status === "pooling"
-                      ? "mint-green"
-                      : undefined}
-                    variant={league.data.status === "scouting"
-                      ? "light"
-                      : "filled"}
-                  >
-                    {league.data.status === "pooling"
-                      ? "Watch pool reveal"
-                      : "Scout the pool"}
-                  </Button>
-                )}
-                {league.data.status === "drafting" && (
-                  <>
-                    <Button
-                      component={Link}
-                      href={`/leagues/${league.data.id}/draft`}
-                      size="md"
-                    >
-                      Go to Draft
-                    </Button>
-                    <Button
-                      component={Link}
-                      href={`/leagues/${league.data.id}/draft/pool`}
-                      variant="light"
-                      size="md"
-                    >
-                      View Draft Pool
-                    </Button>
-                  </>
-                )}
-                {isCommissioner && nextStatus && setupPrerequisitesMet && (
-                  <Button
-                    onClick={() => {
-                      advanceStatus.reset();
-                      openAdvance();
-                    }}
-                    size="md"
-                  >
-                    Advance to {capitalize(nextStatus)}
-                  </Button>
-                )}
-              </Group>
-            </Flex>
-          </Paper>
+          <LeagueHeader
+            league={league.data}
+            isCommissioner={!!isCommissioner}
+            nextStatus={nextStatus}
+            setupPrerequisitesMet={setupPrerequisitesMet}
+            onAdvanceClick={() => {
+              advanceStatus.reset();
+              openAdvance();
+            }}
+          />
 
           <Grid gutter="lg">
             {/* Left column (~2/3) */}
             <Grid.Col span={{ base: 12, md: 8 }}>
               <Stack gap="lg">
-                {/* Your team panel */}
-                <Stack gap="xs">
-                  <Group gap="xs">
-                    <IconSparkles
-                      size={18}
-                      color="var(--mantine-color-mint-green-6)"
-                    />
-                    <Title order={3}>Your team</Title>
-                  </Group>
-                  {currentUserPlayer
-                    ? (
-                      <TrainerCard
-                        name={currentUserPlayer.name}
-                        image={currentUserPlayer.image}
-                        role={currentUserPlayer.role}
-                        subtitle={league.data.name}
-                      />
-                    )
-                    : (
-                      <Card
-                        shadow="sm"
-                        padding="lg"
-                        radius="md"
-                        withBorder
-                      >
-                        <Text c="dimmed" size="sm">
-                          Join this league to see your trainer card here.
-                        </Text>
-                      </Card>
-                    )}
-                  <Text c="dimmed" size="xs" pl={4}>
-                    No picks yet. Your roster will slide in once the draft
-                    begins.
-                  </Text>
-                </Stack>
+                <LeagueYourTeamPanel
+                  leagueName={league.data.name}
+                  currentUserPlayer={currentUserPlayer}
+                />
 
-                {/* Players / who's in */}
-                <Card shadow="sm" padding="lg" radius="md" withBorder>
-                  <Group justify="space-between" mb="sm">
-                    <Title order={3}>
-                      {league.data.status === "setup"
-                        ? "Who's in"
-                        : league.data.status === "drafting"
-                        ? "Players"
-                        : "Standings"}
-                    </Title>
-                    {league.data.maxPlayers && (
-                      <Text size="sm" c="dimmed">
-                        {players.data?.length ?? 0} / {league.data.maxPlayers}
-                      </Text>
-                    )}
-                  </Group>
-                  <Stack gap="sm">
-                    {players.data?.map((player) => {
-                      const strategy = parseNpcStrategy(
-                        player.npcStrategy ?? null,
-                      );
-                      const hasMetaBadges = player.isNpc || !!strategy;
-                      return (
-                        <Stack key={player.id} gap={4}>
-                          <Group
-                            justify="space-between"
-                            wrap="nowrap"
-                            align="center"
-                          >
-                            <Group
-                              gap="xs"
-                              wrap="nowrap"
-                              style={{ flex: 1, minWidth: 0 }}
-                            >
-                              {player.isNpc
-                                ? (
-                                  <NpcAvatar
-                                    name={player.name}
-                                    image={player.image}
-                                    radius="xl"
-                                    size="sm"
-                                  />
-                                )
-                                : (
-                                  <Avatar
-                                    src={player.image}
-                                    alt={player.name}
-                                    radius="xl"
-                                    size="sm"
-                                    color="mint-green"
-                                  >
-                                    {player.name
-                                      .split(" ")
-                                      .map((n) => n[0])
-                                      .join("")
-                                      .toUpperCase()
-                                      .slice(0, 2)}
-                                  </Avatar>
-                                )}
-                              <Text size="sm" style={{ minWidth: 0 }} truncate>
-                                {player.name}
-                              </Text>
-                            </Group>
-                            <Group
-                              gap="xs"
-                              wrap="nowrap"
-                              style={{ flexShrink: 0 }}
-                            >
-                              <Badge
-                                variant="light"
-                                size="sm"
-                                tt="capitalize"
-                              >
-                                {player.role}
-                              </Badge>
-                              {isCommissioner &&
-                                league.data.status === "setup" &&
-                                player.role !== "commissioner" && (
-                                <Tooltip label={`Remove ${player.name}`}>
-                                  <ActionIcon
-                                    variant="subtle"
-                                    color="red"
-                                    size="sm"
-                                    aria-label={`Remove ${player.name}`}
-                                    onClick={() => {
-                                      removePlayer.reset();
-                                      setPlayerToRemove({
-                                        userId: player.userId,
-                                        name: player.name,
-                                      });
-                                    }}
-                                  >
-                                    <IconTrash size={14} />
-                                  </ActionIcon>
-                                </Tooltip>
-                              )}
-                            </Group>
-                          </Group>
-                          {hasMetaBadges && (
-                            <Group gap="xs" wrap="wrap" pl={34}>
-                              {player.isNpc && (
-                                <Badge
-                                  variant="light"
-                                  color="grape"
-                                  size="xs"
-                                >
-                                  NPC
-                                </Badge>
-                              )}
-                              {strategy && (
-                                <Tooltip label={strategy.description}>
-                                  <Badge
-                                    variant="outline"
-                                    color={npcStrategyColor(strategy)}
-                                    size="xs"
-                                  >
-                                    {strategy.label}
-                                  </Badge>
-                                </Tooltip>
-                              )}
-                            </Group>
-                          )}
-                        </Stack>
-                      );
-                    })}
-                    {(!players.data || players.data.length === 0) && (
-                      <Text c="dimmed" size="sm">
-                        No players yet.
-                      </Text>
-                    )}
-                    {isCommissioner && league.data.status === "setup" && (
-                      <Group gap={0} wrap="nowrap">
-                        <Button
-                          variant="light"
-                          size="xs"
-                          loading={addNpcPlayer.isPending}
-                          disabled={atMaxPlayers}
-                          onClick={() =>
-                            addNpcPlayer.mutate({ leagueId: id! })}
-                          style={{
-                            borderTopRightRadius: 0,
-                            borderBottomRightRadius: 0,
-                          }}
-                        >
-                          + Add random NPC
-                        </Button>
-                        <Menu position="bottom-end" withinPortal>
-                          <Menu.Target>
-                            <ActionIcon
-                              variant="light"
-                              size={30}
-                              aria-label="More NPC options"
-                              style={{
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                                borderLeft:
-                                  "1px solid var(--mantine-color-default-border)",
-                              }}
-                            >
-                              <IconChevronDown size={14} />
-                            </ActionIcon>
-                          </Menu.Target>
-                          <Menu.Dropdown>
-                            <Menu.Item onClick={openChooseNpc}>
-                              Choose specific NPC…
-                            </Menu.Item>
-                          </Menu.Dropdown>
-                        </Menu>
-                      </Group>
-                    )}
-                  </Stack>
-                </Card>
+                <LeaguePlayersCard
+                  leagueId={id!}
+                  leagueStatus={league.data.status}
+                  maxPlayers={league.data.maxPlayers}
+                  players={players.data ?? []}
+                  isCommissioner={!!isCommissioner}
+                  atMaxPlayers={atMaxPlayers}
+                  addNpcPending={addNpcPlayer.isPending}
+                  onAddRandomNpc={() => addNpcPlayer.mutate({ leagueId: id! })}
+                  onOpenChooseNpc={openChooseNpc}
+                  onRemovePlayer={(player) => {
+                    removePlayer.reset();
+                    setPlayerToRemove(player);
+                  }}
+                />
               </Stack>
             </Grid.Col>
 
             {/* Right column (~1/3) */}
             <Grid.Col span={{ base: 12, md: 4 }}>
               <Stack gap="lg">
-                <Card shadow="sm" padding="lg" radius="md" withBorder>
-                  <Title order={4} mb="sm">League info</Title>
-                  <Stack gap="md">
-                    <Stack gap={4}>
-                      <Text size="sm" fw={500}>Invite code</Text>
-                      <Group gap={4} wrap="nowrap">
-                        <Text
-                          ff="monospace"
-                          size="sm"
-                          style={{
-                            flex: 1,
-                            minWidth: 0,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {league.data.inviteCode}
-                        </Text>
-                        <CopyButton value={league.data.inviteCode}>
-                          {({ copied, copy }) => (
-                            <Tooltip label={copied ? "Copied" : "Copy"}>
-                              <ActionIcon
-                                variant="subtle"
-                                size="sm"
-                                color={copied ? "teal" : "gray"}
-                                onClick={copy}
-                                aria-label="Copy invite code"
-                              >
-                                {copied ? "✓" : "⎘"}
-                              </ActionIcon>
-                            </Tooltip>
-                          )}
-                        </CopyButton>
-                      </Group>
-                    </Stack>
-                    <Stack gap={4}>
-                      <Text size="sm" fw={500}>Share link</Text>
-                      <Group gap={4} wrap="nowrap">
-                        <Text
-                          ff="monospace"
-                          size="xs"
-                          c="dimmed"
-                          style={{
-                            flex: 1,
-                            minWidth: 0,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {`${globalThis.location.origin}/join/${league.data.inviteCode}`}
-                        </Text>
-                        <CopyButton
-                          value={`${globalThis.location.origin}/join/${league.data.inviteCode}`}
-                        >
-                          {({ copied, copy }) => (
-                            <Tooltip label={copied ? "Copied" : "Copy"}>
-                              <ActionIcon
-                                variant="subtle"
-                                size="sm"
-                                color={copied ? "teal" : "gray"}
-                                onClick={copy}
-                                aria-label="Copy invite link"
-                              >
-                                {copied ? "✓" : "⎘"}
-                              </ActionIcon>
-                            </Tooltip>
-                          )}
-                        </CopyButton>
-                      </Group>
-                    </Stack>
-                    <Group justify="space-between" wrap="nowrap">
-                      <Text size="sm" fw={500}>Created</Text>
-                      <Text size="sm" c="dimmed">
-                        {new Date(league.data.createdAt).toLocaleDateString()}
-                      </Text>
-                    </Group>
-                  </Stack>
-                </Card>
+                <LeagueInfoCard
+                  inviteCode={league.data.inviteCode}
+                  createdAt={league.data.createdAt}
+                />
 
-                <Card shadow="sm" padding="lg" radius="md" withBorder>
-                  <Group justify="space-between" mb="sm">
-                    <Title order={4}>Rules</Title>
-                    <Button
-                      component={Link}
-                      href={`/leagues/${league.data.id}/settings`}
-                      size="xs"
-                      variant="subtle"
-                      leftSection={<IconSettings size={14} />}
-                    >
-                      {isCommissioner && league.data.status === "setup"
-                        ? "Configure"
-                        : "View"}
-                    </Button>
-                  </Group>
-                  {(() => {
-                    if (
-                      !league.data.rulesConfig ||
-                      typeof league.data.rulesConfig !== "object"
-                    ) {
-                      return (
-                        <Text size="sm" c="dimmed">
-                          Not configured yet.
-                        </Text>
-                      );
-                    }
-                    const rules = league.data.rulesConfig as {
-                      draftFormat?: string;
-                      numberOfRounds?: number;
-                      pickTimeLimitSeconds?: number | null;
-                      poolSizeMultiplier?: number;
-                      gameVersion?: string;
-                      excludeLegendaries?: boolean;
-                      excludeStarters?: boolean;
-                      excludeTradeEvolutions?: boolean;
-                    };
-                    const exclusions = [
-                      rules.excludeLegendaries && "Legendaries",
-                      rules.excludeStarters && "Starters",
-                      rules.excludeTradeEvolutions && "Trade evolutions",
-                    ].filter((v): v is string => typeof v === "string");
-                    return (
-                      <Stack gap="xs">
-                        <Group justify="space-between">
-                          <Text size="sm" c="dimmed">Format</Text>
-                          <Text size="sm" tt="capitalize">
-                            {rules.draftFormat ?? "—"}
-                          </Text>
-                        </Group>
-                        <Group justify="space-between">
-                          <Text size="sm" c="dimmed">Rounds</Text>
-                          <Text size="sm">{rules.numberOfRounds ?? "—"}</Text>
-                        </Group>
-                        {league.data.maxPlayers && (
-                          <Group justify="space-between">
-                            <Text size="sm" c="dimmed">Max players</Text>
-                            <Text size="sm">{league.data.maxPlayers}</Text>
-                          </Group>
-                        )}
-                        <Group justify="space-between">
-                          <Text size="sm" c="dimmed">Pick timer</Text>
-                          <Text size="sm">
-                            {rules.pickTimeLimitSeconds
-                              ? `${rules.pickTimeLimitSeconds}s`
-                              : "No limit"}
-                          </Text>
-                        </Group>
-                        {league.data.sportType === "pokemon" && (
-                          <>
-                            <Group justify="space-between">
-                              <Text size="sm" c="dimmed">Game version</Text>
-                              <Text size="sm">
-                                {gameVersionName ?? "All Pokemon"}
-                              </Text>
-                            </Group>
-                            <Group justify="space-between">
-                              <Text size="sm" c="dimmed">Pool multiplier</Text>
-                              <Text size="sm">
-                                {rules.poolSizeMultiplier ?? 2}x
-                              </Text>
-                            </Group>
-                            <Group
-                              justify="space-between"
-                              align="flex-start"
-                              wrap="nowrap"
-                            >
-                              <Text size="sm" c="dimmed">Exclusions</Text>
-                              <Text size="sm" ta="right">
-                                {exclusions.length > 0
-                                  ? exclusions.join(", ")
-                                  : "None"}
-                              </Text>
-                            </Group>
-                          </>
-                        )}
-                      </Stack>
-                    );
-                  })()}
-                </Card>
+                <LeagueRulesCard
+                  leagueId={league.data.id}
+                  leagueStatus={league.data.status}
+                  sportType={league.data.sportType}
+                  maxPlayers={league.data.maxPlayers}
+                  rulesConfig={league.data.rulesConfig}
+                  gameVersionName={gameVersionName}
+                  isCommissioner={!!isCommissioner}
+                />
               </Stack>
             </Grid.Col>
           </Grid>
@@ -659,175 +220,59 @@ export function LeagueDetailPage() {
             </Group>
           )}
 
-          <Modal
+          <AdvanceLeagueModal
             opened={advanceOpened}
             onClose={closeAdvance}
-            title="Advance League Status"
-          >
-            <Stack gap="md">
-              <Text>
-                Are you sure you want to advance{" "}
-                <Text span fw={700}>{league.data.name}</Text> to{" "}
-                <Text span fw={700}>{nextStatus}</Text>? This action cannot be
-                undone.
-              </Text>
-              {advanceStatus.isError && (
-                <Alert color="red" title="Failed to advance">
-                  {advanceStatus.error.message}
-                </Alert>
-              )}
-              <Group justify="flex-end">
-                <Button variant="default" onClick={closeAdvance}>
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleAdvance}
-                  loading={advanceStatus.isPending}
-                >
-                  Advance
-                </Button>
-              </Group>
-            </Stack>
-          </Modal>
+            leagueName={league.data.name}
+            nextStatus={nextStatus}
+            isPending={advanceStatus.isPending}
+            isError={advanceStatus.isError}
+            errorMessage={advanceStatus.error?.message}
+            onConfirm={handleAdvance}
+          />
 
-          <Modal
+          <ChooseNpcModal
             opened={chooseNpcOpened}
             onClose={closeChooseNpc}
-            title="Choose an NPC trainer"
-          >
-            <Stack gap="sm">
-              {availableNpcs.isLoading && (
-                <Group justify="center" py="md">
-                  <Loader size="sm" />
-                </Group>
-              )}
-              {availableNpcs.isError && (
-                <Alert color="red" title="Failed to load NPCs">
-                  {availableNpcs.error.message}
-                </Alert>
-              )}
-              {availableNpcs.data && availableNpcs.data.length === 0 && (
-                <Text c="dimmed" size="sm">
-                  No NPC trainers available — all have already joined.
-                </Text>
-              )}
-              {availableNpcs.data?.map((npc) => {
-                const strategy = parseNpcStrategy(npc.npcStrategy ?? null);
-                return (
-                  <UnstyledButton
-                    key={npc.id}
-                    disabled={addNpcPlayer.isPending}
-                    onClick={() => {
-                      addNpcPlayer.mutate(
-                        { leagueId: id!, npcUserId: npc.id },
-                        { onSuccess: () => closeChooseNpc() },
-                      );
-                    }}
-                    p="sm"
-                    style={{
-                      borderRadius: "var(--mantine-radius-sm)",
-                      border: "1px solid var(--mantine-color-default-border)",
-                    }}
-                  >
-                    <Group justify="space-between" wrap="nowrap">
-                      <Group gap="sm">
-                        <NpcAvatar
-                          name={npc.name}
-                          image={npc.image}
-                          radius="xl"
-                          size="sm"
-                        />
-                        <Text size="sm">{npc.name}</Text>
-                      </Group>
-                      {strategy && (
-                        <Tooltip label={strategy.description} withinPortal>
-                          <Badge
-                            variant="outline"
-                            color={npcStrategyColor(strategy)}
-                            size="xs"
-                          >
-                            {strategy.label}
-                          </Badge>
-                        </Tooltip>
-                      )}
-                    </Group>
-                  </UnstyledButton>
-                );
-              })}
-              {addNpcPlayer.isError && (
-                <Alert color="red" title="Failed to add NPC">
-                  {addNpcPlayer.error.message}
-                </Alert>
-              )}
-            </Stack>
-          </Modal>
+            npcs={availableNpcs.data}
+            isLoading={availableNpcs.isLoading}
+            isError={availableNpcs.isError}
+            errorMessage={availableNpcs.error?.message}
+            addNpcPending={addNpcPlayer.isPending}
+            addNpcError={addNpcPlayer.isError}
+            addNpcErrorMessage={addNpcPlayer.error?.message}
+            onChooseNpc={(npcUserId) => {
+              addNpcPlayer.mutate(
+                { leagueId: id!, npcUserId },
+                { onSuccess: () => closeChooseNpc() },
+              );
+            }}
+          />
 
-          <Modal
-            opened={playerToRemove !== null}
+          <RemovePlayerModal
+            playerToRemove={playerToRemove}
             onClose={() => setPlayerToRemove(null)}
-            title="Remove player"
-          >
-            <Stack gap="md">
-              <Text>
-                Are you sure you want to remove{" "}
-                <Text span fw={700}>{playerToRemove?.name}</Text>{" "}
-                from the league? They can rejoin with the invite code.
-              </Text>
-              {removePlayer.isError && (
-                <Alert color="red" title="Failed to remove">
-                  {removePlayer.error.message}
-                </Alert>
-              )}
-              <Group justify="flex-end">
-                <Button
-                  variant="default"
-                  onClick={() => setPlayerToRemove(null)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  color="red"
-                  loading={removePlayer.isPending}
-                  onClick={() => {
-                    if (!playerToRemove) return;
-                    removePlayer.mutate(
-                      {
-                        leagueId: id!,
-                        playerUserId: playerToRemove.userId,
-                      },
-                      { onSuccess: () => setPlayerToRemove(null) },
-                    );
-                  }}
-                >
-                  Remove
-                </Button>
-              </Group>
-            </Stack>
-          </Modal>
+            isPending={removePlayer.isPending}
+            isError={removePlayer.isError}
+            errorMessage={removePlayer.error?.message}
+            onConfirm={(player) => {
+              removePlayer.mutate(
+                {
+                  leagueId: id!,
+                  playerUserId: player.userId,
+                },
+                { onSuccess: () => setPlayerToRemove(null) },
+              );
+            }}
+          />
 
-          <Modal
+          <DeleteLeagueModal
             opened={deleteOpened}
             onClose={closeDelete}
-            title="Delete League"
-          >
-            <Text mb="lg">
-              Are you sure you want to delete{" "}
-              <Text span fw={700}>{league.data.name}</Text>? This action cannot
-              be undone.
-            </Text>
-            <Group justify="flex-end">
-              <Button variant="default" onClick={closeDelete}>
-                Cancel
-              </Button>
-              <Button
-                color="red"
-                onClick={handleDelete}
-                loading={deleteLeague.isPending}
-              >
-                Delete
-              </Button>
-            </Group>
-          </Modal>
+            leagueName={league.data.name}
+            isPending={deleteLeague.isPending}
+            onConfirm={handleDelete}
+          />
         </>
       )}
     </Container>

--- a/client/src/features/league/components/AdvanceLeagueModal.tsx
+++ b/client/src/features/league/components/AdvanceLeagueModal.tsx
@@ -1,0 +1,52 @@
+import { Alert, Button, Group, Modal, Stack, Text } from "@mantine/core";
+
+interface AdvanceLeagueModalProps {
+  opened: boolean;
+  onClose: () => void;
+  leagueName: string;
+  nextStatus: string | null;
+  isPending: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  onConfirm: () => void;
+}
+
+export function AdvanceLeagueModal({
+  opened,
+  onClose,
+  leagueName,
+  nextStatus,
+  isPending,
+  isError,
+  errorMessage,
+  onConfirm,
+}: AdvanceLeagueModalProps) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Advance League Status"
+    >
+      <Stack gap="md">
+        <Text>
+          Are you sure you want to advance{" "}
+          <Text span fw={700}>{leagueName}</Text> to{" "}
+          <Text span fw={700}>{nextStatus}</Text>? This action cannot be undone.
+        </Text>
+        {isError && (
+          <Alert color="red" title="Failed to advance">
+            {errorMessage}
+          </Alert>
+        )}
+        <Group justify="flex-end">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} loading={isPending}>
+            Advance
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/client/src/features/league/components/ChooseNpcModal.tsx
+++ b/client/src/features/league/components/ChooseNpcModal.tsx
@@ -1,0 +1,115 @@
+import {
+  Alert,
+  Badge,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+  Tooltip,
+  UnstyledButton,
+} from "@mantine/core";
+import { npcStrategyColor, parseNpcStrategy } from "@make-the-pick/shared";
+import { NpcAvatar } from "../NpcAvatar";
+
+interface NpcOption {
+  id: string;
+  name: string;
+  image?: string | null;
+  npcStrategy?: string | null;
+}
+
+interface ChooseNpcModalProps {
+  opened: boolean;
+  onClose: () => void;
+  npcs?: NpcOption[];
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  addNpcPending: boolean;
+  addNpcError: boolean;
+  addNpcErrorMessage?: string;
+  onChooseNpc: (npcUserId: string) => void;
+}
+
+export function ChooseNpcModal({
+  opened,
+  onClose,
+  npcs,
+  isLoading,
+  isError,
+  errorMessage,
+  addNpcPending,
+  addNpcError,
+  addNpcErrorMessage,
+  onChooseNpc,
+}: ChooseNpcModalProps) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Choose an NPC trainer"
+    >
+      <Stack gap="sm">
+        {isLoading && (
+          <Group justify="center" py="md">
+            <Loader size="sm" />
+          </Group>
+        )}
+        {isError && (
+          <Alert color="red" title="Failed to load NPCs">
+            {errorMessage}
+          </Alert>
+        )}
+        {npcs && npcs.length === 0 && (
+          <Text c="dimmed" size="sm">
+            No NPC trainers available — all have already joined.
+          </Text>
+        )}
+        {npcs?.map((npc) => {
+          const strategy = parseNpcStrategy(npc.npcStrategy ?? null);
+          return (
+            <UnstyledButton
+              key={npc.id}
+              disabled={addNpcPending}
+              onClick={() => onChooseNpc(npc.id)}
+              p="sm"
+              style={{
+                borderRadius: "var(--mantine-radius-sm)",
+                border: "1px solid var(--mantine-color-default-border)",
+              }}
+            >
+              <Group justify="space-between" wrap="nowrap">
+                <Group gap="sm">
+                  <NpcAvatar
+                    name={npc.name}
+                    image={npc.image ?? null}
+                    radius="xl"
+                    size="sm"
+                  />
+                  <Text size="sm">{npc.name}</Text>
+                </Group>
+                {strategy && (
+                  <Tooltip label={strategy.description} withinPortal>
+                    <Badge
+                      variant="outline"
+                      color={npcStrategyColor(strategy)}
+                      size="xs"
+                    >
+                      {strategy.label}
+                    </Badge>
+                  </Tooltip>
+                )}
+              </Group>
+            </UnstyledButton>
+          );
+        })}
+        {addNpcError && (
+          <Alert color="red" title="Failed to add NPC">
+            {addNpcErrorMessage}
+          </Alert>
+        )}
+      </Stack>
+    </Modal>
+  );
+}

--- a/client/src/features/league/components/DeleteLeagueModal.tsx
+++ b/client/src/features/league/components/DeleteLeagueModal.tsx
@@ -1,0 +1,38 @@
+import { Button, Group, Modal, Text } from "@mantine/core";
+
+interface DeleteLeagueModalProps {
+  opened: boolean;
+  onClose: () => void;
+  leagueName: string;
+  isPending: boolean;
+  onConfirm: () => void;
+}
+
+export function DeleteLeagueModal({
+  opened,
+  onClose,
+  leagueName,
+  isPending,
+  onConfirm,
+}: DeleteLeagueModalProps) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Delete League"
+    >
+      <Text mb="lg">
+        Are you sure you want to delete{" "}
+        <Text span fw={700}>{leagueName}</Text>? This action cannot be undone.
+      </Text>
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button color="red" onClick={onConfirm} loading={isPending}>
+          Delete
+        </Button>
+      </Group>
+    </Modal>
+  );
+}

--- a/client/src/features/league/components/LeagueHeader.tsx
+++ b/client/src/features/league/components/LeagueHeader.tsx
@@ -1,0 +1,105 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Group,
+  Paper,
+  Stack,
+  Title,
+} from "@mantine/core";
+import { Link } from "wouter";
+import { LifecycleStepper } from "../LifecycleStepper";
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+interface LeagueHeaderProps {
+  league: {
+    id: string;
+    name: string;
+    status: string;
+    sportType?: string | null;
+  };
+  isCommissioner: boolean;
+  nextStatus: string | null;
+  setupPrerequisitesMet: boolean;
+  onAdvanceClick: () => void;
+}
+
+export function LeagueHeader({
+  league,
+  isCommissioner,
+  nextStatus,
+  setupPrerequisitesMet,
+  onAdvanceClick,
+}: LeagueHeaderProps) {
+  return (
+    <Paper withBorder radius="md" p={{ base: "md", sm: "lg" }} mb="lg">
+      <Flex
+        direction={{ base: "column", sm: "row" }}
+        justify="space-between"
+        align={{ base: "stretch", sm: "flex-start" }}
+        gap="md"
+      >
+        <Stack gap="xs" style={{ flex: 1, minWidth: 0 }}>
+          <Title order={1} style={{ wordBreak: "break-word" }}>
+            {league.name}
+          </Title>
+          {league.sportType && (
+            <Group gap="xs">
+              <Badge color="mint-green" variant="light" tt="capitalize">
+                {league.sportType}
+              </Badge>
+            </Group>
+          )}
+          <Box mt="xs">
+            <LifecycleStepper currentPhase={league.status} />
+          </Box>
+        </Stack>
+
+        <Group gap="sm" wrap="wrap">
+          {(league.status === "pooling" ||
+            league.status === "scouting") && (
+            <Button
+              component={Link}
+              href={`/leagues/${league.id}/draft/pool`}
+              size="md"
+              color={league.status === "pooling" ? "mint-green" : undefined}
+              variant={league.status === "scouting" ? "light" : "filled"}
+            >
+              {league.status === "pooling"
+                ? "Watch pool reveal"
+                : "Scout the pool"}
+            </Button>
+          )}
+          {league.status === "drafting" && (
+            <>
+              <Button
+                component={Link}
+                href={`/leagues/${league.id}/draft`}
+                size="md"
+              >
+                Go to Draft
+              </Button>
+              <Button
+                component={Link}
+                href={`/leagues/${league.id}/draft/pool`}
+                variant="light"
+                size="md"
+              >
+                View Draft Pool
+              </Button>
+            </>
+          )}
+          {isCommissioner && nextStatus && setupPrerequisitesMet && (
+            <Button onClick={onAdvanceClick} size="md">
+              Advance to {capitalize(nextStatus)}
+            </Button>
+          )}
+        </Group>
+      </Flex>
+    </Paper>
+  );
+}

--- a/client/src/features/league/components/LeagueInfoCard.tsx
+++ b/client/src/features/league/components/LeagueInfoCard.tsx
@@ -1,0 +1,100 @@
+import {
+  ActionIcon,
+  Card,
+  CopyButton,
+  Group,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+
+interface LeagueInfoCardProps {
+  inviteCode: string;
+  createdAt: string;
+}
+
+export function LeagueInfoCard({ inviteCode, createdAt }: LeagueInfoCardProps) {
+  const shareLink = `${globalThis.location.origin}/join/${inviteCode}`;
+
+  return (
+    <Card shadow="sm" padding="lg" radius="md" withBorder>
+      <Title order={4} mb="sm">League info</Title>
+      <Stack gap="md">
+        <Stack gap={4}>
+          <Text size="sm" fw={500}>Invite code</Text>
+          <Group gap={4} wrap="nowrap">
+            <Text
+              ff="monospace"
+              size="sm"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {inviteCode}
+            </Text>
+            <CopyButton value={inviteCode}>
+              {({ copied, copy }) => (
+                <Tooltip label={copied ? "Copied" : "Copy"}>
+                  <ActionIcon
+                    variant="subtle"
+                    size="sm"
+                    color={copied ? "teal" : "gray"}
+                    onClick={copy}
+                    aria-label="Copy invite code"
+                  >
+                    {copied ? "✓" : "⎘"}
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </CopyButton>
+          </Group>
+        </Stack>
+        <Stack gap={4}>
+          <Text size="sm" fw={500}>Share link</Text>
+          <Group gap={4} wrap="nowrap">
+            <Text
+              ff="monospace"
+              size="xs"
+              c="dimmed"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {shareLink}
+            </Text>
+            <CopyButton value={shareLink}>
+              {({ copied, copy }) => (
+                <Tooltip label={copied ? "Copied" : "Copy"}>
+                  <ActionIcon
+                    variant="subtle"
+                    size="sm"
+                    color={copied ? "teal" : "gray"}
+                    onClick={copy}
+                    aria-label="Copy invite link"
+                  >
+                    {copied ? "✓" : "⎘"}
+                  </ActionIcon>
+                </Tooltip>
+              )}
+            </CopyButton>
+          </Group>
+        </Stack>
+        <Group justify="space-between" wrap="nowrap">
+          <Text size="sm" fw={500}>Created</Text>
+          <Text size="sm" c="dimmed">
+            {new Date(createdAt).toLocaleDateString()}
+          </Text>
+        </Group>
+      </Stack>
+    </Card>
+  );
+}

--- a/client/src/features/league/components/LeaguePlayersCard.tsx
+++ b/client/src/features/league/components/LeaguePlayersCard.tsx
@@ -1,0 +1,207 @@
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Menu,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { IconChevronDown, IconTrash } from "@tabler/icons-react";
+import { npcStrategyColor, parseNpcStrategy } from "@make-the-pick/shared";
+import { NpcAvatar } from "../NpcAvatar";
+
+interface LeaguePlayer {
+  id: string;
+  userId: string;
+  name: string;
+  image: string | null;
+  role: string;
+  isNpc?: boolean;
+  npcStrategy?: string | null;
+}
+
+interface LeaguePlayersCardProps {
+  leagueId: string;
+  leagueStatus: string;
+  maxPlayers?: number | null;
+  players: LeaguePlayer[];
+  isCommissioner: boolean;
+  atMaxPlayers: boolean;
+  addNpcPending: boolean;
+  onAddRandomNpc: () => void;
+  onOpenChooseNpc: () => void;
+  onRemovePlayer: (player: { userId: string; name: string }) => void;
+}
+
+export function LeaguePlayersCard({
+  leagueStatus,
+  maxPlayers,
+  players,
+  isCommissioner,
+  atMaxPlayers,
+  addNpcPending,
+  onAddRandomNpc,
+  onOpenChooseNpc,
+  onRemovePlayer,
+}: LeaguePlayersCardProps) {
+  const title = leagueStatus === "setup"
+    ? "Who's in"
+    : leagueStatus === "drafting"
+    ? "Players"
+    : "Standings";
+
+  return (
+    <Card shadow="sm" padding="lg" radius="md" withBorder>
+      <Group justify="space-between" mb="sm">
+        <Title order={3}>{title}</Title>
+        {maxPlayers && (
+          <Text size="sm" c="dimmed">
+            {players.length} / {maxPlayers}
+          </Text>
+        )}
+      </Group>
+      <Stack gap="sm">
+        {players.map((player) => {
+          const strategy = parseNpcStrategy(player.npcStrategy ?? null);
+          const hasMetaBadges = player.isNpc || !!strategy;
+          return (
+            <Stack key={player.id} gap={4}>
+              <Group
+                justify="space-between"
+                wrap="nowrap"
+                align="center"
+              >
+                <Group
+                  gap="xs"
+                  wrap="nowrap"
+                  style={{ flex: 1, minWidth: 0 }}
+                >
+                  {player.isNpc
+                    ? (
+                      <NpcAvatar
+                        name={player.name}
+                        image={player.image}
+                        radius="xl"
+                        size="sm"
+                      />
+                    )
+                    : (
+                      <Avatar
+                        src={player.image}
+                        alt={player.name}
+                        radius="xl"
+                        size="sm"
+                        color="mint-green"
+                      >
+                        {player.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                          .slice(0, 2)}
+                      </Avatar>
+                    )}
+                  <Text size="sm" style={{ minWidth: 0 }} truncate>
+                    {player.name}
+                  </Text>
+                </Group>
+                <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+                  <Badge variant="light" size="sm" tt="capitalize">
+                    {player.role}
+                  </Badge>
+                  {isCommissioner &&
+                    leagueStatus === "setup" &&
+                    player.role !== "commissioner" && (
+                    <Tooltip label={`Remove ${player.name}`}>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        size="sm"
+                        aria-label={`Remove ${player.name}`}
+                        onClick={() =>
+                          onRemovePlayer({
+                            userId: player.userId,
+                            name: player.name,
+                          })}
+                      >
+                        <IconTrash size={14} />
+                      </ActionIcon>
+                    </Tooltip>
+                  )}
+                </Group>
+              </Group>
+              {hasMetaBadges && (
+                <Group gap="xs" wrap="wrap" pl={34}>
+                  {player.isNpc && (
+                    <Badge variant="light" color="grape" size="xs">
+                      NPC
+                    </Badge>
+                  )}
+                  {strategy && (
+                    <Tooltip label={strategy.description}>
+                      <Badge
+                        variant="outline"
+                        color={npcStrategyColor(strategy)}
+                        size="xs"
+                      >
+                        {strategy.label}
+                      </Badge>
+                    </Tooltip>
+                  )}
+                </Group>
+              )}
+            </Stack>
+          );
+        })}
+        {players.length === 0 && (
+          <Text c="dimmed" size="sm">
+            No players yet.
+          </Text>
+        )}
+        {isCommissioner && leagueStatus === "setup" && (
+          <Group gap={0} wrap="nowrap">
+            <Button
+              variant="light"
+              size="xs"
+              loading={addNpcPending}
+              disabled={atMaxPlayers}
+              onClick={onAddRandomNpc}
+              style={{
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+              }}
+            >
+              + Add random NPC
+            </Button>
+            <Menu position="bottom-end" withinPortal>
+              <Menu.Target>
+                <ActionIcon
+                  variant="light"
+                  size={30}
+                  aria-label="More NPC options"
+                  style={{
+                    borderTopLeftRadius: 0,
+                    borderBottomLeftRadius: 0,
+                    borderLeft: "1px solid var(--mantine-color-default-border)",
+                  }}
+                >
+                  <IconChevronDown size={14} />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Item onClick={onOpenChooseNpc}>
+                  Choose specific NPC…
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          </Group>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/client/src/features/league/components/LeagueRulesCard.tsx
+++ b/client/src/features/league/components/LeagueRulesCard.tsx
@@ -1,0 +1,118 @@
+import { Button, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { IconSettings } from "@tabler/icons-react";
+import { Link } from "wouter";
+
+interface LeagueRulesCardProps {
+  leagueId: string;
+  leagueStatus: string;
+  sportType?: string | null;
+  maxPlayers?: number | null;
+  rulesConfig: unknown;
+  gameVersionName?: string;
+  isCommissioner: boolean;
+}
+
+export function LeagueRulesCard({
+  leagueId,
+  leagueStatus,
+  sportType,
+  maxPlayers,
+  rulesConfig,
+  gameVersionName,
+  isCommissioner,
+}: LeagueRulesCardProps) {
+  return (
+    <Card shadow="sm" padding="lg" radius="md" withBorder>
+      <Group justify="space-between" mb="sm">
+        <Title order={4}>Rules</Title>
+        <Button
+          component={Link}
+          href={`/leagues/${leagueId}/settings`}
+          size="xs"
+          variant="subtle"
+          leftSection={<IconSettings size={14} />}
+        >
+          {isCommissioner && leagueStatus === "setup" ? "Configure" : "View"}
+        </Button>
+      </Group>
+      {(() => {
+        if (!rulesConfig || typeof rulesConfig !== "object") {
+          return (
+            <Text size="sm" c="dimmed">
+              Not configured yet.
+            </Text>
+          );
+        }
+        const rules = rulesConfig as {
+          draftFormat?: string;
+          numberOfRounds?: number;
+          pickTimeLimitSeconds?: number | null;
+          poolSizeMultiplier?: number;
+          gameVersion?: string;
+          excludeLegendaries?: boolean;
+          excludeStarters?: boolean;
+          excludeTradeEvolutions?: boolean;
+        };
+        const exclusions = [
+          rules.excludeLegendaries && "Legendaries",
+          rules.excludeStarters && "Starters",
+          rules.excludeTradeEvolutions && "Trade evolutions",
+        ].filter((v): v is string => typeof v === "string");
+        return (
+          <Stack gap="xs">
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">Format</Text>
+              <Text size="sm" tt="capitalize">
+                {rules.draftFormat ?? "—"}
+              </Text>
+            </Group>
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">Rounds</Text>
+              <Text size="sm">{rules.numberOfRounds ?? "—"}</Text>
+            </Group>
+            {maxPlayers && (
+              <Group justify="space-between">
+                <Text size="sm" c="dimmed">Max players</Text>
+                <Text size="sm">{maxPlayers}</Text>
+              </Group>
+            )}
+            <Group justify="space-between">
+              <Text size="sm" c="dimmed">Pick timer</Text>
+              <Text size="sm">
+                {rules.pickTimeLimitSeconds
+                  ? `${rules.pickTimeLimitSeconds}s`
+                  : "No limit"}
+              </Text>
+            </Group>
+            {sportType === "pokemon" && (
+              <>
+                <Group justify="space-between">
+                  <Text size="sm" c="dimmed">Game version</Text>
+                  <Text size="sm">
+                    {gameVersionName ?? "All Pokemon"}
+                  </Text>
+                </Group>
+                <Group justify="space-between">
+                  <Text size="sm" c="dimmed">Pool multiplier</Text>
+                  <Text size="sm">
+                    {rules.poolSizeMultiplier ?? 2}x
+                  </Text>
+                </Group>
+                <Group
+                  justify="space-between"
+                  align="flex-start"
+                  wrap="nowrap"
+                >
+                  <Text size="sm" c="dimmed">Exclusions</Text>
+                  <Text size="sm" ta="right">
+                    {exclusions.length > 0 ? exclusions.join(", ") : "None"}
+                  </Text>
+                </Group>
+              </>
+            )}
+          </Stack>
+        );
+      })()}
+    </Card>
+  );
+}

--- a/client/src/features/league/components/LeagueYourTeamPanel.tsx
+++ b/client/src/features/league/components/LeagueYourTeamPanel.tsx
@@ -1,0 +1,48 @@
+import { Card, Group, Stack, Text, Title } from "@mantine/core";
+import { IconSparkles } from "@tabler/icons-react";
+import { TrainerCard } from "../TrainerCard";
+
+interface LeagueYourTeamPanelProps {
+  leagueName: string;
+  currentUserPlayer?: {
+    name: string;
+    image: string | null;
+    role: string;
+  } | null;
+}
+
+export function LeagueYourTeamPanel({
+  leagueName,
+  currentUserPlayer,
+}: LeagueYourTeamPanelProps) {
+  return (
+    <Stack gap="xs">
+      <Group gap="xs">
+        <IconSparkles
+          size={18}
+          color="var(--mantine-color-mint-green-6)"
+        />
+        <Title order={3}>Your team</Title>
+      </Group>
+      {currentUserPlayer
+        ? (
+          <TrainerCard
+            name={currentUserPlayer.name}
+            image={currentUserPlayer.image}
+            role={currentUserPlayer.role}
+            subtitle={leagueName}
+          />
+        )
+        : (
+          <Card shadow="sm" padding="lg" radius="md" withBorder>
+            <Text c="dimmed" size="sm">
+              Join this league to see your trainer card here.
+            </Text>
+          </Card>
+        )}
+      <Text c="dimmed" size="xs" pl={4}>
+        No picks yet. Your roster will slide in once the draft begins.
+      </Text>
+    </Stack>
+  );
+}

--- a/client/src/features/league/components/RemovePlayerModal.tsx
+++ b/client/src/features/league/components/RemovePlayerModal.tsx
@@ -1,0 +1,55 @@
+import { Alert, Button, Group, Modal, Stack, Text } from "@mantine/core";
+
+interface RemovePlayerModalProps {
+  playerToRemove: { userId: string; name: string } | null;
+  onClose: () => void;
+  isPending: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  onConfirm: (player: { userId: string; name: string }) => void;
+}
+
+export function RemovePlayerModal({
+  playerToRemove,
+  onClose,
+  isPending,
+  isError,
+  errorMessage,
+  onConfirm,
+}: RemovePlayerModalProps) {
+  return (
+    <Modal
+      opened={playerToRemove !== null}
+      onClose={onClose}
+      title="Remove player"
+    >
+      <Stack gap="md">
+        <Text>
+          Are you sure you want to remove{" "}
+          <Text span fw={700}>{playerToRemove?.name}</Text>{" "}
+          from the league? They can rejoin with the invite code.
+        </Text>
+        {isError && (
+          <Alert color="red" title="Failed to remove">
+            {errorMessage}
+          </Alert>
+        )}
+        <Group justify="flex-end">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            color="red"
+            loading={isPending}
+            onClick={() => {
+              if (!playerToRemove) return;
+              onConfirm(playerToRemove);
+            }}
+          >
+            Remove
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

- `LeagueDetailPage` was ~825 lines and acted as a catch-all page component
- Extracted 9 focused components under `client/src/features/league/components/`
- `LeagueDetailPage` is now a thin shell (~281 lines) that only wires together hooks and passes props

## Extracted components

| Component | Responsibility |
|---|---|
| `LeagueHeader` | League title, sport badge, lifecycle stepper, action buttons |
| `LeagueYourTeamPanel` | Current-user trainer card section |
| `LeaguePlayersCard` | Player roster with NPC add/remove controls |
| `LeagueInfoCard` | Invite code and share-link panel |
| `LeagueRulesCard` | Rules summary with configure/view link |
| `AdvanceLeagueModal` | Confirm advance status dialog |
| `ChooseNpcModal` | Specific NPC picker dialog |
| `RemovePlayerModal` | Confirm remove player dialog |
| `DeleteLeagueModal` | Confirm delete league dialog |

## Test plan

- [x] Pure refactor — no behavior change
- [x] All 31 `LeagueDetailPage` tests pass without modification
- [x] All 229 client tests pass (`deno task test:client`)
- [x] `deno lint` is clean (186 files checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)