### PR TITLE
fix(client): serve favicon as static SVG file

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎯</text></svg>"
-    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Make The Pick</title>
   </head>
   <body>

--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">🎯</text>
+</svg>


### PR DESCRIPTION
## Summary
- Moved the emoji favicon from an inline data URI to a static `client/public/favicon.svg` file
- Fixes 404 on `/favicon.ico` requests since the SVG is now served by the static file handler
- Keeps the 🎯 emoji favicon

## Test plan
- [ ] Verify favicon appears in browser tab in dev
- [ ] Verify no 404 for favicon in browser network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)