### PR TITLE
feat(server): add request-scoped tracing with requestId and userId

### DIFF
--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,13 @@
+import type pino from "pino";
+
+/**
+ * Hono environment type for request-scoped variables.
+ * Passed as a generic to middleware and route handlers
+ * so c.get()/c.set() are fully typed.
+ */
+export type AppEnv = {
+  Variables: {
+    requestId: string;
+    log: pino.Logger;
+  };
+};

--- a/server/features/draft/draft.sse.ts
+++ b/server/features/draft/draft.sse.ts
@@ -1,4 +1,5 @@
 import type { Hono } from "hono";
+import type { AppEnv } from "../../env.ts";
 import { streamSSE } from "hono/streaming";
 import type { DraftEvent, DraftState } from "@make-the-pick/shared";
 import { TRPCError } from "@trpc/server";
@@ -37,7 +38,10 @@ const DEFAULT_HEARTBEAT_MS = 15_000;
  *   4. Subscribes to the publisher and forwards every event as SSE.
  *   5. Unsubscribes cleanly on client disconnect.
  */
-export function registerDraftSseRoute(app: Hono, deps: DraftSseDeps): void {
+export function registerDraftSseRoute(
+  app: Hono<AppEnv>,
+  deps: DraftSseDeps,
+): void {
   const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
 
   app.get("/api/draft/events/:leagueId", async (c) => {

--- a/server/features/draft/draft.sse_test.ts
+++ b/server/features/draft/draft.sse_test.ts
@@ -1,6 +1,9 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { Hono } from "hono";
+import pino from "pino";
 import { TRPCError } from "@trpc/server";
+import type { AppEnv } from "../../env.ts";
+import { requestContextMiddleware } from "../../middleware/request-context.ts";
 import type { DraftEvent, DraftState } from "@make-the-pick/shared";
 import type { DraftService } from "./draft.service.ts";
 import {
@@ -52,7 +55,9 @@ function buildApp(opts: {
   draftService: DraftService;
   sessionUserId: string | null;
 }) {
-  const app = new Hono();
+  const app = new Hono<AppEnv>();
+  const silentLog = pino({ level: "silent" });
+  app.use(requestContextMiddleware(silentLog));
   registerDraftSseRoute(app, {
     draftService: opts.draftService,
     draftEventPublisher: opts.publisher,

--- a/server/features/mod.ts
+++ b/server/features/mod.ts
@@ -34,6 +34,7 @@ import pokemonGiftsJson from "../data/pokemon-gifts.json" with {
   type: "json",
 };
 import type { Hono } from "hono";
+import type { AppEnv } from "../env.ts";
 import {
   createDraftEventPublisher,
   createDraftRepository,
@@ -176,7 +177,7 @@ export function createFeatureRouters(db: Database) {
  * so the publisher singleton is shared with the tRPC-facing draft service.
  */
 export function registerFeatureRoutes(
-  app: Hono,
+  app: Hono<AppEnv>,
   deps: {
     draftEventPublisher: DraftEventPublisher;
     draftService: DraftService;

--- a/server/main.ts
+++ b/server/main.ts
@@ -11,11 +11,14 @@ import { auth } from "./auth/mod.ts";
 import { renderTrpcPanel } from "trpc-ui";
 import { logger } from "./logger.ts";
 import { loggerMiddleware } from "./middleware/logger.ts";
+import { requestContextMiddleware } from "./middleware/request-context.ts";
 import { spaRouteGuard } from "./middleware/spa-fallback.ts";
+import type { AppEnv } from "./env.ts";
 
-export const app: Hono = new Hono();
+export const app: Hono<AppEnv> = new Hono<AppEnv>();
 
-app.use(loggerMiddleware(logger));
+app.use(requestContextMiddleware(logger));
+app.use(loggerMiddleware());
 
 registerEchoWebSocket(app);
 registerFeatureRoutes(app, {
@@ -40,11 +43,12 @@ app.get("/api/health", async (c) => {
 });
 
 app.all("/api/trpc/*", (c) => {
+  const requestLog = c.get("log");
   return fetchRequestHandler({
     endpoint: "/api/trpc",
     req: c.req.raw,
     router: appRouter,
-    createContext: ({ req }) => createContext(req),
+    createContext: ({ req }) => createContext(req, requestLog),
   });
 });
 

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -1,12 +1,13 @@
 import type { MiddlewareHandler } from "hono";
-import type pino from "pino";
+import type { AppEnv } from "../env.ts";
 
-export function loggerMiddleware(log: pino.Logger): MiddlewareHandler {
+export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
   return async (c, next) => {
     const start = Date.now();
 
     await next();
 
+    const log = c.get("log");
     const status = c.res.status;
     const responseTime = Date.now() - start;
     const method = c.req.method;

--- a/server/middleware/logger_test.ts
+++ b/server/middleware/logger_test.ts
@@ -1,7 +1,9 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import { Hono } from "hono";
 import pino from "pino";
+import type { AppEnv } from "../env.ts";
 import { loggerMiddleware } from "./logger.ts";
+import { requestContextMiddleware } from "./request-context.ts";
 
 function createTestLogger() {
   const entries: Record<string, unknown>[] = [];
@@ -15,8 +17,9 @@ function createTestLogger() {
 }
 
 function createTestApp(log: pino.Logger) {
-  const app = new Hono();
-  app.use(loggerMiddleware(log));
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+  app.use(loggerMiddleware());
   app.get("/test", (c) => c.json({ ok: true }));
   app.post("/test", (c) => c.json({ created: true }, 201));
   return app;
@@ -50,8 +53,9 @@ Deno.test("loggerMiddleware logs correct status for non-200 responses", async ()
 
 Deno.test("loggerMiddleware logs at warn level for 4xx responses", async () => {
   const { log, entries } = createTestLogger();
-  const app = new Hono();
-  app.use(loggerMiddleware(log));
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+  app.use(loggerMiddleware());
   app.get("/missing", (c) => c.json({ error: "not found" }, 404));
 
   await app.request("/missing");
@@ -62,8 +66,9 @@ Deno.test("loggerMiddleware logs at warn level for 4xx responses", async () => {
 
 Deno.test("loggerMiddleware logs at error level for 5xx responses", async () => {
   const { log, entries } = createTestLogger();
-  const app = new Hono();
-  app.use(loggerMiddleware(log));
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+  app.use(loggerMiddleware());
   app.get("/fail", (c) => c.json({ error: "server error" }, 500));
 
   await app.request("/fail");
@@ -79,4 +84,15 @@ Deno.test("loggerMiddleware uses info level for successful responses", async () 
   await app.request("/test");
 
   assertEquals(entries[0].level, 30); // pino info level
+});
+
+Deno.test("loggerMiddleware includes requestId from context", async () => {
+  const { log, entries } = createTestLogger();
+  const app = createTestApp(log);
+
+  await app.request("/test");
+
+  assertEquals(entries.length, 1);
+  assertExists(entries[0].requestId);
+  assertEquals(typeof entries[0].requestId, "string");
 });

--- a/server/middleware/request-context.ts
+++ b/server/middleware/request-context.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareHandler } from "hono";
+import type pino from "pino";
+import type { AppEnv } from "../env.ts";
+
+export function requestContextMiddleware(
+  log: pino.Logger,
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    const requestId = c.req.header("X-Request-Id") ?? crypto.randomUUID();
+    const requestLog = log.child({ requestId });
+
+    c.set("requestId", requestId);
+    c.set("log", requestLog);
+
+    await next();
+  };
+}

--- a/server/middleware/request-context_test.ts
+++ b/server/middleware/request-context_test.ts
@@ -1,0 +1,86 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { Hono } from "hono";
+import pino from "pino";
+import type { AppEnv } from "../env.ts";
+import { requestContextMiddleware } from "./request-context.ts";
+
+function createTestLogger() {
+  const entries: Record<string, unknown>[] = [];
+  const stream = {
+    write(msg: string) {
+      entries.push(JSON.parse(msg));
+    },
+  };
+  const log = pino({ level: "debug" }, stream as pino.DestinationStream);
+  return { log, entries };
+}
+
+Deno.test("requestContextMiddleware sets a requestId on the context", async () => {
+  const { log } = createTestLogger();
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+
+  let capturedRequestId: string | undefined;
+  app.get("/test", (c) => {
+    capturedRequestId = c.get("requestId");
+    return c.json({ ok: true });
+  });
+
+  await app.request("/test");
+  assertExists(capturedRequestId);
+  assertEquals(typeof capturedRequestId, "string");
+  assertEquals(capturedRequestId!.length, 36);
+});
+
+Deno.test("requestContextMiddleware sets a child logger with requestId", async () => {
+  const { log, entries } = createTestLogger();
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+
+  app.get("/test", (c) => {
+    const requestLog = c.get("log");
+    requestLog.info("hello from handler");
+    return c.json({ ok: true });
+  });
+
+  await app.request("/test");
+  assertEquals(entries.length, 1);
+  assertExists(entries[0].requestId);
+  assertEquals(entries[0].msg, "hello from handler");
+});
+
+Deno.test("requestContextMiddleware generates unique requestIds per request", async () => {
+  const { log } = createTestLogger();
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+
+  const ids: string[] = [];
+  app.get("/test", (c) => {
+    ids.push(c.get("requestId"));
+    return c.json({ ok: true });
+  });
+
+  await app.request("/test");
+  await app.request("/test");
+
+  assertEquals(ids.length, 2);
+  assertEquals(ids[0] !== ids[1], true);
+});
+
+Deno.test("requestContextMiddleware uses incoming X-Request-Id header if present", async () => {
+  const { log } = createTestLogger();
+  const app = new Hono<AppEnv>();
+  app.use(requestContextMiddleware(log));
+
+  let capturedRequestId: string | undefined;
+  app.get("/test", (c) => {
+    capturedRequestId = c.get("requestId");
+    return c.json({ ok: true });
+  });
+
+  await app.request("/test", {
+    headers: { "X-Request-Id": "upstream-trace-123" },
+  });
+
+  assertEquals(capturedRequestId, "upstream-trace-123");
+});

--- a/server/trpc/context.ts
+++ b/server/trpc/context.ts
@@ -1,19 +1,25 @@
+import type pino from "pino";
 import { auth } from "../auth/mod.ts";
 import { db } from "../db/mod.ts";
 import { logger } from "../logger.ts";
 
-const log = logger.child({ module: "trpc.context" });
+const fallbackLog = logger.child({ module: "trpc.context" });
 
-export async function createContext(req: Request) {
+export async function createContext(
+  req: Request,
+  requestLog?: pino.Logger,
+) {
+  const log = requestLog ?? fallbackLog;
+
   const sessionData = await auth.api.getSession({
     headers: req.headers,
   });
 
-  log.debug(
-    {
-      userId: sessionData?.user?.id ?? null,
-      hasSession: !!sessionData?.session,
-    },
+  const userId = sessionData?.user?.id ?? null;
+  const contextLog = userId ? log.child({ userId }) : log;
+
+  contextLog.debug(
+    { hasSession: !!sessionData?.session },
     "trpc context created",
   );
 
@@ -21,6 +27,7 @@ export async function createContext(req: Request) {
     db,
     session: sessionData?.session ?? null,
     user: sessionData?.user ?? null,
+    log: contextLog,
   };
 }
 

--- a/server/trpc/trpc.ts
+++ b/server/trpc/trpc.ts
@@ -2,10 +2,11 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { logger } from "../logger.ts";
 import type { Context } from "./context.ts";
 
-const log = logger.child({ module: "trpc" });
+const fallbackLog = logger.child({ module: "trpc" });
 
 const t = initTRPC.context<Context>().create({
-  errorFormatter({ shape, error, path, input }) {
+  errorFormatter({ shape, error, path, input, ctx }) {
+    const log = ctx?.log ?? fallbackLog;
     log.error(
       { code: shape.code, path, input, cause: error.cause },
       "tRPC error: %s",
@@ -20,10 +21,10 @@ export const procedure = t.procedure;
 
 export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
   if (!ctx.session || !ctx.user) {
-    log.debug("unauthorized request — no session or user");
+    ctx.log.debug("unauthorized request — no session or user");
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
-  log.debug({ userId: ctx.user.id }, "authenticated procedure call");
+  ctx.log.debug("authenticated procedure call");
   return next({
     ctx: { ...ctx, session: ctx.session, user: ctx.user },
   });

--- a/server/ws/echo.ts
+++ b/server/ws/echo.ts
@@ -1,10 +1,11 @@
 import { upgradeWebSocket } from "hono/deno";
 import type { Hono } from "hono";
+import type { AppEnv } from "../env.ts";
 import { logger } from "../logger.ts";
 
 const log = logger.child({ module: "ws.echo" });
 
-export function registerEchoWebSocket(app: Hono) {
+export function registerEchoWebSocket(app: Hono<AppEnv>) {
   app.get(
     "/ws/echo",
     upgradeWebSocket(() => ({


### PR DESCRIPTION
## Summary

- Adds a `requestContextMiddleware` that generates a unique `requestId` per request (or uses incoming `X-Request-Id`) and creates a Pino child logger on the Hono context
- Logger middleware now reads the request-scoped logger from context, so every HTTP log line includes `requestId`
- tRPC context receives the scoped logger and enriches it with `userId` after auth resolves — procedure logs carry both `requestId` and `userId`
- Introduces `AppEnv` type for typed Hono context variables across all route registrations

## Test plan

- [x] New tests for `requestContextMiddleware` (UUID generation, uniqueness, X-Request-Id passthrough)
- [x] Updated logger middleware tests to verify `requestId` appears in log entries
- [x] All 194 non-DB server tests pass
- [x] All 264 client tests pass
- [x] `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)