### PR TITLE
refactor(draft): extract NPC pick logic into dedicated service

### DIFF
--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -12,7 +12,10 @@ import { computeTurnDeadline, resolveSnakeTurn } from "./draft-utils.ts";
 import type { DraftEventPublisher } from "./draft.events.ts";
 import type { Clock, DraftTimerScheduler } from "./draft.timers.ts";
 import { type NpcScheduler, randomNpcPickDelayMs } from "./npc-scheduler.ts";
-import { pickWithStrategy } from "./npc-strategies.ts";
+import {
+  createNpcPickService,
+  type NpcPickService,
+} from "./npc-pick.service.ts";
 
 const noopPublisher: DraftEventPublisher = {
   subscribe: () => () => {},
@@ -198,6 +201,7 @@ export function createDraftService(deps: {
   clock?: Clock;
   timerScheduler?: DraftTimerScheduler;
   npcScheduler?: NpcScheduler;
+  npcPickService?: NpcPickService;
   randomFn?: () => number;
 }) {
   const publisher = deps.draftEventPublisher ?? noopPublisher;
@@ -205,6 +209,7 @@ export function createDraftService(deps: {
   const scheduler = deps.timerScheduler;
   const npcScheduler = deps.npcScheduler;
   const watchlistRepo = deps.watchlistRepo;
+  const npcPickService = deps.npcPickService ?? createNpcPickService();
   const randomFn = deps.randomFn ?? Math.random;
 
   /**
@@ -737,20 +742,16 @@ export function createDraftService(deps: {
       if (!isNpc) return;
 
       const picks = await deps.draftRepo.listPicks(draftRow.id);
-      const pickedItemIds = new Set(picks.map((p) => p.poolItemId));
-      const available = poolItems.filter((item) => !pickedItemIds.has(item.id));
-      const myPickIds = new Set(
-        picks
-          .filter((p) => p.leaguePlayerId === currentPlayer.id)
-          .map((p) => p.poolItemId),
-      );
-      const myPicks = poolItems.filter((item) => myPickIds.has(item.id));
       const rawStrategy =
         (currentPlayer as { npcStrategy?: string | null }).npcStrategy ?? null;
-      const chosen = pickWithStrategy({
-        rawStrategy,
-        availableItems: available,
-        myPicks,
+      const chosen = npcPickService.selectPick({
+        currentLeaguePlayerId: currentPlayer.id,
+        npcStrategy: rawStrategy,
+        poolItems,
+        picks: picks.map((p) => ({
+          leaguePlayerId: p.leaguePlayerId,
+          poolItemId: p.poolItemId,
+        })),
         randomFn,
       });
       if (!chosen) return;

--- a/server/features/draft/mod.ts
+++ b/server/features/draft/mod.ts
@@ -30,3 +30,5 @@ export type {
 } from "./draft.timers.ts";
 export { createNpcScheduler } from "./npc-scheduler.ts";
 export type { NpcScheduler } from "./npc-scheduler.ts";
+export { createNpcPickService } from "./npc-pick.service.ts";
+export type { NpcPickService } from "./npc-pick.service.ts";

--- a/server/features/draft/npc-pick.service.ts
+++ b/server/features/draft/npc-pick.service.ts
@@ -1,0 +1,63 @@
+/**
+ * NPC pick selection service.
+ *
+ * Extracted from `draft.service.ts` to keep the strategy-selection concern
+ * independently testable and to narrow the blast radius of the draft
+ * service. Given the current NPC player, the draft pool, and the picks so
+ * far, decides which pool item the NPC should draft.
+ *
+ * This service is pure (no I/O). The draft service is responsible for
+ * loading the draft context and persisting the resulting pick.
+ */
+
+import { pickWithStrategy, type StrategyPoolItem } from "./npc-strategies.ts";
+
+export interface NpcPickSelectionInput<T extends StrategyPoolItem> {
+  currentLeaguePlayerId: string;
+  npcStrategy: string | null;
+  poolItems: T[];
+  picks: ReadonlyArray<{ leaguePlayerId: string; poolItemId: string }>;
+  randomFn: () => number;
+}
+
+export interface NpcPickService {
+  selectPick<T extends StrategyPoolItem>(
+    input: NpcPickSelectionInput<T>,
+  ): T | null;
+}
+
+export function createNpcPickService(): NpcPickService {
+  function selectPick<T extends StrategyPoolItem>(
+    input: NpcPickSelectionInput<T>,
+  ): T | null {
+    const {
+      currentLeaguePlayerId,
+      npcStrategy,
+      poolItems,
+      picks,
+      randomFn,
+    } = input;
+
+    const pickedItemIds = new Set(picks.map((p) => p.poolItemId));
+    const availableItems = poolItems.filter(
+      (item) => !pickedItemIds.has(item.id),
+    );
+    if (availableItems.length === 0) return null;
+
+    const myPickIds = new Set(
+      picks
+        .filter((p) => p.leaguePlayerId === currentLeaguePlayerId)
+        .map((p) => p.poolItemId),
+    );
+    const myPicks = poolItems.filter((item) => myPickIds.has(item.id));
+
+    return pickWithStrategy({
+      rawStrategy: npcStrategy,
+      availableItems,
+      myPicks,
+      randomFn,
+    });
+  }
+
+  return { selectPick };
+}

--- a/server/features/draft/npc-pick.service_test.ts
+++ b/server/features/draft/npc-pick.service_test.ts
@@ -1,0 +1,237 @@
+import { assertEquals } from "@std/assert";
+import { createNpcPickService } from "./npc-pick.service.ts";
+
+interface FakePoolItem {
+  id: string;
+  metadata: unknown;
+}
+
+interface FakePick {
+  leaguePlayerId: string;
+  poolItemId: string;
+}
+
+function makeItem(id: string, total: number, pokemonId = 1): FakePoolItem {
+  return {
+    id,
+    metadata: {
+      pokemonId,
+      baseStats: {
+        hp: total,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+}
+
+Deno.test("npcPickService.selectPick: excludes already-picked items from available pool", () => {
+  const service = createNpcPickService();
+  const poolItems: FakePoolItem[] = [
+    makeItem("a", 100),
+    makeItem("b", 200),
+    makeItem("c", 300),
+  ];
+  const picks: FakePick[] = [{ leaguePlayerId: "npc-1", poolItemId: "c" }];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: "best-available",
+    poolItems,
+    picks,
+    randomFn: () => 0,
+  });
+
+  // "c" is already picked, so "b" (total=200) is best available.
+  assertEquals(chosen?.id, "b");
+});
+
+Deno.test("npcPickService.selectPick: best-available strategy picks highest base-stat total", () => {
+  const service = createNpcPickService();
+  const poolItems: FakePoolItem[] = [
+    makeItem("a", 100, 3),
+    makeItem("b", 400, 2),
+    makeItem("c", 400, 1),
+  ];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: "best-available",
+    poolItems,
+    picks: [],
+    randomFn: () => 0,
+  });
+
+  // Ties on total go to lowest pokemonId -> "c".
+  assertEquals(chosen?.id, "c");
+});
+
+Deno.test("npcPickService.selectPick: null strategy falls back to random (chaos) pick", () => {
+  const service = createNpcPickService();
+  const poolItems: FakePoolItem[] = [
+    makeItem("a", 100),
+    makeItem("b", 200),
+    makeItem("c", 300),
+  ];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: null,
+    poolItems,
+    picks: [],
+    // Deterministic randomFn returns 0 -> first available item.
+    randomFn: () => 0,
+  });
+
+  assertEquals(chosen?.id, "a");
+});
+
+Deno.test("npcPickService.selectPick: balanced strategy considers current player's existing picks", () => {
+  const service = createNpcPickService();
+  // All items tied on total; balanced uses type diversity to break ties.
+  const fire = {
+    id: "fire1",
+    metadata: {
+      pokemonId: 1,
+      types: ["fire"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  const water = {
+    id: "water1",
+    metadata: {
+      pokemonId: 2,
+      types: ["water"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  // NPC already owns a fire type; balanced should prefer water now.
+  const alreadyOwned = {
+    id: "owned-fire",
+    metadata: {
+      pokemonId: 99,
+      types: ["fire"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  const poolItemsWithOwned: FakePoolItem[] = [fire, water, alreadyOwned];
+  const picks: FakePick[] = [
+    { leaguePlayerId: "npc-1", poolItemId: "owned-fire" },
+  ];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: "balanced",
+    poolItems: poolItemsWithOwned,
+    picks,
+    randomFn: () => 0,
+  });
+
+  assertEquals(chosen?.id, "water1");
+});
+
+Deno.test("npcPickService.selectPick: returns null when no items are available", () => {
+  const service = createNpcPickService();
+  const poolItems: FakePoolItem[] = [makeItem("a", 100)];
+  const picks: FakePick[] = [{ leaguePlayerId: "npc-1", poolItemId: "a" }];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: "best-available",
+    poolItems,
+    picks,
+    randomFn: () => 0,
+  });
+
+  assertEquals(chosen, null);
+});
+
+Deno.test("npcPickService.selectPick: only considers the current player's own picks for balanced scoring", () => {
+  const service = createNpcPickService();
+  const fire = {
+    id: "fire1",
+    metadata: {
+      pokemonId: 1,
+      types: ["fire"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  const water = {
+    id: "water1",
+    metadata: {
+      pokemonId: 2,
+      types: ["water"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  const ownedFire = {
+    id: "owned-fire",
+    metadata: {
+      pokemonId: 99,
+      types: ["fire"],
+      baseStats: {
+        hp: 100,
+        attack: 0,
+        defense: 0,
+        specialAttack: 0,
+        specialDefense: 0,
+        speed: 0,
+      },
+    },
+  };
+  const poolItems: FakePoolItem[] = [fire, water, ownedFire];
+  // Some OTHER player owns a fire pick; current NPC owns nothing.
+  const picks: FakePick[] = [
+    { leaguePlayerId: "other-player", poolItemId: "owned-fire" },
+  ];
+
+  const chosen = service.selectPick({
+    currentLeaguePlayerId: "npc-1",
+    npcStrategy: "balanced",
+    poolItems,
+    picks,
+    randomFn: () => 0,
+  });
+
+  // Other player's fire ownership should not penalize fire for npc-1; both
+  // fire and water have equal penalty (0), same total -> first item wins.
+  assertEquals(chosen?.id, "fire1");
+});

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -40,6 +40,7 @@ import {
   createDraftRouter,
   createDraftService,
   createDraftTimerScheduler,
+  createNpcPickService,
   createNpcScheduler,
   type DraftEventPublisher,
   type DraftService,
@@ -105,6 +106,7 @@ export function createFeatureRouters(db: Database) {
   const draftTimerScheduler = createDraftTimerScheduler({ draftRepo });
   const npcScheduler = createNpcScheduler();
   const watchlistRepo = createWatchlistRepository(db);
+  const npcPickService = createNpcPickService();
   const draftService = createDraftService({
     draftRepo,
     leagueRepo,
@@ -113,6 +115,7 @@ export function createFeatureRouters(db: Database) {
     draftEventPublisher,
     timerScheduler: draftTimerScheduler,
     npcScheduler,
+    npcPickService,
   });
   draftTimerScheduler.setAutoPickHandler(({ leagueId }) =>
     draftService.runAutoPick({ leagueId })


### PR DESCRIPTION
## Summary
- First decomposition step for `server/features/draft/draft.service.ts` (~1100 lines). Extracts NPC pick *selection* into a new `npc-pick.service.ts` factory so it can be tested in isolation against plain fixtures.
- `draft.service.ts` now delegates to an injected `npcPickService` inside `runNpcPick` instead of computing `available` / `myPicks` and calling `pickWithStrategy` inline.
- Composition root (`server/features/mod.ts`) constructs `npcPickService` and passes it into `draftService`; the existing `draft.service_test.ts` is untouched to minimize conflict with the parallel fixture-extraction branch.

## Test plan
- [x] `deno task test:server` — all 267 server tests pass
- [x] New `npc-pick.service_test.ts` covers: already-picked exclusion, best-available tiebreak, null-strategy chaos fallback, balanced uses only current player's picks, empty-pool returns null
- [x] `deno lint` clean

Future PRs will extract the remaining turn-orchestration and timer-scheduling concerns out of `draft.service.ts`.