### PR TITLE
feat(draft): show evolution chain sprites in species-mode rows

### DIFF
--- a/client/src/features/draft/AvailablePoolTable.test.tsx
+++ b/client/src/features/draft/AvailablePoolTable.test.tsx
@@ -119,4 +119,79 @@ describe("AvailablePoolTable", () => {
     renderTable();
     expect(screen.getByText(/available pool/i)).toBeInTheDocument();
   });
+
+  it("renders an evolution chain with sprites and a 'X Line' label for species rows", () => {
+    const speciesItem = {
+      id: "species-1",
+      draftPoolId: "pool-1",
+      name: "blastoise",
+      thumbnailUrl: "https://example.com/blastoise.png",
+      metadata: {
+        mode: "species",
+        finals: [
+          {
+            pokemonId: 9,
+            name: "blastoise",
+            regionalForm: null,
+            types: ["water"],
+            baseStats: {
+              hp: 79,
+              attack: 83,
+              defense: 100,
+              specialAttack: 85,
+              specialDefense: 105,
+              speed: 78,
+            },
+            generation: "generation-i",
+            spriteUrl: "https://example.com/blastoise.png",
+          },
+        ],
+        members: [
+          {
+            pokemonId: 7,
+            name: "squirtle",
+            regionalForm: null,
+            stage: "base",
+            spriteUrl: "https://example.com/squirtle.png",
+          },
+          {
+            pokemonId: 8,
+            name: "wartortle",
+            regionalForm: null,
+            stage: "middle",
+            spriteUrl: "https://example.com/wartortle.png",
+          },
+          {
+            pokemonId: 9,
+            name: "blastoise",
+            regionalForm: null,
+            stage: "final",
+            spriteUrl: "https://example.com/blastoise.png",
+          },
+        ],
+      },
+    } as unknown as Parameters<typeof makeDraftState>[0]["poolItems"] extends
+      (infer T)[] ? T : never;
+    const draftState = makeDraftState({
+      poolItems: [speciesItem],
+      availableItemIds: ["species-1"],
+    });
+    render(
+      <MantineProvider>
+        <AvailablePoolTable
+          leagueId="league-1"
+          draftState={draftState}
+          isMyTurn
+          onPick={vi.fn()}
+          isPicking={false}
+        />
+      </MantineProvider>,
+    );
+    expect(screen.getByText(/blastoise line/i)).toBeInTheDocument();
+    expect(screen.getByAltText("squirtle")).toBeInTheDocument();
+    expect(screen.getByAltText("wartortle")).toBeInTheDocument();
+    expect(screen.getAllByAltText("blastoise").length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
 });

--- a/client/src/features/draft/AvailablePoolTable.tsx
+++ b/client/src/features/draft/AvailablePoolTable.tsx
@@ -209,11 +209,36 @@ export function AvailablePoolTable({
       {
         accessorKey: "name",
         header: "Name",
-        Cell: ({ renderedCellValue }) => (
-          <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
-            {renderedCellValue}
-          </span>
-        ),
+        Cell: ({ row, renderedCellValue }) => {
+          const display = getPoolItemDisplay(row.original);
+          if (display?.mode === "species" && display.chain.length > 0) {
+            return (
+              <Group gap={4} wrap="nowrap" align="center">
+                {display.chain.map((stage) => (
+                  <img
+                    key={stage.pokemonId}
+                    src={stage.spriteUrl ?? undefined}
+                    alt={stage.name}
+                    width={32}
+                    height={32}
+                    style={{
+                      objectFit: "contain",
+                      imageRendering: "pixelated",
+                    }}
+                  />
+                ))}
+                <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
+                  {row.original.name} Line
+                </span>
+              </Group>
+            );
+          }
+          return (
+            <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
+              {renderedCellValue}
+            </span>
+          );
+        },
       },
       {
         id: "types",

--- a/client/src/features/draft/pool-item-display.test.ts
+++ b/client/src/features/draft/pool-item-display.test.ts
@@ -65,12 +65,21 @@ function speciesItem(): DraftPoolItem {
           name: "vulpix",
           regionalForm: null,
           stage: "base",
+          spriteUrl: "https://example.com/vulpix.png",
         },
         {
           pokemonId: 38,
           name: "ninetales",
           regionalForm: null,
           stage: "final",
+          spriteUrl: "https://example.com/ninetales.png",
+        },
+        {
+          pokemonId: 10228,
+          name: "vulpix-alola",
+          regionalForm: "alola",
+          stage: "base",
+          spriteUrl: "https://example.com/vulpix-alola.png",
         },
       ],
     },
@@ -137,6 +146,21 @@ describe("getPoolItemDisplay", () => {
     expect(display!.regionalFinals.length).toBe(1);
     expect(display!.regionalFinals[0].regionalForm).toBe("alola");
     expect(display!.regionalFinals[0].types).toEqual(["ice", "fairy"]);
+  });
+
+  it("exposes the primary-line evolution chain in base→final order, dropping regional pre-evos", () => {
+    const display = getPoolItemDisplay(speciesItem());
+    expect(display!.chain.map((c) => c.pokemonId)).toEqual([37, 38]);
+    expect(display!.chain.map((c) => c.stage)).toEqual(["base", "final"]);
+    expect(display!.chain.map((c) => c.spriteUrl)).toEqual([
+      "https://example.com/vulpix.png",
+      "https://example.com/ninetales.png",
+    ]);
+  });
+
+  it("returns an empty chain for individual rows", () => {
+    const display = getPoolItemDisplay(individualItem());
+    expect(display!.chain).toEqual([]);
   });
 
   it("returns null metadata when the item has no metadata", () => {

--- a/client/src/features/draft/pool-item-display.ts
+++ b/client/src/features/draft/pool-item-display.ts
@@ -19,6 +19,21 @@ type SpeciesFinalLike = {
   spriteUrl: string | null;
 };
 
+type SpeciesMemberLike = {
+  pokemonId: number;
+  name: string;
+  regionalForm: string | null;
+  stage: "base" | "middle" | "final";
+  spriteUrl: string | null;
+};
+
+export type SpeciesChainStage = {
+  pokemonId: number;
+  name: string;
+  stage: "base" | "middle" | "final";
+  spriteUrl: string | null;
+};
+
 // Flat projection of a draft pool item's metadata regardless of drafting
 // mode. The table UI is one row per pool item in both modes — individual
 // rows render the Pokemon's own stats, species rows render the terminal
@@ -38,6 +53,11 @@ export type PoolItemDisplay = {
   // a species has regional-variant finals (e.g. Alolan Ninetales).
   // Empty for individual rows.
   regionalFinals: SpeciesFinalLike[];
+  // For species rows, the evolution chain that terminates at the primary
+  // final (base → middle → final), excluding regional variants. Used to
+  // render an inline sprite chain like "<Squirtle><Wartortle><Blastoise>
+  // Blastoise Line". Empty for individual rows.
+  chain: SpeciesChainStage[];
 };
 
 // Projects a draft pool item's metadata onto the flat `PoolItemDisplay`
@@ -64,9 +84,24 @@ export function getPoolItemDisplay(
   if (metadata.mode === "species") {
     const speciesMeta = metadata as unknown as {
       finals: SpeciesFinalLike[];
+      members: SpeciesMemberLike[];
     };
     const [primary, ...regionalFinals] = speciesMeta.finals;
     if (!primary) return null;
+    // The chain shown in the row is the line that terminates at the
+    // primary (base-region) final only — regional pre-evos are dropped so
+    // a Vulpix → Ninetales row never accidentally renders Alolan Vulpix.
+    // Members are stored in base→final order for the primary line, with
+    // regional variants appended after, so filtering by regionalForm===null
+    // also preserves the correct visual order.
+    const chain: SpeciesChainStage[] = speciesMeta.members
+      .filter((m) => m.regionalForm === null)
+      .map((m) => ({
+        pokemonId: m.pokemonId,
+        name: m.name,
+        stage: m.stage,
+        spriteUrl: m.spriteUrl,
+      }));
     return {
       mode: "species",
       pokemonId: primary.pokemonId,
@@ -74,6 +109,7 @@ export function getPoolItemDisplay(
       baseStats: primary.baseStats,
       generation: primary.generation,
       regionalFinals,
+      chain,
     };
   }
 
@@ -90,6 +126,7 @@ export function getPoolItemDisplay(
     baseStats: individualMeta.baseStats,
     generation: individualMeta.generation,
     regionalFinals: [],
+    chain: [],
   };
 }
 

--- a/packages/shared/schemas/draft-pool.ts
+++ b/packages/shared/schemas/draft-pool.ts
@@ -80,11 +80,13 @@ const speciesMemberPoolItemSchema: z.ZodObject<{
   name: z.ZodString;
   regionalForm: z.ZodNullable<z.ZodString>;
   stage: z.ZodEnum<["base", "middle", "final"]>;
+  spriteUrl: z.ZodNullable<z.ZodString>;
 }> = object({
   pokemonId: number(),
   name: string(),
   regionalForm: nullable(string()),
   stage: enum_(["base", "middle", "final"]),
+  spriteUrl: nullable(string()),
 });
 
 // Species-mode metadata: the unit of drafting is an entire evolution line

--- a/packages/shared/schemas/draft-pool_test.ts
+++ b/packages/shared/schemas/draft-pool_test.ts
@@ -66,24 +66,28 @@ const speciesMetadata = {
       name: "vulpix",
       regionalForm: null,
       stage: "base" as const,
+      spriteUrl: null,
     },
     {
       pokemonId: 38,
       name: "ninetales",
       regionalForm: null,
       stage: "final" as const,
+      spriteUrl: null,
     },
     {
       pokemonId: 10228,
       name: "vulpix-alola",
       regionalForm: "alola",
       stage: "base" as const,
+      spriteUrl: null,
     },
     {
       pokemonId: 10229,
       name: "ninetales-alola",
       regionalForm: "alola",
       stage: "final" as const,
+      spriteUrl: null,
     },
   ],
 };

--- a/packages/shared/schemas/species.ts
+++ b/packages/shared/schemas/species.ts
@@ -45,11 +45,13 @@ export const speciesMemberSchema: z.ZodObject<{
   name: z.ZodString;
   regionalForm: z.ZodNullable<z.ZodString>;
   stage: typeof speciesMemberStageSchema;
+  spriteUrl: z.ZodNullable<z.ZodString>;
 }> = object({
   pokemonId: number(),
   name: string(),
   regionalForm: nullable(string()),
   stage: speciesMemberStageSchema,
+  spriteUrl: nullable(string()),
 });
 
 export type SpeciesMember = z.infer<typeof speciesMemberSchema>;
@@ -158,6 +160,7 @@ export function buildSpecies(
         name: cursorMon.name,
         regionalForm: null,
         stage,
+        spriteUrl: cursorMon.spriteUrl,
       });
       cursorId = cursorNode.evolvesFromId;
     }
@@ -212,6 +215,7 @@ export function buildSpecies(
           name: p.name,
           regionalForm: parsed.form,
           stage,
+          spriteUrl: p.spriteUrl,
         });
         draft.memberIds.add(p.id);
       }

