### PR TITLE
test(e2e): add league settings edit flow

### DIFF
--- a/e2e/tests/league-settings.spec.ts
+++ b/e2e/tests/league-settings.spec.ts
@@ -30,11 +30,11 @@ test.describe("League settings", () => {
     await expect(page.getByLabel("Max Players")).toHaveValue("4");
 
     // Toggle a setting that shows up uniquely in the rules card.
-    // Mantine Switch has a CSS thumb animation that prevents Playwright's
-    // actionability "stable" check from passing, so we force the click.
-    await page
-      .getByRole("switch", { name: /Exclude Legendaries/ })
-      .click({ force: true });
+    const legendariesSwitch = page.getByRole("switch", {
+      name: /Exclude Legendaries/,
+    });
+    await legendariesSwitch.scrollIntoViewIfNeeded();
+    await legendariesSwitch.click({ force: true });
 
     // Wait for auto-save to settle before navigating away.
     await expect(page.getByText("Saving...")).toHaveCount(0, { timeout: 5000 });

--- a/e2e/tests/league-settings.spec.ts
+++ b/e2e/tests/league-settings.spec.ts
@@ -30,11 +30,9 @@ test.describe("League settings", () => {
     await expect(page.getByLabel("Max Players")).toHaveValue("4");
 
     // Toggle a setting that shows up uniquely in the rules card.
-    const legendariesSwitch = page.getByRole("switch", {
-      name: /Exclude Legendaries/,
-    });
-    await legendariesSwitch.scrollIntoViewIfNeeded();
-    await legendariesSwitch.click({ force: true });
+    // The Mantine Switch input is visually hidden (zero-size), so we click
+    // the label text instead which toggles the underlying checkbox.
+    await page.getByText("Exclude Legendaries").click();
 
     // Wait for auto-save to settle before navigating away.
     await expect(page.getByText("Saving...")).toHaveCount(0, { timeout: 5000 });

--- a/e2e/tests/league-settings.spec.ts
+++ b/e2e/tests/league-settings.spec.ts
@@ -30,7 +30,11 @@ test.describe("League settings", () => {
     await expect(page.getByLabel("Max Players")).toHaveValue("4");
 
     // Toggle a setting that shows up uniquely in the rules card.
-    await page.getByLabel("Exclude Legendaries").check();
+    // Mantine Switch inlines the description into the label text, so the
+    // string form of getByLabel won't match — use role + regex instead.
+    await page
+      .getByRole("switch", { name: /Exclude Legendaries/ })
+      .check();
 
     // Wait for auto-save to settle before navigating away.
     await expect(page.getByText("Saving...")).toHaveCount(0, { timeout: 5000 });

--- a/e2e/tests/league-settings.spec.ts
+++ b/e2e/tests/league-settings.spec.ts
@@ -30,11 +30,11 @@ test.describe("League settings", () => {
     await expect(page.getByLabel("Max Players")).toHaveValue("4");
 
     // Toggle a setting that shows up uniquely in the rules card.
-    // Mantine Switch inlines the description into the label text, so the
-    // string form of getByLabel won't match — use role + regex instead.
+    // Mantine Switch has a CSS thumb animation that prevents Playwright's
+    // actionability "stable" check from passing, so we force the click.
     await page
       .getByRole("switch", { name: /Exclude Legendaries/ })
-      .check();
+      .click({ force: true });
 
     // Wait for auto-save to settle before navigating away.
     await expect(page.getByText("Saving...")).toHaveCount(0, { timeout: 5000 });

--- a/e2e/tests/league-settings.spec.ts
+++ b/e2e/tests/league-settings.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "../fixtures/auth.ts";
+import { closeDatabase } from "../helpers/db.ts";
+
+test.describe("League settings", () => {
+  test.afterAll(async () => {
+    await closeDatabase();
+  });
+
+  test("commissioner edits settings and the rules card reflects the change", async ({ authenticatedPage: page }) => {
+    const leagueName = `Settings League ${Date.now()}`;
+
+    await page.goto("/leagues/new");
+    await page.getByLabel("League Name").fill(leagueName);
+    await page.getByLabel("Number of Rounds").fill("6");
+    await page.getByLabel("Max Players").fill("4");
+    await page.getByRole("button", { name: /^create$/i }).click();
+    await expect(page).toHaveURL(/\/leagues\/[0-9a-f-]+$/);
+
+    // The rules card starts with no exclusions selected.
+    await expect(page.getByText("Exclusions")).toBeVisible();
+    await expect(page.getByText("None", { exact: true })).toBeVisible();
+
+    await page.getByRole("link", { name: /configure/i }).click();
+    await expect(page).toHaveURL(/\/leagues\/[0-9a-f-]+\/settings$/);
+    await expect(page.getByRole("heading", { name: "League Settings" }))
+      .toBeVisible();
+
+    // Verify persisted state round-trips into the settings form.
+    await expect(page.getByLabel("Number of Rounds")).toHaveValue("6");
+    await expect(page.getByLabel("Max Players")).toHaveValue("4");
+
+    // Toggle a setting that shows up uniquely in the rules card.
+    await page.getByLabel("Exclude Legendaries").check();
+
+    // Wait for auto-save to settle before navigating away.
+    await expect(page.getByText("Saving...")).toHaveCount(0, { timeout: 5000 });
+
+    await page.getByRole("link", { name: /back to league/i }).click();
+    await expect(page).toHaveURL(/\/leagues\/[0-9a-f-]+$/);
+
+    // Rules card now reflects the exclusion.
+    await expect(page.getByText("Legendaries", { exact: true })).toBeVisible();
+    await expect(page.getByText("None", { exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New \`e2e/tests/league-settings.spec.ts\` — commissioner opens the rules card's Configure link, verifies persisted state hydrates the form, toggles Exclude Legendaries, and confirms the detail page's rules card reflects the change after auto-save.
- Scoped to setting changes that don't trigger pool generation so the spec runs against the bare migrated e2e database. Phase-advance coverage depends on seeded pokemon data and is deferred.

## Test plan
- [ ] CI runs \`deno task test:e2e\` — new spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)