### PR TITLE
fix(server): promote business-event logs to info, demote HTTP noise to debug

### DIFF
--- a/server/features/draft/draft.service.ts
+++ b/server/features/draft/draft.service.ts
@@ -320,7 +320,7 @@ export function createDraftService(deps: {
     async startDraft(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {
-      log.debug({ userId, leagueId }, "starting draft");
+      log.info({ userId, leagueId }, "starting draft");
       const league = await deps.leagueRepo.findById(leagueId);
       if (!league) {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
@@ -451,7 +451,7 @@ export function createDraftService(deps: {
         poolItemId: string;
       },
     ) {
-      log.debug({ userId, leagueId, poolItemId }, "making draft pick");
+      log.info({ userId, leagueId, poolItemId }, "making draft pick");
       const { league, players, poolItems } = await loadDraftContext(leagueId);
 
       const draftRow = await deps.draftRepo.findByLeagueId(leagueId);
@@ -622,7 +622,7 @@ export function createDraftService(deps: {
     async runAutoPick(
       { leagueId }: { leagueId: string },
     ) {
-      log.debug({ leagueId }, "running auto-pick");
+      log.info({ leagueId }, "running auto-pick");
       const { league, players, poolItems } = await loadDraftContext(leagueId);
 
       const draftRow = await deps.draftRepo.findByLeagueId(leagueId);
@@ -739,7 +739,7 @@ export function createDraftService(deps: {
     async runNpcPick(
       { leagueId }: { leagueId: string },
     ) {
-      log.debug({ leagueId }, "running NPC auto-pick");
+      log.info({ leagueId }, "running NPC auto-pick");
       if (!npcScheduler) return;
       const { league, players, poolItems } = await loadDraftContext(leagueId);
 
@@ -859,7 +859,7 @@ export function createDraftService(deps: {
         fastMode: boolean;
       },
     ) {
-      log.debug({ userId, leagueId, fastMode }, "setting draft fast mode");
+      log.info({ userId, leagueId, fastMode }, "setting draft fast mode");
       const league = await deps.leagueRepo.findById(leagueId);
       if (!league) {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
@@ -915,7 +915,7 @@ export function createDraftService(deps: {
         poolItemId: string;
       },
     ) {
-      log.debug(
+      log.info(
         { userId, leagueId, poolItemId },
         "commissioner picking on behalf of current player",
       );
@@ -1073,7 +1073,7 @@ export function createDraftService(deps: {
     async forceAutoPick(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {
-      log.debug({ userId, leagueId }, "commissioner forcing auto-pick");
+      log.info({ userId, leagueId }, "commissioner forcing auto-pick");
       const { league, players, poolItems } = await loadDraftContext(leagueId);
 
       const caller = await deps.leagueRepo.findPlayer(leagueId, userId);
@@ -1230,7 +1230,7 @@ export function createDraftService(deps: {
     async pauseDraft(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {
-      log.debug({ userId, leagueId }, "pausing draft");
+      log.info({ userId, leagueId }, "pausing draft");
       const league = await deps.leagueRepo.findById(leagueId);
       if (!league) {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
@@ -1282,7 +1282,7 @@ export function createDraftService(deps: {
     async resumeDraft(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {
-      log.debug({ userId, leagueId }, "resuming draft");
+      log.info({ userId, leagueId }, "resuming draft");
       const league = await deps.leagueRepo.findById(leagueId);
       if (!league) {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });
@@ -1360,7 +1360,7 @@ export function createDraftService(deps: {
     async undoLastPick(
       { userId, leagueId }: { userId: string; leagueId: string },
     ) {
-      log.debug({ userId, leagueId }, "undoing last pick");
+      log.info({ userId, leagueId }, "undoing last pick");
       const league = await deps.leagueRepo.findById(leagueId);
       if (!league) {
         throw new TRPCError({ code: "NOT_FOUND", message: "League not found" });

--- a/server/features/league/league.service.ts
+++ b/server/features/league/league.service.ts
@@ -40,7 +40,7 @@ export function createLeagueService(
   return {
     create(userId: string, input: CreateLeagueInput) {
       const inviteCode = generateInviteCode();
-      log.debug({ userId, name: input.name, inviteCode }, "creating league");
+      log.info({ userId, name: input.name, inviteCode }, "creating league");
       return deps.leagueRepo.createWithCommissioner(userId, {
         ...input,
         inviteCode,
@@ -80,7 +80,7 @@ export function createLeagueService(
         });
       }
       await deps.leagueRepo.deleteById(leagueId);
-      log.debug({ leagueId }, "league deleted");
+      log.info({ leagueId }, "league deleted");
     },
 
     async listPlayers(leagueId: string) {
@@ -138,7 +138,7 @@ export function createLeagueService(
         maxPlayers: input.maxPlayers,
         rulesConfig: input.rulesConfig,
       });
-      log.debug({ leagueId: input.leagueId }, "league settings updated");
+      log.info({ leagueId: input.leagueId }, "league settings updated");
       return updated;
     },
 
@@ -222,7 +222,7 @@ export function createLeagueService(
         input.leagueId,
         nextStatus,
       );
-      log.debug(
+      log.info(
         { leagueId: input.leagueId, newStatus: nextStatus },
         "league status advanced",
       );
@@ -276,7 +276,7 @@ export function createLeagueService(
       }
 
       await deps.leagueRepo.addPlayer(league.id, userId);
-      log.debug({ userId, leagueId: league.id }, "user joined league");
+      log.info({ userId, leagueId: league.id }, "user joined league");
       return league;
     },
 
@@ -336,7 +336,7 @@ export function createLeagueService(
         npc = available[Math.floor(Math.random() * available.length)];
       }
       await deps.leagueRepo.addPlayer(input.leagueId, npc.id);
-      log.debug(
+      log.info(
         { leagueId: input.leagueId, npcId: npc.id, npcName: npc.name },
         "NPC added to league",
       );
@@ -427,7 +427,7 @@ export function createLeagueService(
       }
 
       await deps.leagueRepo.deletePlayer(input.leagueId, input.playerUserId);
-      log.debug(
+      log.info(
         { leagueId: input.leagueId, playerUserId: input.playerUserId },
         "player removed from league",
       );
@@ -475,7 +475,7 @@ export function createLeagueService(
         userId,
         npc.id,
       );
-      log.debug(
+      log.info(
         { leagueId: input.leagueId, userId, npcId: npc.id },
         "player left league, replaced by NPC",
       );

--- a/server/features/user/user.service.ts
+++ b/server/features/user/user.service.ts
@@ -8,9 +8,9 @@ export function createUserService(
 ) {
   return {
     async deleteAccount(userId: string): Promise<void> {
-      log.debug({ userId }, "deleting user account");
+      log.info({ userId }, "deleting user account");
       await deps.userRepo.deleteById(userId);
-      log.debug({ userId }, "user account deleted");
+      log.info({ userId }, "user account deleted");
     },
   };
 }

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -21,7 +21,7 @@ export function loggerMiddleware(): MiddlewareHandler<AppEnv> {
     } else if (status >= 400) {
       log.warn(data, msg);
     } else {
-      log.info(data, msg);
+      log.debug(data, msg);
     }
   };
 }

--- a/server/middleware/logger_test.ts
+++ b/server/middleware/logger_test.ts
@@ -77,13 +77,13 @@ Deno.test("loggerMiddleware logs at error level for 5xx responses", async () => 
   assertEquals(entries[0].level, 50); // pino error level
 });
 
-Deno.test("loggerMiddleware uses info level for successful responses", async () => {
+Deno.test("loggerMiddleware uses debug level for successful responses", async () => {
   const { log, entries } = createTestLogger();
   const app = createTestApp(log);
 
   await app.request("/test");
 
-  assertEquals(entries[0].level, 30); // pino info level
+  assertEquals(entries[0].level, 20); // pino debug level
 });
 
 Deno.test("loggerMiddleware includes requestId from context", async () => {


### PR DESCRIPTION
## Summary
- Promoted business-meaningful debug logs to info level in draft, league, and user services (draft picks, league creation/join, status advances, commissioner overrides, account deletion, etc.)
- Demoted successful HTTP 2xx/3xx request logging from info to debug in the logger middleware — this was the routing noise flooding production info logs
- Read-only lookups, validation checks, and auth guards remain at debug

## Test plan
- [x] All 264 server tests pass (including updated logger middleware test)
- [x] All 264 client tests pass
- [x] `deno lint` clean
- [ ] Verify production info logs show business events instead of just navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)