--- a/packages/shared/schemas/species_test.ts
+++ b/packages/shared/schemas/species_test.ts
@@ -73,6 +73,12 @@ Deno.test("buildSpecies: linear 3-stage line collapses to one species", () => {
     charizard.members.map((m) => m.stage),
     ["base", "middle", "final"],
   );
+  // Each member carries its own sprite so the UI can render an evolution
+  // chain like "<charmander> <charmeleon> <charizard> Charizard Line".
+  assertEquals(
+    charizard.members.map((m) => m.spriteUrl),
+    ["sprite/4.png", "sprite/5.png", "sprite/6.png"],
+  );
 });
 
 Deno.test("buildSpecies: single-stage pokemon is its own species", () => {
@@ -156,6 +162,7 @@ Deno.test("buildSpecies: regional variants of a terminal collapse into one speci
   if (!alolaVulpix) throw new Error("missing alolan vulpix");
   assertEquals(alolaVulpix.regionalForm, "alola");
   assertEquals(alolaVulpix.stage, "base");
+  assertEquals(alolaVulpix.spriteUrl, "sprite/10103.png");
 });
 
 Deno.test("buildSpecies: linear chain with Galarian pre-evos collapses to one species (Obstagoon)", () => {


### PR DESCRIPTION
## Summary
- Species-mode rows now render the full primary-line evolution chain inline in the Name cell — `<Squirtle><Wartortle><Blastoise> Blastoise Line` — instead of just the terminal final's name + thumbnail.
- Added `spriteUrl` to `SpeciesMember` (shared schemas + draft-pool item metadata) and populated it in `buildSpecies` for both linear walks and the regional-variant fold.
- Client `getPoolItemDisplay` now exposes a `chain[]` filtered to `regionalForm === null` so a Kanto Ninetales row never accidentally pulls in Alolan Vulpix.
- Individual-mode rows are unchanged.

## Test plan
- [x] `deno task test:server` — 271 passing (shared schema + service tests cover the new `spriteUrl` field on members for linear and regional fixtures)
- [x] `deno task test:client` — 232 passing (new tests assert chain ordering, sprite URLs, and that `AvailablePoolTable` renders sprite imgs + "Blastoise Line" for species rows)
- [x] `deno task build` — clean
- [x] `deno lint` — clean
- [ ] **Not visually verified in the browser:** there is no species-mode seed data, so I couldn't render a real species row in dev. The vitest assertions cover sprite alt text, ordering, and the trailing label, but a real-data smoke test is worth a quick look once merged into a branch with species data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)