### PR TITLE
ci(db): add migration journal timestamp ordering check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ jobs:
           deno-version: v2.7.11
       - run: deno lint
 
+  migration-journal:
+    name: Migration Journal Order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.7.11
+      - run: deno task db:check-journal
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/deno.json
+++ b/deno.json
@@ -21,6 +21,7 @@
     "start": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env main.ts",
     "db:start": "docker compose up -d --wait",
     "db:stop": "docker compose down",
+    "db:check-journal": "deno run --allow-read server/db/migrations/check-journal-order.ts",
     "db:generate": "cd server && deno run -A npm:drizzle-kit generate",
     "db:migrate": "cd server && deno run --allow-net --allow-env --allow-read --allow-sys --env=../.env.example db/migrate.ts",
     "sync:pokemon": "deno run --allow-net --allow-write --allow-read scripts/sync-pokemon.ts",

--- a/server/db/migrations/check-journal-order.ts
+++ b/server/db/migrations/check-journal-order.ts
@@ -1,0 +1,32 @@
+interface JournalEntry {
+  idx: number;
+  when: number;
+  tag: string;
+}
+
+export function assertJournalTimestampsMonotonic(
+  entries: JournalEntry[],
+): void {
+  for (let i = 1; i < entries.length; i++) {
+    const prev = entries[i - 1];
+    const curr = entries[i];
+    if (curr.when <= prev.when) {
+      throw new Error(
+        `Migration journal timestamps are not monotonically increasing: ` +
+          `"${curr.tag}" (idx ${curr.idx}, when ${curr.when}) <= ` +
+          `"${prev.tag}" (idx ${prev.idx}, when ${prev.when}). ` +
+          `Fix the "when" field in meta/_journal.json so entries are strictly increasing.`,
+      );
+    }
+  }
+}
+
+if (import.meta.main) {
+  const journalPath = new URL("./meta/_journal.json", import.meta.url)
+    .pathname;
+  const journal = JSON.parse(Deno.readTextFileSync(journalPath));
+  assertJournalTimestampsMonotonic(journal.entries);
+  console.log(
+    `✓ All ${journal.entries.length} migration timestamps are monotonically increasing.`,
+  );
+}

--- a/server/db/migrations/check-journal-order_test.ts
+++ b/server/db/migrations/check-journal-order_test.ts
@@ -1,0 +1,48 @@
+import { assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { assertJournalTimestampsMonotonic } from "./check-journal-order.ts";
+
+describe("assertJournalTimestampsMonotonic", () => {
+  it("passes when timestamps are strictly increasing", () => {
+    const entries = [
+      { idx: 0, when: 100, tag: "0000_first" },
+      { idx: 1, when: 200, tag: "0001_second" },
+      { idx: 2, when: 300, tag: "0002_third" },
+    ];
+    assertJournalTimestampsMonotonic(entries);
+  });
+
+  it("throws when a timestamp goes backwards", () => {
+    const entries = [
+      { idx: 0, when: 100, tag: "0000_first" },
+      { idx: 1, when: 300, tag: "0001_second" },
+      { idx: 2, when: 200, tag: "0002_third" },
+    ];
+    assertThrows(
+      () => assertJournalTimestampsMonotonic(entries),
+      Error,
+      "0002_third",
+    );
+  });
+
+  it("throws when timestamps are equal", () => {
+    const entries = [
+      { idx: 0, when: 100, tag: "0000_first" },
+      { idx: 1, when: 100, tag: "0001_second" },
+    ];
+    assertThrows(
+      () => assertJournalTimestampsMonotonic(entries),
+      Error,
+      "0001_second",
+    );
+  });
+
+  it("passes with a single entry", () => {
+    const entries = [{ idx: 0, when: 100, tag: "0000_first" }];
+    assertJournalTimestampsMonotonic(entries);
+  });
+
+  it("passes with an empty list", () => {
+    assertJournalTimestampsMonotonic([]);
+  });
+});

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -138,7 +138,7 @@
     {
       "idx": 19,
       "version": "7",
-      "when": 1775911239873,
+      "when": 1776260000000,
       "tag": "0019_greedy_marten_broadcloak",
       "breakpoints": true
     },
@@ -187,7 +187,7 @@
     {
       "idx": 26,
       "version": "7",
-      "when": 1775946673911,
+      "when": 1776390000000,
       "tag": "0026_medical_legion",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Adds a CI check that validates Drizzle migration journal timestamps are strictly monotonically increasing
- Fixes two existing out-of-order timestamps (idx 19 and 26) that caused migration 0026 (`fast_mode`) to be silently skipped on production
- Available as `deno task db:check-journal` for local use

## Context
Drizzle's migrator silently skips migrations whose `when` timestamp is earlier than an already-applied migration. When branches with migrations are merged out of chronological order, this causes columns to never be created on deploy — which is exactly what happened with the `fast_mode` column.

## Test plan
- [x] Unit tests for the ordering check (5 cases)
- [x] Server tests pass (282)
- [x] Client tests pass (262)
- [x] Lint clean
- [x] `deno task db:check-journal` passes with fixed timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)