### PR TITLE
refactor(league): drop Standings nav and gate Draft Room/Pool by phase

### DIFF
--- a/client/src/features/league/LeagueSidebar.test.tsx
+++ b/client/src/features/league/LeagueSidebar.test.tsx
@@ -146,6 +146,40 @@ describe("LeagueSidebar", () => {
     expect(screen.getByText(/draft room/i)).toBeInTheDocument();
   });
 
+  it("disables Draft Room while status is pooling", () => {
+    setup({ leagueStatus: "pooling" });
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /draft room/i })).toBeNull();
+    expect(screen.getByText(/draft room/i)).toBeInTheDocument();
+  });
+
+  it("disables Draft Room while status is scouting", () => {
+    setup({ leagueStatus: "scouting" });
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /draft room/i })).toBeNull();
+    expect(screen.getByText(/draft room/i)).toBeInTheDocument();
+  });
+
+  it("disables Draft Pool while status is setup", () => {
+    setup({ leagueStatus: "setup" });
+    renderSidebar();
+    expect(screen.queryByRole("link", { name: /draft pool/i })).toBeNull();
+    expect(screen.getByText(/draft pool/i)).toBeInTheDocument();
+  });
+
+  it("enables Draft Pool while status is pooling", () => {
+    setup({ leagueStatus: "pooling" });
+    renderSidebar();
+    const pool = screen.getByRole("link", { name: /draft pool/i });
+    expect(pool).toHaveAttribute("href", "/leagues/L1/draft/pool");
+  });
+
+  it("does not render a Standings nav item", () => {
+    setup({ leagueStatus: "drafting" });
+    renderSidebar();
+    expect(screen.queryByText(/standings/i)).toBeNull();
+  });
+
   it("shows Settings link for commissioner", () => {
     setup({ role: "commissioner" });
     renderSidebar();

--- a/client/src/features/league/LeagueSidebar.tsx
+++ b/client/src/features/league/LeagueSidebar.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
 } from "@mantine/core";
 import {
-  IconChartBar,
   IconChecklist,
   IconLayoutDashboard,
   IconSettings,
@@ -54,7 +53,9 @@ export function LeagueSidebar(
   ) ?? false;
 
   const status = league.data?.status ?? "setup";
-  const draftEnabled = status !== "setup";
+  const poolEnabled = status !== "setup";
+  const draftRoomEnabled = status === "drafting" || status === "competing" ||
+    status === "complete";
   const picksEnabled = status === "competing" || status === "complete";
   const name = league.data?.name ?? "League";
 
@@ -100,29 +101,22 @@ export function LeagueSidebar(
           collapsed={collapsed}
         />
         <LeagueNavItem
-          to={draftEnabled ? draftHref : undefined}
+          to={draftRoomEnabled ? draftHref : undefined}
           label="Draft Room"
           icon={<IconSwords size={20} />}
           active={isDraftActive}
           collapsed={collapsed}
-          disabled={!draftEnabled}
-          tooltip={!draftEnabled ? "Draft hasn't started" : undefined}
+          disabled={!draftRoomEnabled}
+          tooltip={!draftRoomEnabled ? "Draft hasn't started" : undefined}
         />
         <LeagueNavItem
-          to={draftEnabled ? poolHref : undefined}
+          to={poolEnabled ? poolHref : undefined}
           label="Draft Pool"
           icon={<IconTelescope size={20} />}
           active={isPoolActive}
           collapsed={collapsed}
-          disabled={!draftEnabled}
-          tooltip={!draftEnabled ? "Draft hasn't started" : undefined}
-        />
-        <LeagueNavItem
-          label="Standings"
-          icon={<IconChartBar size={20} />}
-          collapsed={collapsed}
-          disabled
-          badge="Soon"
+          disabled={!poolEnabled}
+          tooltip={!poolEnabled ? "Pool hasn't been revealed yet" : undefined}
         />
         <LeagueNavItem
           to={picksEnabled ? picksHref : undefined}


### PR DESCRIPTION
## Summary
- Remove the placeholder Standings nav item from the league sidebar — there is no backing screen yet, so it was misleading.
- Gate Draft Room on the `drafting` phase (instead of any non-setup phase), so it fades out until it's actually meaningful.
- Keep Draft Pool faded out during setup with a clearer "Pool hasn't been revealed yet" tooltip.

## Test plan
- [x] `deno task test:client` (233 passed)
- [x] `deno lint`
- [x] New TDD coverage in `LeagueSidebar.test.tsx` for the Standings removal and tightened Draft Room phase gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)