### PR TITLE
feat(client): set descriptive document.title per page

### DIFF
--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -14,6 +14,7 @@ import {
 import { useMemo } from "react";
 import { Link, useParams } from "wouter";
 import { useSession } from "../../auth";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { useLeague, useLeaguePlayers } from "../league/use-leagues";
 import { AllRostersPanel } from "./AllRostersPanel";
 import { AvailablePoolTable } from "./AvailablePoolTable";
@@ -32,6 +33,7 @@ export function DraftPage() {
   const { id } = useParams<{ id: string }>();
   const leagueId = id!;
   const league = useLeague(leagueId);
+  usePageTitle(league.data ? `Draft · ${league.data.name}` : undefined);
   const leaguePlayers = useLeaguePlayers(leagueId);
   const draft = useDraft(leagueId);
   const makePick = useMakePick(leagueId);

--- a/client/src/features/draft/DraftPoolPage.tsx
+++ b/client/src/features/draft/DraftPoolPage.tsx
@@ -37,6 +37,7 @@ import type {
 import { getPoolItemDisplay, getPoolItemStatTotal } from "./pool-item-display";
 import { Link, useParams } from "wouter";
 import { useSession } from "../../auth";
+import { usePageTitle } from "../../hooks/use-page-title";
 import {
   useAdvanceLeagueStatus,
   useLeague,
@@ -300,6 +301,11 @@ export function DraftPoolPage() {
   const advanceStatus = useAdvanceLeagueStatus();
 
   const isPooling = league.data?.status === "pooling";
+  usePageTitle(
+    league.data
+      ? `${isPooling ? "Pool Reveal" : "Draft Pool"} · ${league.data.name}`
+      : undefined,
+  );
   const isCommissioner = players.data?.some(
     (p) => p.userId === session?.user?.id && p.role === "commissioner",
   ) ?? false;

--- a/client/src/features/draft/PicksPage.tsx
+++ b/client/src/features/draft/PicksPage.tsx
@@ -19,6 +19,7 @@ import {
 import { useMemo } from "react";
 import { Link, useParams } from "wouter";
 import type { DraftPoolItem } from "@make-the-pick/shared";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { useLeague } from "../league/use-leagues";
 import { AllRostersPanel } from "./AllRostersPanel";
 import { useDraft } from "./use-draft";
@@ -39,6 +40,7 @@ export function PicksPage() {
   const { id } = useParams<{ id: string }>();
   const leagueId = id!;
   const league = useLeague(leagueId);
+  usePageTitle(league.data ? `Picks · ${league.data.name}` : undefined);
   const draft = useDraft(leagueId);
 
   const isLoading = league.isLoading || draft.isLoading;

--- a/client/src/features/league/CreateLeaguePage.tsx
+++ b/client/src/features/league/CreateLeaguePage.tsx
@@ -12,10 +12,12 @@ import {
 } from "@mantine/core";
 import { type FormEvent, useState } from "react";
 import { Link, useLocation } from "wouter";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
 import { useCreateLeague } from "./use-leagues";
 
 export function CreateLeaguePage() {
+  usePageTitle("New League");
   const [, navigate] = useLocation();
   const createLeague = useCreateLeague();
   const pokemonVersions = usePokemonVersions();

--- a/client/src/features/league/JoinLeaguePage.tsx
+++ b/client/src/features/league/JoinLeaguePage.tsx
@@ -1,9 +1,11 @@
 import { Alert, Anchor, Center, Loader, Stack, Text } from "@mantine/core";
 import { useEffect, useRef } from "react";
 import { useLocation, useParams } from "wouter";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { useJoinLeague } from "./use-leagues";
 
 export function JoinLeaguePage() {
+  usePageTitle("Joining League");
   const { inviteCode } = useParams<{ inviteCode: string }>();
   const [, navigate] = useLocation();
   const joinLeague = useJoinLeague();

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -12,6 +12,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { useMemo, useState } from "react";
 import { Link, useLocation, useParams } from "wouter";
 import { useSession } from "../../auth";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { AllRostersPanel } from "../draft/AllRostersPanel";
 import { useDraft } from "../draft/use-draft";
 import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
@@ -46,6 +47,7 @@ const NEXT_STATUS: Record<string, string | null> = {
 export function LeagueDetailPage() {
   const { id } = useParams<{ id: string }>();
   const league = useLeague(id!);
+  usePageTitle(league.data?.name);
   const pokemonVersions = usePokemonVersions();
   const gameVersionName = useMemo(() => {
     const rules = league.data?.rulesConfig as

--- a/client/src/features/league/LeagueListPage.tsx
+++ b/client/src/features/league/LeagueListPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "mantine-react-table";
 import { useMemo } from "react";
 import { Link, useLocation } from "wouter";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { JoinLeagueModal } from "./JoinLeagueModal";
 import { useLeagues } from "./use-leagues";
 
@@ -56,6 +57,7 @@ function nextActionFor(league: LeagueRow): string {
 }
 
 export function LeagueListPage() {
+  usePageTitle("My Leagues");
   const leagues = useLeagues();
   const [, navigate] = useLocation();
   const [joinOpened, joinHandlers] = useDisclosure(false);

--- a/client/src/features/league/LeagueSettingsPage.tsx
+++ b/client/src/features/league/LeagueSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useState } from "react";
 import { Link, useParams } from "wouter";
 import { useSession } from "../../auth";
+import { usePageTitle } from "../../hooks/use-page-title";
 import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
 import {
   useLeague,
@@ -25,6 +26,7 @@ import {
 export function LeagueSettingsPage() {
   const { id } = useParams<{ id: string }>();
   const league = useLeague(id!);
+  usePageTitle(league.data ? `Settings · ${league.data.name}` : undefined);
   const players = useLeaguePlayers(id!);
   const { data: session } = useSession();
   const updateSettings = useUpdateLeagueSettings();

--- a/client/src/hooks/use-page-title.test.ts
+++ b/client/src/hooks/use-page-title.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { usePageTitle } from "./use-page-title";
+
+const ORIGINAL_TITLE = "Make The Pick";
+
+afterEach(() => {
+  document.title = ORIGINAL_TITLE;
+});
+
+describe("usePageTitle", () => {
+  it("sets document title to `<title> · Make The Pick`", () => {
+    renderHook(() => usePageTitle("Leagues"));
+    expect(document.title).toBe("Leagues · Make The Pick");
+  });
+
+  it("leaves title at the base when given undefined (still loading)", () => {
+    renderHook(() => usePageTitle(undefined));
+    expect(document.title).toBe(ORIGINAL_TITLE);
+  });
+
+  it("restores the previous title on unmount", () => {
+    document.title = "Previous";
+    const { unmount } = renderHook(() => usePageTitle("Draft"));
+    expect(document.title).toBe("Draft · Make The Pick");
+    unmount();
+    expect(document.title).toBe("Previous");
+  });
+
+  it("updates title when the argument changes", () => {
+    const { rerender } = renderHook(
+      ({ title }: { title: string | undefined }) => usePageTitle(title),
+      { initialProps: { title: "First" as string | undefined } },
+    );
+    expect(document.title).toBe("First · Make The Pick");
+    rerender({ title: "Second" });
+    expect(document.title).toBe("Second · Make The Pick");
+  });
+});

--- a/client/src/hooks/use-page-title.ts
+++ b/client/src/hooks/use-page-title.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+const BASE_TITLE = "Make The Pick";
+
+export function usePageTitle(title: string | undefined): void {
+  useEffect(() => {
+    if (!title) return;
+    const previous = document.title;
+    document.title = `${title} · ${BASE_TITLE}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { Alert, Center, Stack, Title, UnstyledButton } from "@mantine/core";
 import { useSearch } from "wouter";
 import { signIn } from "../auth";
+import { usePageTitle } from "../hooks/use-page-title";
 
 const googleLogoSvg =
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
@@ -11,6 +12,7 @@ const googleLogoSvg =
 </svg>`;
 
 export function LoginPage() {
+  usePageTitle("Sign In");
   const search = useSearch();
   const hasOAuthError = new URLSearchParams(search).get("error") === "oauth";
 


### PR DESCRIPTION
## Summary
- Add `usePageTitle` hook that sets `document.title` to `<title> · Make The Pick` and restores the previous title on unmount.
- Wire it into every page with meaningful context: leagues list, league detail (by name), settings, draft, draft pool / pool reveal, picks, create, join, and login — so browser tabs are distinguishable when several are open.

## Test plan
- [x] `deno task test:client` (253 passing, incl. new `use-page-title` tests)
- [x] `deno task build`
- [x] `deno lint`