### PR TITLE
fix(server): return 404 for bot-probe paths instead of serving SPA shell

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -11,6 +11,7 @@ import { auth } from "./auth/mod.ts";
 import { renderTrpcPanel } from "trpc-ui";
 import { logger } from "./logger.ts";
 import { loggerMiddleware } from "./middleware/logger.ts";
+import { spaRouteGuard } from "./middleware/spa-fallback.ts";
 
 export const app: Hono = new Hono();
 
@@ -59,6 +60,11 @@ if (Deno.env.get("DENO_ENV") !== "production") {
 // In production, serve the built client assets
 if (Deno.env.get("DENO_ENV") === "production") {
   app.use("/*", serveStatic({ root: "../client/dist" }));
+}
+
+app.get("/*", spaRouteGuard());
+
+if (Deno.env.get("DENO_ENV") === "production") {
   app.get("/*", serveStatic({ root: "../client/dist", path: "index.html" }));
 }
 

--- a/server/middleware/spa-fallback.ts
+++ b/server/middleware/spa-fallback.ts
@@ -1,0 +1,33 @@
+import type { MiddlewareHandler } from "hono";
+
+// The client is a server-side-routed SPA: routes like `/leagues` or
+// `/draft/abc` must fall back to `index.html`. But the SPA fallback must
+// NOT catch file-shaped paths — doing so turns every bot probe
+// (`/.git/config`, `/wp-login.php`, `/.env`) into a 200 with the app shell,
+// which encourages further scanning.
+export function looksLikeSpaRoute(pathname: string): boolean {
+  if (/(^|\/)\.[^/]/.test(pathname)) return false;
+  const last = pathname.split("/").pop() ?? "";
+  if (last.includes(".")) return false;
+  return true;
+}
+
+// Runs after any real static-asset handler: if the path doesn't look like a
+// SPA route, 404 it instead of letting it fall through to `index.html`.
+export function spaRouteGuard(): MiddlewareHandler {
+  return async (c, next) => {
+    if (c.req.method !== "GET") {
+      await next();
+      return;
+    }
+    const { pathname } = new URL(c.req.url);
+    if (pathname.startsWith("/api/") || pathname.startsWith("/dev/")) {
+      await next();
+      return;
+    }
+    if (!looksLikeSpaRoute(pathname)) {
+      return c.notFound();
+    }
+    await next();
+  };
+}

--- a/server/middleware/spa-fallback_test.ts
+++ b/server/middleware/spa-fallback_test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "@std/assert";
+import { looksLikeSpaRoute } from "./spa-fallback.ts";
+
+Deno.test("looksLikeSpaRoute: treats extensionless paths as SPA routes", () => {
+  assertEquals(looksLikeSpaRoute("/"), true);
+  assertEquals(looksLikeSpaRoute("/leagues"), true);
+  assertEquals(looksLikeSpaRoute("/league/abc123"), true);
+  assertEquals(looksLikeSpaRoute("/draft/abc/room"), true);
+});
+
+Deno.test("looksLikeSpaRoute: rejects file-shaped paths", () => {
+  assertEquals(looksLikeSpaRoute("/wp-login.php"), false);
+  assertEquals(looksLikeSpaRoute("/assets/main.js"), false);
+  assertEquals(looksLikeSpaRoute("/favicon.ico"), false);
+  assertEquals(looksLikeSpaRoute("/robots.txt"), false);
+});
+
+Deno.test("looksLikeSpaRoute: rejects dotfile probes", () => {
+  assertEquals(looksLikeSpaRoute("/.git/config"), false);
+  assertEquals(looksLikeSpaRoute("/.env"), false);
+  assertEquals(looksLikeSpaRoute("/.env.production"), false);
+  assertEquals(looksLikeSpaRoute("/foo/.git/config"), false);
+  assertEquals(looksLikeSpaRoute("/nested/.env"), false);
+});


### PR DESCRIPTION
## Summary
- Added `spaRouteGuard` middleware that rejects paths containing dotfile segments (`/.git/config`, `/.env`) or file extensions (`/wp-login.php`) with 404 instead of serving `index.html`
- Extracted `looksLikeSpaRoute()` helper so the logic is unit-testable
- Real static assets still served by the prior `serveStatic({ root })` handler; only extensionless SPA routes fall through to `index.html`

## Test plan
- [x] Unit tests for `looksLikeSpaRoute` covering SPA routes, file-shaped paths, and dotfile probes
- [x] All 274 server tests pass
- [x] All 256 client tests pass
- [ ] Deploy and verify `https://makethepick.gg/.git/config` returns 404
- [ ] Verify `https://makethepick.gg/leagues` still loads the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)