### PR TITLE
test(e2e): add league create/list/delete flow

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,10 +1,25 @@
+import { createHmac } from "node:crypto";
 import { type Page, test as base } from "@playwright/test";
-import { closeDatabase, resetDatabase, seedTestUser } from "../helpers/db.ts";
+import { resetDatabase, seedTestUser } from "../helpers/db.ts";
 import { SESSION_COOKIE_NAME } from "../helpers/seed-data.ts";
 
 type AuthFixtures = {
   authenticatedPage: Page;
 };
+
+const BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ??
+  "e2e-test-secret-not-real";
+
+/**
+ * Better Auth (via better-call) stores the session cookie as
+ * `encodeURIComponent("{token}.{base64(HMAC-SHA256(secret, token))}")`.
+ * The fixture must produce a value that passes signature verification or
+ * the server silently drops the cookie and redirects to /login.
+ */
+function signSessionCookie(token: string, secret: string): string {
+  const signature = createHmac("sha256", secret).update(token).digest("base64");
+  return encodeURIComponent(`${token}.${signature}`);
+}
 
 /**
  * Extended test fixture that provides an `authenticatedPage` with a
@@ -15,6 +30,7 @@ export const test = base.extend<AuthFixtures>({
   authenticatedPage: async ({ browser, baseURL }, use) => {
     await resetDatabase();
     const { sessionToken } = await seedTestUser();
+    const signedCookie = signSessionCookie(sessionToken, BETTER_AUTH_SECRET);
 
     const context = await browser.newContext({
       baseURL,
@@ -22,7 +38,7 @@ export const test = base.extend<AuthFixtures>({
         cookies: [
           {
             name: SESSION_COOKIE_NAME,
-            value: sessionToken,
+            value: signedCookie,
             domain: "localhost",
             path: "/",
             httpOnly: true,

--- a/e2e/tests/league.spec.ts
+++ b/e2e/tests/league.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "../fixtures/auth.ts";
+import { closeDatabase } from "../helpers/db.ts";
+
+test.describe("League management", () => {
+  test.afterAll(async () => {
+    await closeDatabase();
+  });
+
+  test("commissioner creates a league, sees it in the list, and deletes it", async ({ authenticatedPage: page }) => {
+    const leagueName = `Test League ${Date.now()}`;
+
+    await page.goto("/leagues");
+    await expect(page.getByRole("heading", { name: "My Leagues" }))
+      .toBeVisible();
+
+    await page.getByRole("link", { name: /create league/i }).click();
+    await expect(page).toHaveURL(/\/leagues\/new/);
+
+    await page.getByLabel("League Name").fill(leagueName);
+    await page.getByLabel("Number of Rounds").fill("6");
+    await page.getByLabel("Max Players").fill("4");
+    await page.getByRole("button", { name: /^create$/i }).click();
+
+    await expect(page).toHaveURL(/\/leagues\/[0-9a-f-]+$/);
+    await expect(page.getByRole("heading", { name: leagueName })).toBeVisible();
+
+    await page.getByRole("link", { name: /back to leagues/i }).click();
+    await expect(page).toHaveURL(/\/leagues$/);
+    await expect(page.getByText(leagueName)).toBeVisible();
+
+    await page.getByText(leagueName).click();
+    await expect(page).toHaveURL(/\/leagues\/[0-9a-f-]+$/);
+
+    await page.getByRole("button", { name: /delete league/i }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /delete/i })
+      .click();
+
+    await expect(page).toHaveURL(/\/leagues$/);
+    await expect(page.getByText(leagueName)).not.toBeVisible();
+  });
+
+  test("create form rejects an empty name", async ({ authenticatedPage: page }) => {
+    await page.goto("/leagues/new");
+    await page.getByLabel("Number of Rounds").fill("6");
+    await page.getByLabel("Max Players").fill("4");
+    await page.getByRole("button", { name: /^create$/i }).click();
+
+    await expect(page).toHaveURL(/\/leagues\/new$/);
+  });
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -29,10 +29,11 @@ test.describe("Smoke tests", () => {
     ).toBeVisible();
   });
 
-  test("authenticated user sees the home page", async ({ authenticatedPage }) => {
+  test("authenticated user lands on the leagues list", async ({ authenticatedPage }) => {
     await authenticatedPage.goto("/");
+    await expect(authenticatedPage).toHaveURL(/\/leagues$/);
     await expect(
-      authenticatedPage.getByRole("heading", { name: "Make The Pick" }),
+      authenticatedPage.getByRole("heading", { name: "My Leagues" }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- First league management E2E spec: commissioner creates a league, verifies it on the list, then deletes it.
- Asserts the create form rejects an empty name.
- PR1 of a planned E2E buildout (draft-setup → watchlist/notes → multi-user draft-room).

## Test plan
- [ ] CI runs `deno task test:e2e` — new `e2e/tests/league.spec.ts` passes alongside the existing smoke suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)