### PR TITLE
refactor(layout): slim sidebar, link brand to /leagues

### DIFF
--- a/client/src/components/AppLayout.test.tsx
+++ b/client/src/components/AppLayout.test.tsx
@@ -20,13 +20,11 @@ vi.mock("../auth", () => ({
 }));
 
 const {
-  mockUseLeagues,
   mockUseLeague,
   mockUseLeaguePlayers,
   mockDeleteAccountMutate,
   locationRef,
 } = vi.hoisted(() => ({
-  mockUseLeagues: vi.fn(),
   mockUseLeague: vi.fn(),
   mockUseLeaguePlayers: vi.fn(),
   mockDeleteAccountMutate: vi.fn(),
@@ -34,7 +32,6 @@ const {
 }));
 
 vi.mock("../features/league/use-leagues", () => ({
-  useLeagues: mockUseLeagues,
   useLeague: mockUseLeague,
   useLeaguePlayers: mockUseLeaguePlayers,
 }));
@@ -67,7 +64,6 @@ function renderLayout(children: React.ReactNode = <div>content</div>) {
 
 function setupMocks(
   overrides: {
-    leagues?: Array<{ id: string; name: string; status: string }>;
     location?: string;
     currentLeague?: { id: string; name: string; status: string } | null;
     players?: Array<{ userId: string; role: "commissioner" | "player" }>;
@@ -79,10 +75,6 @@ function setupMocks(
       user: { id: "u1", name: "Ash Ketchum", image: null },
     },
     isPending: false,
-  });
-  mockUseLeagues.mockReturnValue({
-    data: overrides.leagues ?? [],
-    isLoading: false,
   });
   mockUseLeague.mockReturnValue({
     data: overrides.currentLeague ?? null,
@@ -119,48 +111,29 @@ describe("AppLayout shell", () => {
     expect(within(nav).queryByRole("link", { name: /^home$/i })).toBeNull();
   });
 
-  it("has a Leagues section in the sidebar", () => {
+  it("links the Make the Pick brand to /leagues", () => {
     setupMocks();
     renderLayout();
     const nav = screen.getByRole("navigation");
-    expect(within(nav).getByText(/leagues/i)).toBeInTheDocument();
+    const brand = within(nav).getByRole("link", { name: /make the pick/i });
+    expect(brand).toHaveAttribute("href", "/leagues");
   });
 
-  it("lists the user's leagues as children under Leagues", () => {
-    setupMocks({
-      leagues: [
-        {
-          id: "L1",
-          name: "Johto Classic",
-          status: "setup",
-        },
-        {
-          id: "L2",
-          name: "Kanto Rumble",
-          status: "drafting",
-        },
-      ],
-    });
-    renderLayout();
-    const nav = screen.getByRole("navigation");
-    const johto = within(nav).getByRole("link", { name: /johto classic/i });
-    expect(johto).toHaveAttribute("href", "/leagues/L1");
-    const kanto = within(nav).getByRole("link", { name: /kanto rumble/i });
-    expect(kanto).toHaveAttribute("href", "/leagues/L2");
-  });
-
-  it("shows a Research entry in the sidebar", () => {
+  it("does not render a Leagues nav section on non-league routes", () => {
     setupMocks();
     renderLayout();
     const nav = screen.getByRole("navigation");
-    expect(within(nav).getByText(/research/i)).toBeInTheDocument();
+    expect(within(nav).queryByRole("link", { name: /^leagues$/i })).toBeNull();
+    expect(within(nav).queryByRole("button", { name: /^leagues$/i }))
+      .toBeNull();
   });
 
-  it("shows a Profile entry in the sidebar", () => {
+  it("does not render Research or Profile entries", () => {
     setupMocks();
     renderLayout();
     const nav = screen.getByRole("navigation");
-    expect(within(nav).getByText(/profile/i)).toBeInTheDocument();
+    expect(within(nav).queryByText(/research/i)).toBeNull();
+    expect(within(nav).queryByText(/profile/i)).toBeNull();
   });
 
   it("renders the user's name in the sidebar footer", () => {
@@ -237,7 +210,7 @@ describe("AppLayout league mode", () => {
       .toHaveAttribute("href", "/leagues/L1/draft");
   });
 
-  it("omits Home and Leagues nav links in league mode (redundant with All leagues)", () => {
+  it("does not render an All leagues back-link in league mode (brand handles it)", () => {
     setupMocks({
       location: "/leagues/L1",
       currentLeague: { id: "L1", name: "Johto", status: "drafting" },
@@ -245,18 +218,17 @@ describe("AppLayout league mode", () => {
     });
     renderLayout();
     const nav = screen.getByRole("navigation");
-    expect(within(nav).queryByRole("link", { name: /^home$/i })).toBeNull();
-    expect(within(nav).queryByRole("link", { name: /^leagues$/i })).toBeNull();
-    expect(within(nav).getByRole("link", { name: /all leagues/i }))
-      .toHaveAttribute("href", "/leagues");
+    expect(within(nav).queryByRole("link", { name: /all leagues/i }))
+      .toBeNull();
+    const brand = within(nav).getByRole("link", { name: /make the pick/i });
+    expect(brand).toHaveAttribute("href", "/leagues");
   });
 
   it("does not enter league mode on /leagues list route", () => {
     setupMocks({ location: "/leagues" });
     renderLayout();
     const nav = screen.getByRole("navigation");
-    expect(within(nav).queryByRole("link", { name: /all leagues/i }))
-      .toBeNull();
+    expect(within(nav).queryByRole("link", { name: /overview/i })).toBeNull();
   });
 
   it("does not enter league mode on /leagues/new", () => {

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -2,7 +2,6 @@ import {
   ActionIcon,
   AppShell,
   Avatar,
-  Badge,
   Box,
   Burger,
   Button,
@@ -10,7 +9,6 @@ import {
   Group,
   Menu,
   Modal,
-  NavLink,
   ScrollArea,
   Stack,
   Text,
@@ -19,17 +17,10 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useEffect } from "react";
-import {
-  IconBinoculars,
-  IconChevronLeft,
-  IconChevronRight,
-  IconTrophy,
-  IconUser,
-} from "@tabler/icons-react";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { Link, useLocation } from "wouter";
 import { signOut, useSession } from "../auth";
-import { useLeagues } from "../features/league/use-leagues";
 import { LeagueSidebar, parseLeagueId } from "../features/league/LeagueSidebar";
 import { trpc } from "../trpc";
 
@@ -49,13 +40,11 @@ export function AppLayout({ children }: AppLayoutProps) {
     useDisclosure(false);
   const [deleteOpened, { open: openDelete, close: closeDelete }] =
     useDisclosure(false);
-  const [leaguesOpened, { toggle: toggleLeagues }] = useDisclosure(true);
 
   useEffect(() => {
     closeMobile();
   }, [location, closeMobile]);
 
-  const leagues = useLeagues();
   const deleteAccount = trpc.user.deleteAccount.useMutation({
     onSuccess: () => {
       globalThis.location.replace("/login");
@@ -73,8 +62,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     ? NAVBAR_COLLAPSED_WIDTH
     : NAVBAR_EXPANDED_WIDTH;
 
-  const isLeaguesActive = location.startsWith("/leagues");
-  const leagueItems = leagues.data ?? [];
   const currentLeagueId = parseLeagueId(location);
 
   return (
@@ -109,90 +96,41 @@ export function AppLayout({ children }: AppLayoutProps) {
             {collapsed
               ? (
                 <Tooltip label="Make the Pick" position="right">
-                  <Text fw={800} size="lg" ta="center">
-                    M
-                  </Text>
+                  <UnstyledButton
+                    component={Link}
+                    href="/leagues"
+                    aria-label="Make the Pick"
+                    style={{ display: "block", width: "100%" }}
+                  >
+                    <Text fw={800} size="lg" ta="center">
+                      M
+                    </Text>
+                  </UnstyledButton>
                 </Tooltip>
               )
               : (
-                <Text fw={800} size="lg">
-                  Make the Pick
-                </Text>
+                <UnstyledButton
+                  component={Link}
+                  href="/leagues"
+                  aria-label="Make the Pick"
+                  style={{ display: "block", width: "100%" }}
+                >
+                  <Text fw={800} size="lg">
+                    Make the Pick
+                  </Text>
+                </UnstyledButton>
               )}
           </Box>
           <Divider />
 
           <ScrollArea style={{ flex: 1 }}>
-            {currentLeagueId
-              ? (
-                <LeagueSidebar
-                  leagueId={currentLeagueId}
-                  location={location}
-                  collapsed={collapsed}
-                />
-              )
-              : (
-                <Stack gap={2} py="xs">
-                  {collapsed
-                    ? (
-                      <Tooltip label="Leagues" position="right">
-                        <div>
-                          <SidebarLink
-                            to="/leagues"
-                            label="Leagues"
-                            icon={<IconTrophy size={20} />}
-                            active={isLeaguesActive}
-                            collapsed
-                          />
-                        </div>
-                      </Tooltip>
-                    )
-                    : (
-                      <NavLink
-                        label="Leagues"
-                        leftSection={<IconTrophy size={20} />}
-                        childrenOffset={28}
-                        opened={leaguesOpened}
-                        onClick={toggleLeagues}
-                        active={isLeaguesActive}
-                        variant="filled"
-                      >
-                        {leagueItems.map((league) => (
-                          <NavLink
-                            key={league.id}
-                            component={Link}
-                            href={`/leagues/${league.id}`}
-                            label={league.name}
-                            active={location === `/leagues/${league.id}`}
-                            variant="light"
-                          />
-                        ))}
-                        <NavLink
-                          component={Link}
-                          href="/leagues"
-                          label="Browse all"
-                          c="dimmed"
-                        />
-                      </NavLink>
-                    )}
-
-                  <SidebarLink
-                    label="Research"
-                    icon={<IconBinoculars size={20} />}
-                    collapsed={collapsed}
-                    disabled
-                    badge="Soon"
-                  />
-
-                  <SidebarLink
-                    label="Profile"
-                    icon={<IconUser size={20} />}
-                    collapsed={collapsed}
-                    disabled
-                    badge="Soon"
-                  />
-                </Stack>
-              )}
+            {currentLeagueId && (
+              <LeagueSidebar
+                leagueId={currentLeagueId}
+                location={location}
+                collapsed={collapsed}
+              />
+            )}
           </ScrollArea>
 
           <Divider />
@@ -326,48 +264,6 @@ export function AppLayout({ children }: AppLayoutProps) {
       </Modal>
     </AppShell>
   );
-}
-
-interface SidebarLinkProps {
-  to?: string;
-  label: string;
-  icon: ReactNode;
-  active?: boolean;
-  collapsed: boolean;
-  disabled?: boolean;
-  badge?: string;
-}
-
-function SidebarLink(
-  { to, label, icon, active, collapsed, disabled, badge }: SidebarLinkProps,
-) {
-  const link = (
-    <NavLink
-      component={disabled || !to ? "button" : Link}
-      href={to}
-      label={collapsed ? undefined : label}
-      leftSection={icon}
-      active={active}
-      disabled={disabled}
-      rightSection={!collapsed && badge
-        ? (
-          <Badge size="xs" variant="light" color="gray">
-            {badge}
-          </Badge>
-        )
-        : undefined}
-      variant="filled"
-      aria-label={label}
-    />
-  );
-  if (collapsed) {
-    return (
-      <Tooltip label={label} position="right">
-        <div>{link}</div>
-      </Tooltip>
-    );
-  }
-  return link;
 }
 
 function breadcrumbForLocation(location: string): string {

--- a/client/src/features/league/LeagueSidebar.test.tsx
+++ b/client/src/features/league/LeagueSidebar.test.tsx
@@ -112,11 +112,10 @@ describe("LeagueSidebar", () => {
     expect(screen.getByText(/drafting/i)).toBeInTheDocument();
   });
 
-  it("has a back link to /leagues", () => {
+  it("does not render an All leagues back link (handled by AppLayout brand)", () => {
     setup();
     renderSidebar();
-    const back = screen.getByRole("link", { name: /all leagues/i });
-    expect(back).toHaveAttribute("href", "/leagues");
+    expect(screen.queryByRole("link", { name: /all leagues/i })).toBeNull();
   });
 
   it("has an Overview link to the league detail page", () => {

--- a/client/src/features/league/LeagueSidebar.tsx
+++ b/client/src/features/league/LeagueSidebar.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
 } from "@mantine/core";
 import {
-  IconArrowLeft,
   IconChartBar,
   IconChecklist,
   IconLayoutDashboard,
@@ -73,18 +72,9 @@ export function LeagueSidebar(
 
   return (
     <Stack gap={0}>
-      <Box px={collapsed ? "xs" : "md"} pt="xs" pb="sm">
-        <NavLink
-          component={Link}
-          href="/leagues"
-          leftSection={<IconArrowLeft size={16} />}
-          label={collapsed ? undefined : "All leagues"}
-          aria-label="All leagues"
-          variant="subtle"
-          c="dimmed"
-        />
-        {!collapsed && (
-          <Group gap="xs" px="sm" pt="xs" wrap="nowrap">
+      {!collapsed && (
+        <Box px="md" pt="xs" pb="sm">
+          <Group gap="xs" px="sm" wrap="nowrap">
             <Text fw={700} size="sm" truncate>
               {name}
             </Text>
@@ -97,8 +87,8 @@ export function LeagueSidebar(
               {status}
             </Badge>
           </Group>
-        )}
-      </Box>
+        </Box>
+      )}
       <Divider />
 
       <Stack gap={2} py="xs">


### PR DESCRIPTION
## Summary
- Drop the non-league sidebar block (Leagues dropdown, Research, Profile) — it duplicated what `/leagues` already shows in its table.
- Make the "Make the Pick" brand a `Link` to `/leagues`, giving the app one canonical home affordance.
- Remove the "← All leagues" back-link from `LeagueSidebar`; the brand now plays that role on individual league pages.
- Trim now-unused imports, helpers (`SidebarLink`), and `useLeagues` calls in `AppLayout`.

## Test plan
- [x] `deno task test:client` — 228/228 passing
- [x] `deno lint` — clean
- [ ] Manual: visit `/leagues` → sidebar shows only brand + user menu
- [ ] Manual: open a league → sidebar shows league context, no "All leagues" item
- [ ] Manual: click "Make the Pick" brand from a league → returns to `/leagues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)