### PR TITLE
feat(draft): add commissioner override pick and force auto-pick

### DIFF
--- a/client/src/features/draft/CommissionerControls.tsx
+++ b/client/src/features/draft/CommissionerControls.tsx
@@ -12,10 +12,21 @@ export interface CommissionerControlsProps {
   leagueId: string;
   players: Array<{ leaguePlayerId: string; name: string }>;
   poolItemsById: Record<string, DraftPoolItem>;
+  onForceAutoPick?: () => void;
+  isForceAutoPickPending?: boolean;
+  forceAutoPickError?: { message: string } | null;
 }
 
 export function CommissionerControls(
-  { draftState, leagueId, players, poolItemsById }: CommissionerControlsProps,
+  {
+    draftState,
+    leagueId,
+    players,
+    poolItemsById,
+    onForceAutoPick,
+    isForceAutoPickPending,
+    forceAutoPickError,
+  }: CommissionerControlsProps,
 ) {
   const pause = usePauseDraft(leagueId);
   const resume = useResumeDraft(leagueId);
@@ -81,6 +92,17 @@ export function CommissionerControls(
             Undo Last Pick
           </Button>
         )}
+        {onForceAutoPick && status === "in_progress" && (
+          <Button
+            size="xs"
+            variant="light"
+            color="grape"
+            onClick={onForceAutoPick}
+            loading={isForceAutoPickPending}
+          >
+            Force Auto Pick
+          </Button>
+        )}
       </Group>
 
       {pause.error && (
@@ -96,6 +118,11 @@ export function CommissionerControls(
       {undo.error && (
         <Alert color="red" title="Failed to undo pick">
           {undo.error.message}
+        </Alert>
+      )}
+      {forceAutoPickError && (
+        <Alert color="red" title="Failed to force auto-pick">
+          {forceAutoPickError.message}
         </Alert>
       )}
 

--- a/client/src/features/draft/DraftPage.test.tsx
+++ b/client/src/features/draft/DraftPage.test.tsx
@@ -41,6 +41,16 @@ vi.mock("./use-draft-events", () => ({
 
 vi.mock("./use-draft-commissioner", () => ({
   useSetFastMode: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+  useCommissionerPick: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+  useForceAutoPick: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
 }));
 
 vi.mock("./CommissionerControls", () => ({

--- a/client/src/features/draft/DraftPage.tsx
+++ b/client/src/features/draft/DraftPage.tsx
@@ -27,7 +27,11 @@ import { DraftHeader } from "./DraftHeader";
 import { PausedOverlay } from "./PausedOverlay";
 import { WatchlistPanel } from "./WatchlistPanel";
 import { useDraft, useMakePick, useStartDraft } from "./use-draft";
-import { useSetFastMode } from "./use-draft-commissioner";
+import {
+  useCommissionerPick,
+  useForceAutoPick,
+  useSetFastMode,
+} from "./use-draft-commissioner";
 import { useDraftCeremony } from "./use-draft-ceremony";
 import { useDraftEvents } from "./use-draft-events";
 import { leaguePlayerForPick } from "./snake.ts";
@@ -64,6 +68,8 @@ export function DraftPage() {
   const serverFastMode = draftState?.draft.fastMode ?? false;
   const ceremony = useDraftCeremony(serverFastMode);
   const setFastMode = useSetFastMode(leagueId);
+  const commissionerPick = useCommissionerPick(leagueId);
+  const forceAutoPick = useForceAutoPick(leagueId);
 
   useDraftEvents(leagueId, {
     enabled: isDraftLive,
@@ -101,9 +107,13 @@ export function DraftPage() {
     return map;
   }, [draftState]);
 
+  const canCommissionerOverride = isCommissioner && !isMyTurn &&
+    draftState?.draft.status === "in_progress";
+
   async function handlePick(poolItemId: string): Promise<void> {
+    const mutation = canCommissionerOverride ? commissionerPick : makePick;
     await new Promise<void>((resolve, reject) => {
-      makePick.mutate(
+      mutation.mutate(
         { leagueId, poolItemId },
         {
           onSuccess: () => resolve(),
@@ -211,6 +221,9 @@ export function DraftPage() {
               leagueId={leagueId}
               players={commissionerPlayerList}
               poolItemsById={poolItemsById}
+              onForceAutoPick={() => forceAutoPick.mutate({ leagueId })}
+              isForceAutoPickPending={forceAutoPick.isPending}
+              forceAutoPickError={forceAutoPick.error}
             />
           )}
           <Grid>
@@ -218,9 +231,10 @@ export function DraftPage() {
               <AvailablePoolTable
                 leagueId={leagueId}
                 draftState={draftState}
-                isMyTurn={isMyTurn}
+                isMyTurn={isMyTurn || !!canCommissionerOverride}
                 onPick={handlePick}
-                isPicking={makePick.isPending}
+                isPicking={makePick.isPending ||
+                  commissionerPick.isPending}
               />
             </Grid.Col>
             <Grid.Col span={{ base: 12, lg: 3 }}>

--- a/client/src/features/draft/use-draft-commissioner.ts
+++ b/client/src/features/draft/use-draft-commissioner.ts
@@ -31,11 +31,27 @@ interface SetFastModeMutation {
   };
 }
 
+interface CommissionerPickMutation {
+  useMutation: (opts?: {
+    onSuccess?: () => void;
+  }) => {
+    mutate: (input: { leagueId: string; poolItemId: string }) => void;
+    mutateAsync: (
+      input: { leagueId: string; poolItemId: string },
+    ) => Promise<unknown>;
+    isPending: boolean;
+    error: { message: string } | null;
+    reset: () => void;
+  };
+}
+
 interface CommissionerApi {
   pause: CommissionerMutation;
   resume: CommissionerMutation;
   undoLastPick: CommissionerMutation;
   setFastMode: SetFastModeMutation;
+  commissionerPick: CommissionerPickMutation;
+  forceAutoPick: CommissionerMutation;
 }
 
 // deno-lint-ignore no-explicit-any
@@ -71,6 +87,24 @@ export function useUndoLastPick(leagueId: string) {
 export function useSetFastMode(leagueId: string) {
   const utils = trpc.useUtils();
   return commissionerApi.setFastMode.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}
+
+export function useCommissionerPick(leagueId: string) {
+  const utils = trpc.useUtils();
+  return commissionerApi.commissionerPick.useMutation({
+    onSuccess: () => {
+      utils.draft.getState.invalidate({ leagueId });
+    },
+  });
+}
+
+export function useForceAutoPick(leagueId: string) {
+  const utils = trpc.useUtils();
+  return commissionerApi.forceAutoPick.useMutation({
     onSuccess: () => {
       utils.draft.getState.invalidate({ leagueId });
     },

--- a/packages/shared/mod.ts
+++ b/packages/shared/mod.ts
@@ -1,4 +1,6 @@
 export {
+  type CommissionerPickInput,
+  commissionerPickInputSchema,
   draftCompletedEventSchema,
   type DraftEvent,
   draftEventSchema,
@@ -22,6 +24,8 @@ export {
   draftStateEventSchema,
   draftStateSchema,
   draftTurnChangeEventSchema,
+  type ForceAutoPickInput,
+  forceAutoPickInputSchema,
   type GetDraftStateInput,
   getDraftStateInputSchema,
   type MakePickInput,

--- a/packages/shared/schemas/draft.ts
+++ b/packages/shared/schemas/draft.ts
@@ -136,6 +136,26 @@ export const setFastModeInputSchema: z.ZodObject<{
 
 export type SetFastModeInput = z.infer<typeof setFastModeInputSchema>;
 
+export const commissionerPickInputSchema: z.ZodObject<{
+  leagueId: z.ZodString;
+  poolItemId: z.ZodString;
+}> = object({
+  leagueId: string().uuid(),
+  poolItemId: string().uuid(),
+});
+
+export type CommissionerPickInput = z.infer<
+  typeof commissionerPickInputSchema
+>;
+
+export const forceAutoPickInputSchema: z.ZodObject<{
+  leagueId: z.ZodString;
+}> = object({
+  leagueId: string().uuid(),
+});
+
+export type ForceAutoPickInput = z.infer<typeof forceAutoPickInputSchema>;
+
 // SSE event schemas
 export const draftStartedEventSchema: z.ZodObject<{
   type: z.ZodLiteral<"draft:started">;

--- a/packages/shared/schemas/mod.ts
+++ b/packages/shared/schemas/mod.ts
@@ -1,4 +1,6 @@
 export {
+  type CommissionerPickInput,
+  commissionerPickInputSchema,
   draftCompletedEventSchema,
   type DraftEvent,
   draftEventSchema,
@@ -22,6 +24,8 @@ export {
   draftStateEventSchema,
   draftStateSchema,
   draftTurnChangeEventSchema,
+  type ForceAutoPickInput,
+  forceAutoPickInputSchema,
   type GetDraftStateInput,
   getDraftStateInputSchema,
   type MakePickInput,

--- a/server/features/draft/draft.router.ts
+++ b/server/features/draft/draft.router.ts
@@ -1,4 +1,6 @@
 import {
+  commissionerPickInputSchema,
+  forceAutoPickInputSchema,
   getDraftStateInputSchema,
   makePickInputSchema,
   pauseDraftInputSchema,
@@ -84,6 +86,25 @@ export function createDraftRouter(draftService: DraftService) {
           userId: ctx.user.id,
           leagueId: input.leagueId,
           fastMode: input.fastMode,
+        });
+      }),
+
+    commissionerPick: protectedProcedure
+      .input(commissionerPickInputSchema)
+      .mutation(({ ctx, input }) => {
+        return draftService.commissionerPick({
+          userId: ctx.user.id,
+          leagueId: input.leagueId,
+          poolItemId: input.poolItemId,
+        });
+      }),
+
+    forceAutoPick: protectedProcedure
+      .input(forceAutoPickInputSchema)
+      .mutation(({ ctx, input }) => {
+        return draftService.forceAutoPick({
+          userId: ctx.user.id,
+          leagueId: input.leagueId,
         });
       }),
   });

--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -908,6 +908,325 @@ export function createDraftService(deps: {
       return { fastMode };
     },
 
+    async commissionerPick(
+      { userId, leagueId, poolItemId }: {
+        userId: string;
+        leagueId: string;
+        poolItemId: string;
+      },
+    ) {
+      log.debug(
+        { userId, leagueId, poolItemId },
+        "commissioner picking on behalf of current player",
+      );
+      const { league, players, poolItems } = await loadDraftContext(leagueId);
+
+      const caller = await deps.leagueRepo.findPlayer(leagueId, userId);
+      if (caller?.role !== "commissioner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the league commissioner can override a pick",
+        });
+      }
+
+      const draftRow = await deps.draftRepo.findByLeagueId(leagueId);
+      if (!draftRow) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No draft has been created for this league yet",
+        });
+      }
+      if (draftRow.status !== "in_progress") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Draft is not in progress",
+        });
+      }
+
+      const pickOrder = draftRow.pickOrder as string[];
+      const turn = resolveSnakeTurn(pickOrder, draftRow.currentPick);
+      const currentPlayer = players.find(
+        (p) => p.id === turn.leaguePlayerId,
+      );
+      if (!currentPlayer) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Could not resolve the current turn player",
+        });
+      }
+
+      const poolItem = poolItems.find((item) => item.id === poolItemId);
+      if (!poolItem) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Pool item does not belong to this draft's pool",
+        });
+      }
+
+      const existingPick = await deps.draftRepo.findPickByPoolItem(
+        draftRow.id,
+        poolItemId,
+      );
+      if (existingPick) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "That pool item has already been picked",
+        });
+      }
+
+      let createdPickRow: Awaited<ReturnType<DraftRepository["createPick"]>>;
+      try {
+        createdPickRow = await deps.draftRepo.createPick({
+          draftId: draftRow.id,
+          leaguePlayerId: currentPlayer.id,
+          poolItemId,
+          pickNumber: draftRow.currentPick,
+        });
+      } catch (err) {
+        if (err instanceof DraftPickConflictError) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "That pool item has already been picked",
+          });
+        }
+        throw err;
+      }
+
+      const nextPick = await deps.draftRepo.incrementCurrentPick(draftRow.id);
+      const numberOfRounds = getNumberOfRounds(league);
+      const totalPicks = numberOfRounds * pickOrder.length;
+      let finalDraft = { ...draftRow, currentPick: nextPick };
+      const isFinalPick = nextPick >= totalPicks;
+      const now = clock.now();
+      let nextDeadline: Date | null = null;
+      if (isFinalPick) {
+        finalDraft = await deps.draftRepo.updateStatus(
+          draftRow.id,
+          "complete",
+          { completedAt: now },
+        );
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, null);
+        finalDraft = { ...finalDraft, currentTurnDeadline: null };
+      } else {
+        const pickTimeLimitSeconds = getPickTimeLimitSeconds(league);
+        nextDeadline = computeTurnDeadline(now, pickTimeLimitSeconds);
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, nextDeadline);
+        finalDraft = { ...finalDraft, currentTurnDeadline: nextDeadline };
+      }
+
+      const picks = await deps.draftRepo.listPicks(draftRow.id);
+      const state = toStateShape({
+        draft: finalDraft,
+        picks,
+        players,
+        poolItems,
+      });
+
+      const pickRound = resolveSnakeTurn(pickOrder, createdPickRow.pickNumber)
+        .round;
+      publisher.publish(leagueId, {
+        type: "draft:pick_made",
+        data: {
+          id: createdPickRow.id,
+          draftId: createdPickRow.draftId,
+          leaguePlayerId: createdPickRow.leaguePlayerId,
+          poolItemId: createdPickRow.poolItemId,
+          pickNumber: createdPickRow.pickNumber,
+          pickedAt: createdPickRow.pickedAt instanceof Date
+            ? createdPickRow.pickedAt.toISOString()
+            : String(createdPickRow.pickedAt),
+          autoPicked: createdPickRow.autoPicked ?? false,
+          playerName: currentPlayer.name,
+          itemName: poolItem.name,
+          round: pickRound,
+        },
+      });
+
+      if (isFinalPick) {
+        publisher.publish(leagueId, {
+          type: "draft:completed",
+          data: {
+            completedAt: finalDraft.completedAt instanceof Date
+              ? finalDraft.completedAt.toISOString()
+              : (finalDraft.completedAt ?? new Date().toISOString()),
+          },
+        });
+        scheduler?.cancel(draftRow.id);
+        npcScheduler?.cancel(draftRow.id);
+      } else {
+        publishTurnChange(leagueId, pickOrder, nextPick, nextDeadline);
+        scheduler?.schedule(draftRow.id, leagueId, nextDeadline);
+        maybeScheduleNpcPick({
+          draftId: draftRow.id,
+          leagueId,
+          pickOrder,
+          currentPick: nextPick,
+          players,
+          league,
+          fastMode: draftRow.fastMode ?? false,
+        });
+      }
+
+      return state;
+    },
+
+    async forceAutoPick(
+      { userId, leagueId }: { userId: string; leagueId: string },
+    ) {
+      log.debug({ userId, leagueId }, "commissioner forcing auto-pick");
+      const { league, players, poolItems } = await loadDraftContext(leagueId);
+
+      const caller = await deps.leagueRepo.findPlayer(leagueId, userId);
+      if (caller?.role !== "commissioner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the league commissioner can force an auto-pick",
+        });
+      }
+
+      const draftRow = await deps.draftRepo.findByLeagueId(leagueId);
+      if (!draftRow) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No draft has been created for this league yet",
+        });
+      }
+      if (draftRow.status !== "in_progress") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Draft is not in progress",
+        });
+      }
+
+      const pickOrder = draftRow.pickOrder as string[];
+      const turn = resolveSnakeTurn(pickOrder, draftRow.currentPick);
+      const currentPlayer = players.find(
+        (p) => p.id === turn.leaguePlayerId,
+      );
+      if (!currentPlayer) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Could not resolve the current turn player",
+        });
+      }
+
+      npcScheduler?.cancel(draftRow.id);
+
+      const picks = await deps.draftRepo.listPicks(draftRow.id);
+      const pickedItemIds = new Set(picks.map((p) => p.poolItemId));
+      const available = poolItems.filter(
+        (item) => !pickedItemIds.has(item.id),
+      );
+      const chosen = await selectQueueOrBstPick(
+        currentPlayer.id,
+        available,
+      );
+      if (!chosen) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "No available items to auto-pick",
+        });
+      }
+
+      let createdPickRow: Awaited<ReturnType<DraftRepository["createPick"]>>;
+      try {
+        createdPickRow = await deps.draftRepo.createPick({
+          draftId: draftRow.id,
+          leaguePlayerId: currentPlayer.id,
+          poolItemId: chosen.id,
+          pickNumber: draftRow.currentPick,
+          autoPicked: true,
+        });
+      } catch (err) {
+        if (err instanceof DraftPickConflictError) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "A pick was already made for this turn",
+          });
+        }
+        throw err;
+      }
+
+      const nextPick = await deps.draftRepo.incrementCurrentPick(draftRow.id);
+      const numberOfRounds = getNumberOfRounds(league);
+      const totalPicks = numberOfRounds * pickOrder.length;
+      let finalDraft = { ...draftRow, currentPick: nextPick };
+      const isFinalPick = nextPick >= totalPicks;
+      const now = clock.now();
+      let nextDeadline: Date | null = null;
+      if (isFinalPick) {
+        finalDraft = await deps.draftRepo.updateStatus(
+          draftRow.id,
+          "complete",
+          { completedAt: now },
+        );
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, null);
+        finalDraft = { ...finalDraft, currentTurnDeadline: null };
+      } else {
+        const pickTimeLimitSeconds = getPickTimeLimitSeconds(league);
+        nextDeadline = computeTurnDeadline(now, pickTimeLimitSeconds);
+        await deps.draftRepo.updateTurnDeadline(draftRow.id, nextDeadline);
+        finalDraft = { ...finalDraft, currentTurnDeadline: nextDeadline };
+      }
+
+      const allPicks = await deps.draftRepo.listPicks(draftRow.id);
+      const state = toStateShape({
+        draft: finalDraft,
+        picks: allPicks,
+        players,
+        poolItems,
+      });
+
+      const pickRound = resolveSnakeTurn(
+        pickOrder,
+        createdPickRow.pickNumber,
+      ).round;
+      publisher.publish(leagueId, {
+        type: "draft:pick_made",
+        data: {
+          id: createdPickRow.id,
+          draftId: createdPickRow.draftId,
+          leaguePlayerId: createdPickRow.leaguePlayerId,
+          poolItemId: createdPickRow.poolItemId,
+          pickNumber: createdPickRow.pickNumber,
+          pickedAt: createdPickRow.pickedAt instanceof Date
+            ? createdPickRow.pickedAt.toISOString()
+            : String(createdPickRow.pickedAt),
+          autoPicked: true,
+          playerName: currentPlayer.name,
+          itemName: chosen.name,
+          round: pickRound,
+        },
+      });
+
+      if (isFinalPick) {
+        publisher.publish(leagueId, {
+          type: "draft:completed",
+          data: {
+            completedAt: finalDraft.completedAt instanceof Date
+              ? finalDraft.completedAt.toISOString()
+              : (finalDraft.completedAt ?? new Date().toISOString()),
+          },
+        });
+        scheduler?.cancel(draftRow.id);
+        npcScheduler?.cancel(draftRow.id);
+      } else {
+        publishTurnChange(leagueId, pickOrder, nextPick, nextDeadline);
+        scheduler?.schedule(draftRow.id, leagueId, nextDeadline);
+        maybeScheduleNpcPick({
+          draftId: draftRow.id,
+          leagueId,
+          pickOrder,
+          currentPick: nextPick,
+          players,
+          league,
+          fastMode: draftRow.fastMode ?? false,
+        });
+      }
+
+      return state;
+    },
+
     async pauseDraft(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {

--- a/server/features/draft/draft.service_test.ts
+++ b/server/features/draft/draft.service_test.ts
@@ -2403,3 +2403,236 @@ Deno.test("draftService.runNpcPick: no-op when current player is not an NPC", as
 
   assertEquals(createPickCalled, false);
 });
+
+// --- commissionerPick -------------------------------------------------------
+
+Deno.test("draftService.commissionerPick: commissioner picks on behalf of current player", async () => {
+  const { league, pool, playerA, playerB, poolItems, draft } =
+    setupCommissionerFakes({ draftStatus: "in_progress", currentPick: 0 });
+  const publisher = createRecordingPublisher();
+
+  const createdPicks: FakeDraftPick[] = [];
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve(createdPicks),
+    incrementCurrentPick: () => Promise.resolve(1),
+    createPick: (input: CreatePickInput) => {
+      const row = {
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: input.autoPicked ?? false,
+      };
+      createdPicks.push(row);
+      return Promise.resolve(row);
+    },
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: (_leagueId, userId) =>
+      Promise.resolve(
+        userId === "user-1"
+          ? { ...playerA, leagueId: league.id }
+          : null as FakePlayer,
+      ),
+    findPlayersByLeagueId: () => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+  });
+
+  const state = await service.commissionerPick({
+    userId: "user-1",
+    leagueId: league.id,
+    poolItemId: poolItems[0].id,
+  });
+
+  assertEquals(state.draft.currentPick, 1);
+  // Pick should be attributed to playerA (the current turn player, pick 0)
+  const pick = state.picks.find((p) => p.poolItemId === poolItems[0].id);
+  assertEquals(pick?.leaguePlayerId, playerA.id);
+  // Should emit pick_made
+  const pickMade = publisher.published.find((e) =>
+    e.event.type === "draft:pick_made"
+  );
+  assertEquals(pickMade !== undefined, true);
+});
+
+Deno.test("draftService.commissionerPick: rejects non-commissioner", async () => {
+  const { league, pool, playerA, playerB, poolItems, draft } =
+    setupCommissionerFakes({ draftStatus: "in_progress", currentPick: 0 });
+
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: (_leagueId, userId) =>
+      Promise.resolve(
+        userId === "user-2"
+          ? { ...playerB, leagueId: league.id }
+          : null as FakePlayer,
+      ),
+    findPlayersByLeagueId: () => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+
+  const service = createDraftService({ draftRepo, leagueRepo, draftPoolRepo });
+
+  await assertRejects(
+    () =>
+      service.commissionerPick({
+        userId: "user-2",
+        leagueId: league.id,
+        poolItemId: poolItems[0].id,
+      }),
+    TRPCError,
+    "commissioner",
+  );
+});
+
+Deno.test("draftService.commissionerPick: rejects already-picked item", async () => {
+  const { league, pool, playerA, playerB, poolItems, draft } =
+    setupCommissionerFakes({ draftStatus: "in_progress", currentPick: 0 });
+
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+    findPickByPoolItem: () =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        draftId: draft.id,
+        leaguePlayerId: playerA.id,
+        poolItemId: poolItems[0].id,
+        pickNumber: 0,
+        pickedAt: new Date(),
+        autoPicked: false,
+      }),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: () => Promise.resolve({ ...playerA, leagueId: league.id }),
+    findPlayersByLeagueId: () => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+
+  const service = createDraftService({ draftRepo, leagueRepo, draftPoolRepo });
+
+  await assertRejects(
+    () =>
+      service.commissionerPick({
+        userId: "user-1",
+        leagueId: league.id,
+        poolItemId: poolItems[0].id,
+      }),
+    TRPCError,
+    "already been picked",
+  );
+});
+
+// --- forceAutoPick ----------------------------------------------------------
+
+Deno.test("draftService.forceAutoPick: commissioner forces an auto-pick for current player", async () => {
+  const { league, pool, playerA, playerB, poolItems, draft } =
+    setupCommissionerFakes({ draftStatus: "in_progress", currentPick: 0 });
+  const publisher = createRecordingPublisher();
+
+  const createdPicks: FakeDraftPick[] = [];
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve(createdPicks),
+    incrementCurrentPick: () => Promise.resolve(1),
+    createPick: (input: CreatePickInput) => {
+      const row = {
+        id: crypto.randomUUID(),
+        draftId: input.draftId,
+        leaguePlayerId: input.leaguePlayerId,
+        poolItemId: input.poolItemId,
+        pickNumber: input.pickNumber,
+        pickedAt: new Date(),
+        autoPicked: input.autoPicked ?? false,
+      };
+      createdPicks.push(row);
+      return Promise.resolve(row);
+    },
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: () => Promise.resolve({ ...playerA, leagueId: league.id }),
+    findPlayersByLeagueId: () => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+
+  const service = createDraftService({
+    draftRepo,
+    leagueRepo,
+    draftPoolRepo,
+    draftEventPublisher: publisher,
+  });
+
+  const state = await service.forceAutoPick({
+    userId: "user-1",
+    leagueId: league.id,
+  });
+
+  assertEquals(state.draft.currentPick, 1);
+  assertEquals(state.picks.length, 1);
+  assertEquals(state.picks[0].autoPicked, true);
+  const pickMade = publisher.published.find((e) =>
+    e.event.type === "draft:pick_made"
+  );
+  assertEquals(pickMade !== undefined, true);
+});
+
+Deno.test("draftService.forceAutoPick: rejects non-commissioner", async () => {
+  const { league, pool, playerA, playerB, poolItems, draft } =
+    setupCommissionerFakes({ draftStatus: "in_progress", currentPick: 0 });
+
+  const draftRepo = createFakeDraftRepo({
+    findByLeagueId: () => Promise.resolve(draft),
+    listPicks: () => Promise.resolve([]),
+  });
+  const leagueRepo = createFakeLeagueRepo({
+    findById: () => Promise.resolve(league),
+    findPlayer: (_leagueId, userId) =>
+      Promise.resolve(
+        userId === "user-2"
+          ? { ...playerB, leagueId: league.id }
+          : null as FakePlayer,
+      ),
+    findPlayersByLeagueId: () => Promise.resolve([playerA, playerB]),
+  });
+  const draftPoolRepo = createFakeDraftPoolRepo({
+    findByLeagueId: () => Promise.resolve(pool),
+    findItemsByPoolId: () => Promise.resolve(poolItems),
+  });
+
+  const service = createDraftService({ draftRepo, leagueRepo, draftPoolRepo });
+
+  await assertRejects(
+    () => service.forceAutoPick({ userId: "user-2", leagueId: league.id }),
+    TRPCError,
+    "commissioner",
+  );
+});


### PR DESCRIPTION
## Summary
- **Commissioner Override Pick**: commissioners can now pick any pool item on behalf of the current turn player. The pool table pick buttons stay enabled for commissioners even when it's not their turn — picks route through the new `commissionerPick` endpoint which attributes the pick to whoever is on the clock.
- **Force Auto Pick**: a "Force Auto Pick" button in commissioner controls triggers the queue-first / BST-fallback auto-pick algorithm immediately for the current turn player (NPC or human). Cancels any pending NPC scheduler delay.
- Both endpoints enforce commissioner role and require the draft to be in_progress.

## Test plan
- [x] `commissionerPick` — picks on behalf of current player, rejects non-commissioners, rejects already-picked items
- [x] `forceAutoPick` — auto-picks for current player, rejects non-commissioners
- [x] All 286 server tests pass
- [x] All 262 client tests pass
- [x] `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)