### PR TITLE
feat(league): allow members to leave a league

### DIFF
--- a/client/src/features/league/LeagueDetailPage.test.tsx
+++ b/client/src/features/league/LeagueDetailPage.test.tsx
@@ -15,6 +15,8 @@ const {
   mockUseAvailableNpcs,
   mockUseRemoveLeaguePlayer,
   mockRemovePlayerMutate,
+  mockUseLeaveLeague,
+  mockLeaveMutate,
   mockUseDraft,
   mockUsePokemonVersions,
 } = vi.hoisted(
@@ -30,6 +32,8 @@ const {
     mockUseAvailableNpcs: vi.fn(),
     mockUseRemoveLeaguePlayer: vi.fn(),
     mockRemovePlayerMutate: vi.fn(),
+    mockUseLeaveLeague: vi.fn(),
+    mockLeaveMutate: vi.fn(),
     mockUseDraft: vi.fn(),
     mockUsePokemonVersions: vi.fn(),
   }),
@@ -43,6 +47,7 @@ vi.mock("./use-leagues", () => ({
   useAddNpcPlayer: mockUseAddNpcPlayer,
   useAvailableNpcs: mockUseAvailableNpcs,
   useRemoveLeaguePlayer: mockUseRemoveLeaguePlayer,
+  useLeaveLeague: mockUseLeaveLeague,
 }));
 
 vi.mock("../draft/use-draft", () => ({
@@ -128,6 +133,13 @@ describe("LeagueDetailPage", () => {
       isError: false,
       error: null,
     });
+    mockUseLeaveLeague.mockReturnValue({
+      mutate: mockLeaveMutate,
+      reset: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -205,6 +217,48 @@ describe("LeagueDetailPage", () => {
     expect(
       screen.getByRole("button", { name: /delete league/i }),
     ).toBeInTheDocument();
+  });
+
+  it("shows leave button when user is a member (not commissioner)", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "member",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /leave league/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show leave button when user is the commissioner", () => {
+    mockUseLeague.mockReturnValue({ data: mockLeague, isLoading: false });
+    mockUseLeaguePlayers.mockReturnValue({
+      data: [
+        {
+          id: "p1",
+          userId: "user-1",
+          name: "Alice",
+          image: null,
+          role: "commissioner",
+          joinedAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /leave league/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show delete button when user is not the commissioner", () => {

--- a/client/src/features/league/LeagueDetailPage.tsx
+++ b/client/src/features/league/LeagueDetailPage.tsx
@@ -19,6 +19,7 @@ import { usePokemonVersions } from "../pokemon-version/use-pokemon-versions";
 import { AdvanceLeagueModal } from "./components/AdvanceLeagueModal";
 import { ChooseNpcModal } from "./components/ChooseNpcModal";
 import { DeleteLeagueModal } from "./components/DeleteLeagueModal";
+import { LeaveLeagueModal } from "./components/LeaveLeagueModal";
 import { LeagueHeader } from "./components/LeagueHeader";
 import { LeagueInfoCard } from "./components/LeagueInfoCard";
 import { LeaguePlayersCard } from "./components/LeaguePlayersCard";
@@ -32,6 +33,7 @@ import {
   useDeleteLeague,
   useLeague,
   useLeaguePlayers,
+  useLeaveLeague,
   useRemoveLeaguePlayer,
 } from "./use-leagues";
 
@@ -66,6 +68,7 @@ export function LeagueDetailPage() {
   const advanceStatus = useAdvanceLeagueStatus();
   const addNpcPlayer = useAddNpcPlayer();
   const removePlayer = useRemoveLeaguePlayer();
+  const leaveLeague = useLeaveLeague();
   const [, navigate] = useLocation();
   const [playerToRemove, setPlayerToRemove] = useState<
     { userId: string; name: string } | null
@@ -77,6 +80,9 @@ export function LeagueDetailPage() {
     useDisclosure(false);
   const [chooseNpcOpened, { open: openChooseNpc, close: closeChooseNpc }] =
     useDisclosure(false);
+  const [leaveOpened, { open: openLeave, close: closeLeave }] = useDisclosure(
+    false,
+  );
   const availableNpcs = useAvailableNpcs(id!, chooseNpcOpened);
 
   const isCommissioner = players.data?.some(
@@ -109,6 +115,13 @@ export function LeagueDetailPage() {
     );
   };
 
+  const handleLeave = () => {
+    leaveLeague.mutate(
+      { leagueId: id! },
+      { onSuccess: () => navigate("/leagues") },
+    );
+  };
+
   const handleAdvance = () => {
     advanceStatus.mutate(
       { leagueId: id! },
@@ -119,6 +132,9 @@ export function LeagueDetailPage() {
   const currentUserPlayer = players.data?.find(
     (p) => p.userId === session?.user?.id,
   );
+
+  const isMember = currentUserPlayer &&
+    currentUserPlayer.role !== "commissioner";
 
   const poolItemsById = useMemo(() => {
     const map: Record<
@@ -209,8 +225,21 @@ export function LeagueDetailPage() {
             </Card>
           )}
 
-          {isCommissioner && (
-            <Group justify="flex-end" mt="xl">
+          <Group justify="flex-end" mt="xl">
+            {isMember && (
+              <Button
+                color="red"
+                variant="subtle"
+                size="xs"
+                onClick={() => {
+                  leaveLeague.reset();
+                  openLeave();
+                }}
+              >
+                Leave league
+              </Button>
+            )}
+            {isCommissioner && (
               <Button
                 color="red"
                 variant="subtle"
@@ -219,8 +248,8 @@ export function LeagueDetailPage() {
               >
                 Delete league
               </Button>
-            </Group>
-          )}
+            )}
+          </Group>
 
           <AdvanceLeagueModal
             opened={advanceOpened}
@@ -266,6 +295,16 @@ export function LeagueDetailPage() {
                 { onSuccess: () => setPlayerToRemove(null) },
               );
             }}
+          />
+
+          <LeaveLeagueModal
+            opened={leaveOpened}
+            onClose={closeLeave}
+            leagueName={league.data.name}
+            isPending={leaveLeague.isPending}
+            isError={leaveLeague.isError}
+            errorMessage={leaveLeague.error?.message}
+            onConfirm={handleLeave}
           />
 
           <DeleteLeagueModal

--- a/client/src/features/league/components/LeaveLeagueModal.tsx
+++ b/client/src/features/league/components/LeaveLeagueModal.tsx
@@ -1,0 +1,46 @@
+import { Alert, Button, Group, Modal, Stack, Text } from "@mantine/core";
+
+interface LeaveLeagueModalProps {
+  opened: boolean;
+  onClose: () => void;
+  leagueName: string;
+  isPending: boolean;
+  isError: boolean;
+  errorMessage?: string;
+  onConfirm: () => void;
+}
+
+export function LeaveLeagueModal({
+  opened,
+  onClose,
+  leagueName,
+  isPending,
+  isError,
+  errorMessage,
+  onConfirm,
+}: LeaveLeagueModalProps) {
+  return (
+    <Modal opened={opened} onClose={onClose} title="Leave league">
+      <Stack gap="md">
+        <Text>
+          Are you sure you want to leave{" "}
+          <Text span fw={700}>{leagueName}</Text>? An NPC trainer will take your
+          spot (including any picks you've made).
+        </Text>
+        {isError && (
+          <Alert color="red" title="Failed to leave">
+            {errorMessage}
+          </Alert>
+        )}
+        <Group justify="flex-end">
+          <Button variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button color="red" loading={isPending} onClick={onConfirm}>
+            Leave
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/client/src/features/league/use-leagues.ts
+++ b/client/src/features/league/use-leagues.ts
@@ -80,6 +80,15 @@ export function useRemoveLeaguePlayer() {
   });
 }
 
+export function useLeaveLeague() {
+  const utils = trpc.useUtils();
+  return trpc.league.leave.useMutation({
+    onSuccess: () => {
+      utils.league.list.invalidate();
+    },
+  });
+}
+
 export function useDeleteLeague() {
   const utils = trpc.useUtils();
   return trpc.league.delete.useMutation({

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -79,6 +79,8 @@ export {
   leagueSchema,
   type LeagueStatus,
   leagueStatusSchema,
+  type LeaveLeagueInput,
+  leaveLeagueSchema,
   type RulesConfig,
   rulesConfigSchema,
   type SportType,

--- a/packages/shared/schemas/league.ts
+++ b/packages/shared/schemas/league.ts
@@ -163,3 +163,11 @@ export const leaguePlayerSchema: z.ZodObject<{
 });
 
 export type LeaguePlayer = z.infer<typeof leaguePlayerSchema>;
+
+export const leaveLeagueSchema: z.ZodObject<{
+  leagueId: z.ZodString;
+}> = object({
+  leagueId: string().uuid(),
+});
+
+export type LeaveLeagueInput = z.infer<typeof leaveLeagueSchema>;

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -80,6 +80,8 @@ export {
   leagueSchema,
   type LeagueStatus,
   leagueStatusSchema,
+  type LeaveLeagueInput,
+  leaveLeagueSchema,
   type RulesConfig,
   rulesConfigSchema,
   type SportType,

--- a/server/features/draft-pool/draft-pool.service_test.ts
+++ b/server/features/draft-pool/draft-pool.service_test.ts
@@ -109,6 +109,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    replacePlayerUser: (_leagueId, _oldUserId, _newUserId) => Promise.resolve(),
     findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),

--- a/server/features/draft/draft.fixtures.ts
+++ b/server/features/draft/draft.fixtures.ts
@@ -176,6 +176,7 @@ export function createFakeLeagueRepo(
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    replacePlayerUser: (_leagueId, _oldUserId, _newUserId) => Promise.resolve(),
     findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     ...overrides,
   };

--- a/server/features/league/league.repository.ts
+++ b/server/features/league/league.repository.ts
@@ -213,6 +213,27 @@ export function createLeagueRepository(db: Database) {
       return result ?? null;
     },
 
+    async replacePlayerUser(
+      leagueId: string,
+      oldUserId: string,
+      newUserId: string,
+    ): Promise<void> {
+      log.debug(
+        { leagueId, oldUserId, newUserId },
+        "replacing player user in league",
+      );
+      await db.update(leaguePlayer).set({ userId: newUserId }).where(
+        and(
+          eq(leaguePlayer.leagueId, leagueId),
+          eq(leaguePlayer.userId, oldUserId),
+        ),
+      );
+      log.debug(
+        { leagueId, oldUserId, newUserId },
+        "player user replaced in league",
+      );
+    },
+
     async deletePlayer(leagueId: string, userId: string): Promise<void> {
       log.debug({ leagueId, userId }, "deleting player from league");
       await db.delete(leaguePlayer).where(

--- a/server/features/league/league.repository_test.ts
+++ b/server/features/league/league.repository_test.ts
@@ -534,6 +534,63 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "leagueRepository.replacePlayerUser: swaps user on existing leaguePlayer row",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { db, client } = createTestDb();
+    const repo = createLeagueRepository(db);
+    const commissionerId = crypto.randomUUID();
+    const memberId = crypto.randomUUID();
+    const npcId = `npc-${crypto.randomUUID()}`;
+
+    try {
+      await createTestUser(db, commissionerId);
+      await createTestUser(db, memberId);
+      await db.insert(user).values({
+        id: npcId,
+        name: "NPC Trainer",
+        email: `${npcId}@test.com`,
+        emailVerified: false,
+        isNpc: true,
+        npcStrategy: "best-available",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const created = await repo.createWithCommissioner(commissionerId, {
+        name: "Replace League",
+        inviteCode: "REPL0001",
+        ...defaultSettings,
+      });
+      await repo.addPlayer(created.id, memberId);
+
+      const before = await repo.findPlayer(created.id, memberId);
+      assertEquals(before?.userId, memberId);
+      const originalPlayerId = before!.id;
+
+      await repo.replacePlayerUser(created.id, memberId, npcId);
+
+      const afterOld = await repo.findPlayer(created.id, memberId);
+      assertEquals(afterOld, null);
+
+      const afterNew = await repo.findPlayer(created.id, npcId);
+      assertEquals(afterNew?.userId, npcId);
+      assertEquals(afterNew?.id, originalPlayerId);
+      assertEquals(afterNew?.role, "member");
+    } finally {
+      await db.delete(leaguePlayer);
+      await db.delete(league);
+      await db.delete(user).where(eq(user.id, commissionerId));
+      await db.delete(user).where(eq(user.id, memberId));
+      await db.delete(user).where(eq(user.id, npcId));
+      await client.end();
+    }
+  },
+});
+
+Deno.test({
   name: "leagueRepository.findAllByUserId: returns leagues the user belongs to",
   sanitizeResources: false,
   sanitizeOps: false,

--- a/server/features/league/league.router.ts
+++ b/server/features/league/league.router.ts
@@ -1,6 +1,7 @@
 import {
   advanceLeagueStatusSchema,
   createLeagueSchema,
+  leaveLeagueSchema,
   updateLeagueSettingsSchema,
 } from "@make-the-pick/shared";
 import { object, string } from "zod";
@@ -71,6 +72,12 @@ export function createLeagueRouter(leagueService: LeagueService) {
       .input(object({ leagueId: string().uuid() }))
       .query(({ ctx, input }) => {
         return leagueService.listAvailableNpcs(ctx.user.id, input);
+      }),
+
+    leave: protectedProcedure
+      .input(leaveLeagueSchema)
+      .mutation(({ ctx, input }) => {
+        return leagueService.leaveLeague(ctx.user.id, input);
       }),
 
     delete: protectedProcedure

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -432,6 +432,54 @@ export function createLeagueService(
         "player removed from league",
       );
     },
+
+    async leaveLeague(userId: string, input: { leagueId: string }) {
+      log.debug(
+        { userId, leagueId: input.leagueId },
+        "attempting to leave league",
+      );
+      const league = await deps.leagueRepo.findById(input.leagueId);
+      if (!league) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
+      }
+
+      const player = await deps.leagueRepo.findPlayer(input.leagueId, userId);
+      if (!player) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "You are not a member of this league",
+        });
+      }
+
+      if (player.role === "commissioner") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "The commissioner cannot leave the league — delete it instead",
+        });
+      }
+
+      const available = await deps.leagueRepo.findAvailableNpcUsers(
+        input.leagueId,
+      );
+      if (available.length === 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Cannot leave — no NPC trainers available to take your spot",
+        });
+      }
+
+      const npc = available[Math.floor(Math.random() * available.length)];
+      await deps.leagueRepo.replacePlayerUser(
+        input.leagueId,
+        userId,
+        npc.id,
+      );
+      log.debug(
+        { leagueId: input.leagueId, userId, npcId: npc.id },
+        "player left league, replaced by NPC",
+      );
+    },
   };
 }
 

--- a/server/features/league/league.service_test.ts
+++ b/server/features/league/league.service_test.ts
@@ -73,6 +73,7 @@ function createFakeRepo(
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),
     countPlayers: (_leagueId) => Promise.resolve(0),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    replacePlayerUser: (_leagueId, _oldUserId, _newUserId) => Promise.resolve(),
     findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     ...overrides,
   };
@@ -1766,4 +1767,154 @@ Deno.test("leagueService.listAvailableNpcs: forbids non-commissioners", async ()
     TRPCError,
   );
   assertEquals(error.code, "FORBIDDEN");
+});
+
+// --- leaveLeague ---
+
+Deno.test("leagueService.leaveLeague: replaces member with NPC", async () => {
+  const fakeLeague = createFakeLeague({ status: "drafting" });
+  let replacedLeagueId: string | undefined;
+  let replacedOldUserId: string | undefined;
+  let replacedNewUserId: string | undefined;
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, userId) => {
+      if (userId === "member-1") {
+        return Promise.resolve({
+          id: crypto.randomUUID(),
+          leagueId: fakeLeague.id,
+          userId: "member-1",
+          role: "member" as const,
+          joinedAt: new Date(),
+        });
+      }
+      return Promise.resolve(null);
+    },
+    findAvailableNpcUsers: (_leagueId) =>
+      Promise.resolve([
+        {
+          id: "npc-red",
+          name: "Red",
+          email: "npc@test.com",
+          emailVerified: false,
+          image: null,
+          isNpc: true,
+          npcStrategy: "best-available",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]),
+    replacePlayerUser: (leagueId, oldUserId, newUserId) => {
+      replacedLeagueId = leagueId;
+      replacedOldUserId = oldUserId;
+      replacedNewUserId = newUserId;
+      return Promise.resolve();
+    },
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+  await service.leaveLeague("member-1", { leagueId: fakeLeague.id });
+
+  assertEquals(replacedLeagueId, fakeLeague.id);
+  assertEquals(replacedOldUserId, "member-1");
+  assertEquals(replacedNewUserId, "npc-red");
+});
+
+Deno.test("leagueService.leaveLeague: throws NOT_FOUND when league does not exist", async () => {
+  const repo = createFakeRepo();
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const error = await assertRejects(
+    () => service.leaveLeague("user-1", { leagueId: "nonexistent" }),
+    TRPCError,
+  );
+  assertEquals(error.code, "NOT_FOUND");
+});
+
+Deno.test("leagueService.leaveLeague: throws NOT_FOUND when user is not a member", async () => {
+  const fakeLeague = createFakeLeague();
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) => Promise.resolve(null),
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const error = await assertRejects(
+    () => service.leaveLeague("outsider", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "NOT_FOUND");
+});
+
+Deno.test("leagueService.leaveLeague: throws BAD_REQUEST when commissioner tries to leave", async () => {
+  const fakeLeague = createFakeLeague();
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "commissioner-1",
+        role: "commissioner" as const,
+        joinedAt: new Date(),
+      }),
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const error = await assertRejects(
+    () => service.leaveLeague("commissioner-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
+});
+
+Deno.test("leagueService.leaveLeague: throws BAD_REQUEST when no NPCs available", async () => {
+  const fakeLeague = createFakeLeague();
+  const repo = createFakeRepo({
+    findById: (_id) => Promise.resolve(fakeLeague),
+    findPlayer: (_leagueId, _userId) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        leagueId: fakeLeague.id,
+        userId: "member-1",
+        role: "member" as const,
+        joinedAt: new Date(),
+      }),
+    findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
+  });
+
+  const service = createLeagueService({
+    leagueRepo: repo,
+    draftRepo: createFakeDraftRepo(),
+    draftPoolRepo: createFakeDraftPoolRepo(),
+    draftPoolService: createFakeDraftPoolService(),
+  });
+
+  const error = await assertRejects(
+    () => service.leaveLeague("member-1", { leagueId: fakeLeague.id }),
+    TRPCError,
+  );
+  assertEquals(error.code, "BAD_REQUEST");
 });

--- a/server/features/pool-item-note/pool-item-note.service_test.ts
+++ b/server/features/pool-item-note/pool-item-note.service_test.ts
@@ -76,6 +76,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    replacePlayerUser: (_leagueId, _oldUserId, _newUserId) => Promise.resolve(),
     findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),

--- a/server/features/watchlist/watchlist.service_test.ts
+++ b/server/features/watchlist/watchlist.service_test.ts
@@ -75,6 +75,7 @@ function createFakeLeagueRepo(
     findPlayersByLeagueId: (_leagueId) => Promise.resolve([]),
     deleteById: (_id) => Promise.resolve(),
     deletePlayer: (_leagueId, _userId) => Promise.resolve(),
+    replacePlayerUser: (_leagueId, _oldUserId, _newUserId) => Promise.resolve(),
     findAvailableNpcUsers: (_leagueId) => Promise.resolve([]),
     updateSettings: (_id, _data) => Promise.resolve(createFakeLeague()),
     updateStatus: (_id, _status) => Promise.resolve(createFakeLeague()),


### PR DESCRIPTION
## Summary
- Members can leave a league at any phase — their spot is replaced by a random available NPC
- The swap updates the existing `leaguePlayer` row's `userId` in-place, preserving all draft picks, watchlist items, and pool-item notes
- Commissioner cannot leave (must delete the league instead); leave is rejected if no NPCs are available
- Added `Leave league` button on the league detail page for non-commissioner members, with confirmation modal

## Test plan
- [x] Repository integration test: `replacePlayerUser` swaps userId while preserving leaguePlayer id
- [x] Service unit tests: happy path, NOT_FOUND (league/player), BAD_REQUEST (commissioner/no NPCs)
- [x] Client tests: leave button visible for members, hidden for commissioner
- [x] All 287 server tests pass
- [x] All 264 client tests pass
- [x] Lint clean
- [ ] Manual: join a league as member, click Leave league, confirm NPC replacement in player list

🤖 Generated with [Claude Code](https://claude.com/claude-code)