### PR TITLE
fix(draft): only widen thumbnail column for species drafts

### DIFF
--- a/client/src/features/draft/AvailablePoolTable.tsx
+++ b/client/src/features/draft/AvailablePoolTable.tsx
@@ -99,6 +99,18 @@ export function AvailablePoolTable({
     return draftState.poolItems.filter((item) => availableSet.has(item.id));
   }, [draftState.availableItemIds, draftState.poolItems]);
 
+  // A draft is single-mode (all items individual or all species), so the
+  // first item with metadata tells us which width the thumbnail column
+  // needs — wide enough for a 3-stage chain in species mode, narrow for
+  // a single Avatar in individual mode.
+  const isSpeciesDraft = useMemo(() => {
+    for (const item of draftState.poolItems) {
+      const display = getPoolItemDisplay(item);
+      if (display) return display.mode === "species";
+    }
+    return false;
+  }, [draftState.poolItems]);
+
   function handleClickItem(item: DraftPoolItem) {
     setPendingItem(item);
     open();
@@ -194,7 +206,7 @@ export function AvailablePoolTable({
       {
         accessorKey: "thumbnailUrl",
         header: "",
-        size: 140,
+        size: isSpeciesDraft ? 140 : 56,
         enableSorting: false,
         enableColumnFilter: false,
         Cell: ({ row }) => {
@@ -343,6 +355,7 @@ export function AvailablePoolTable({
       addToWatchlist,
       removeFromWatchlist,
       isMyTurn,
+      isSpeciesDraft,
     ],
   );
 


### PR DESCRIPTION
## Summary
- Thumbnail column was unconditionally 140px to fit the species evolution chain, leaving wasted space next to the 56px Avatar in individual-mode drafts.
- Detect draft mode from the first pool item with metadata (drafts are single-mode by construction) and size the column conditionally: 140px for species, 56px for individual.

## Test plan
- [x] \`deno task test:client\` — 228 passing
- [x] \`deno task build\` — clean
- [x] \`deno lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)