### PR TITLE
fix(draft): move species evolution chain into the thumbnail column

### DIFF
--- a/client/src/features/draft/AvailablePoolTable.tsx
+++ b/client/src/features/draft/AvailablePoolTable.tsx
@@ -194,48 +194,51 @@ export function AvailablePoolTable({
       {
         accessorKey: "thumbnailUrl",
         header: "",
-        size: 56,
+        size: 140,
         enableSorting: false,
         enableColumnFilter: false,
-        Cell: ({ row }) => (
-          <Avatar
-            src={row.original.thumbnailUrl}
-            alt={row.original.name}
-            size="md"
-            radius="sm"
-          />
-        ),
-      },
-      {
-        accessorKey: "name",
-        header: "Name",
-        Cell: ({ row, renderedCellValue }) => {
+        Cell: ({ row }) => {
           const display = getPoolItemDisplay(row.original);
           if (display?.mode === "species" && display.chain.length > 0) {
             return (
-              <Group gap={4} wrap="nowrap" align="center">
+              <Group gap={2} wrap="nowrap" align="center">
                 {display.chain.map((stage) => (
                   <img
                     key={stage.pokemonId}
                     src={stage.spriteUrl ?? undefined}
                     alt={stage.name}
-                    width={32}
-                    height={32}
+                    width={36}
+                    height={36}
                     style={{
                       objectFit: "contain",
                       imageRendering: "pixelated",
                     }}
                   />
                 ))}
-                <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
-                  {row.original.name} Line
-                </span>
               </Group>
             );
           }
           return (
+            <Avatar
+              src={row.original.thumbnailUrl}
+              alt={row.original.name}
+              size="md"
+              radius="sm"
+            />
+          );
+        },
+      },
+      {
+        accessorKey: "name",
+        header: "Name",
+        Cell: ({ row, renderedCellValue }) => {
+          const display = getPoolItemDisplay(row.original);
+          const label = display?.mode === "species"
+            ? `${row.original.name} Line`
+            : renderedCellValue;
+          return (
             <span style={{ fontWeight: 500, textTransform: "capitalize" }}>
-              {renderedCellValue}
+              {label}
             </span>
           );
         },


### PR DESCRIPTION
## Summary
- Fixes the duplicate-sprite bug in species-mode rows: the terminal final was rendering twice (once in the thumbnail Avatar, once at the end of the chain in the Name cell).
- Chain now lives in the thumbnail column for species rows; Name cell goes back to a plain `{name} Line` label.
- Individual rows keep the Avatar thumbnail unchanged.
- Widened the thumbnail column from 56→140px so a 3-stage chain fits.

## Test plan
- [x] \`deno task test:client\` — 229 passing (existing chain test still asserts sprite alt text + "Blastoise Line" label)
- [x] \`deno task build\` — clean
- [x] \`deno lint\` — clean
- [ ] **Visual check needed** in a real species-mode league to confirm the chain reads cleanly at 36px and that the Name column isn't squeezed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)